### PR TITLE
Added a type check for tf.float16

### DIFF
--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -148,6 +148,8 @@ def get_tf_tensor_data(tensor):
         data = [0]
     elif tensor.dtype == tf.float32:
         data = [0.]
+    elif tensor.dtype == tf.float16:
+        data = [0]
     elif tensor.string_val:
         data = tensor.string_val
     else:


### PR DESCRIPTION
Note that [ONNX requires](https://github.com/onnx/onnx/blob/master/onnx/onnx.proto#L332) that float 16 data should be stored in a `int32_data` field, so here using `[0]` instead of `[0.]`.