### PR TITLE
support for onnx-1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ Tf2onnx is in its early development. Mileage will vary since TensorFlow supports
 | [![Build Status](https://travis-ci.org/onnx/tensorflow-onnx.svg?branch=master)](https://travis-ci.org/onnx/tensorflow-onnx)
 
 # Supported ONNX version
-tensorflow-onnx will use the onnx version installed on your system and installs onnx-1.2.2 if none is found.
+tensorflow-onnx will use the onnx version installed on your system and installs the latest onnx version if none is found.
 
-One important thing with onnx-1.3 being released:
+By default we use opset 7 for the resulting onnx graph since most runtimes will support opset 7.
 
-by default tensorflow-onnx will use the highest opset found on your system to generate the onnx graph.
-If you have onnx-1.3 installed the graph is generated with opset 8.
-You can tell tensorflow-onnx with ```--opset 7``` to generated the graph with opset 7 so runtimes that don't support opset 8 keep working.
+With the release of onnx-1.3 there is now opset 8 - to create an onnx graph for opset 8 use in the command line ```--opset 8```.
 
 # Status
 Basic net and conv nets should work. A list of models that pass tests can be found [here](tests/run_pretrained_models.yaml)

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -61,7 +61,8 @@ def default_custom_op_handler(ctx, node, name, args):
 def main():
     args = get_args()
 
-    print("using tensorflow={}, onnx={}".format(tf.__version__, onnx.__version__))
+    opset = tf2onnx.tfonnx.find_opset(args.opset)
+    print("using tensorflow={}, onnx={}, opset={}".format(tf.__version__, onnx.__version__, opset))
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 import collections
 import tf2onnx
-from onnx import numpy_helper, optimizer, ModelProto, defs, OperatorSetIdProto, TensorShapeProto
+from onnx import numpy_helper, optimizer, ModelProto, OperatorSetIdProto, TensorShapeProto
 from tf2onnx import utils, __version__
 from tf2onnx.utils import *
 
@@ -253,9 +253,7 @@ class Graph(object):
         self._output_shapes = output_shapes
         ops = [Node(node, self) for node in nodes]
         self.set_nodes(ops)
-        if opset is None or opset == 0:
-            opset = defs.onnx_opset_version()
-        self._opset = opset
+        self._opset = tf2onnx.tfonnx.find_opset(opset)
         self._extra_opset = extra_opset
 
     @property

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -15,7 +15,8 @@ import traceback
 
 import numpy as np
 import tf2onnx
-from onnx import helper, onnx_pb, numpy_helper
+from onnx import helper, onnx_pb, numpy_helper, defs
+
 from tensorflow.python.framework import graph_util
 from tensorflow.tools.graph_transforms import TransformGraph
 from tf2onnx import utils
@@ -31,7 +32,17 @@ log = logging.getLogger("tf2onnx")
 TARGET_RS4 = "rs4"
 TARGET_CAFFE2 = "caffe2"
 POSSIBLE_TARGETS = [TARGET_RS4, TARGET_CAFFE2]
-DEFAULT_TARGET = [TARGET_RS4, TARGET_CAFFE2]
+DEFAULT_TARGET = []
+PREFERRED_OPSET = 7
+
+
+def find_opset(opset):
+    if opset is None or opset == 0:
+        opset = defs.onnx_opset_version()
+        if opset > PREFERRED_OPSET:
+            # if we use a newer onnx opset than most runtimes support, default to the one most supported
+            opset = PREFERRED_OPSET
+    return opset
 
 
 def tensorflow_to_onnx(graph, shape_override):
@@ -1209,11 +1220,16 @@ _OPSET_7 = {
     "FusedBatchNorm": (fused_batchnorm_op7, []),
 }
 
+_OPSET_8 = {
+    # don't need special handling of ops for opset 8
+}
+
 _OPSETS = [
     (4, _OPSET_4),
     (5, _OPSET_5),
     (6, _OPSET_6),
     (7, _OPSET_7),
+    (8, _OPSET_8),
 ]
 
 


### PR DESCRIPTION
Support for onnx-1.3 which was already released.
- onnx-1.3 uses opset 8 which is supported by few runtimes so we default to opset 7 for now. The default can be overwritten with ```--opset 8```.
- print the used opset at startup
- set default target to nothing, aka no old caffe2 workarounds are going to be used by default

@pengwa, can you review ?