### PR TITLE
add support for tf.image.resize_nearest_neighbor

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -42,6 +42,12 @@ class Node(object):
             self.data_format = self.data_format.s.decode("utf-8")
 
     @property
+    def normalized_inputs(self):
+        val = sorted([self.graph.get_node_by_name(n)
+            for n in sorted(self._input)], key=lambda x: x.type)
+        return val
+
+    @property
     def input(self):
         return self._input
 
@@ -387,7 +393,7 @@ class Graph(object):
         if self._opset > 0:
             imp = OperatorSetIdProto()
             imp.version = self._opset
-            kwargs["opset"] = imp
+            kwargs["opset_imports"] = [imp]
 
         model_proto = helper.make_model(graph, **kwargs)
 

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -75,7 +75,7 @@ ONNX_VALID_ATTRIBUTES = {
     'min', 'seed', 'ends', 'paddings', 'to', 'gamma', 'width_scale', 'normalize_variance', 'group', 'ratio', 'values',
     'dtype', 'output_shape', 'spatial', 'split', 'input_forget', 'keepdims', 'transA', 'auto_pad', 'border', 'low',
     'linear_before_reset', 'height_scale', 'output_padding', 'shape', 'kernel_shape', 'epsilon', 'size', 'starts',
-    'direction', 'max', 'clip', 'across_channels', 'value', 'strides', 'extra_shape'
+    'direction', 'max', 'clip', 'across_channels', 'value', 'strides', 'extra_shape', 'scales'
 }
 
 


### PR DESCRIPTION
Fix for https://github.com/onnx/tensorflow-onnx/issues/16. Did not find a runtime that supports this so I did not test it correctly.
Gotcha: Upsample in onnx takes the output shape as attribute but in tensorflow it is an input ... we can only convert it if the input[1] is a constant.
It requires opset 7 or better (if you have a onnx with opset 7 installed tensorflow-onnx will use it, else you can pass in --opset 7 in the command line)
