### PR TITLE
Removed duplicated g.replace_subgraph

### DIFF
--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1383,7 +1383,6 @@ def rewrite_random_uniform(g, ops):
             new_node = Node(helper.make_node("RandomUniformLike", [shape_op.input[0]], [out_name],
                                          name=op_name, low=tmin, high=tmax,
                                          dtype=dtype), g)
-            ops = g.replace_subgraph(ops, match, [], [output], [], [new_node])
         else:
             shape = g.get_shape(output.output[0])
             new_node = Node(helper.make_node("RandomUniform", [], [out_name],


### PR DESCRIPTION
Removed a duplicated `g.replace_subgraph` line which caused the `replace_subgraph` function to be called twice if `ru_op.inputs[0].type == "Shape"`