### PR TITLE
Refine lstm

### DIFF
--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -9,15 +9,7 @@ This rewriter depends on tf2onnx.rewriter.lstm_rewriter's results.
 from __future__ import division
 from __future__ import print_function
 
-import collections
-import numpy as np
-import tf2onnx
-
-from onnx import helper, defs, numpy_helper, checker, onnx_pb
-from onnx import AttributeProto, TensorProto, GraphProto
-from tf2onnx import utils
-from tf2onnx.graph import Node, Graph
-from tf2onnx.graph_matcher import *
+from onnx import numpy_helper
 from tf2onnx.rewriter.rnn_utils import *
 
 logging.basicConfig(level=logging.INFO)

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -9,172 +9,29 @@ This rewriter depends on tf2onnx.rewriter.lstm_rewriter's results.
 from __future__ import division
 from __future__ import print_function
 
-from onnx import numpy_helper
+import collections
+import numpy as np
+import tf2onnx
+
+from onnx import helper, defs, numpy_helper, checker, onnx_pb
+from onnx import AttributeProto, TensorProto, GraphProto
+from tf2onnx import utils
+from tf2onnx.graph import Node, Graph
+from tf2onnx.graph_matcher import *
 from tf2onnx.rewriter.rnn_utils import *
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("tf2onnx.rewriter.bilstm_rewriter")
 
-batch_major_output_pattern =  \
-    OpTypePattern('Pack', name='output_fw_bw_tuple', inputs=[
-        OpTypePattern("Transpose", inputs=[
-            OpTypePattern("Squeeze", inputs=[
-                OpTypePattern("LSTM", name="lstm_fw")
-                # we cannot define inner pattern for LSTM's input, because if some of inputs are const, 
-                # that are not in g._nodes, so match pattern search will fail.
-            ])
-        ]),
-        OpTypePattern("ReverseV2", inputs=[
-            OpTypePattern("Transpose", inputs=[
-                OpTypePattern("Squeeze", inputs=[
-                    OpTypePattern("LSTM", name="lstm_bw"),
-                ]),
-            ]),
-            OpTypePattern("*", name="reversev2_axis"),
-        ]),
-    ])
 
-batch_major_ch_pattern_state_is_not_tuple = \
-    OpTypePattern('Pack', name='cell_state_fw_bw_tuple', inputs=[
-        OpTypePattern("Squeeze", name="fw_ch_output_squeeze", inputs=[
-            OpTypePattern("Concat", inputs=[
-                OpTypePattern("LSTM", name="lstm_fw"),
-                OpTypePattern("LSTM", name="lstm_fw1")
-            ]),
-        ]),
-        OpTypePattern("Squeeze", inputs=[
-            OpTypePattern("Concat", inputs=[
-                OpTypePattern("LSTM", name="lstm_bw"),
-                OpTypePattern("LSTM", name="lstm_bw1")
-            ]),
-        ]),
-    ])
-
-batch_major_ch_pattern_state_is_tuple = \
-    OpTypePattern('Pack', name='cell_state_fw_bw_tuple', inputs=[
-        OpTypePattern("Concat", inputs=[
-            OpTypePattern("LSTM", name="lstm_fw"),
-            OpTypePattern("LSTM", name="lstm_fw1")
-        ]),
-        OpTypePattern("Concat", inputs=[
-            OpTypePattern("LSTM", name="lstm_bw"),
-            OpTypePattern("LSTM", name="lstm_bw1")
-        ]),
-    ])
-
-
-def batch_major_output_match_check(g, ops, merged_matches):
-    matcher = GraphMatcher(batch_major_output_pattern, allow_reorder=True)
-    output_match_results = list(matcher.match_ops(ops))
-    for match in output_match_results:
-        lstm_fw = match.get_op("lstm_fw")
-        lstm_bw = match.get_op("lstm_bw")
-        transpose_fw = lstm_fw.inputs[0]
-        rnn_input_fw = transpose_fw.input[0]
-
-        transpose_bw = lstm_bw.inputs[0]
-        reverse_bw = transpose_bw.inputs[0]
-        if reverse_bw.type != "ReverseV2":
-            continue
-        rnn_input_bw = reverse_bw.input[0]
-
-        final_pack = match.get_op("output_fw_bw_tuple")
-
-        if rnn_input_fw == rnn_input_bw:
-            fw_bw_pair_name = lstm_fw.name + "," + lstm_bw.name
-            if fw_bw_pair_name not in merged_matches:
-                merged_matches[fw_bw_pair_name] = [None, None]
-                log.debug("batch_major_output_match_check: found fw_bw pair " + fw_bw_pair_name)
-
-            assert not merged_matches[fw_bw_pair_name][0]
-            to_delete = [transpose_bw, reverse_bw]
-            merged_matches[fw_bw_pair_name][0] = MatchedLSTM(transpose_fw.inputs[0],
-                                                             lstm_fw, lstm_bw, final_pack, to_delete, match)
-        else:
-            continue
-
-
-def batch_major_ch_match_checks(g, ops, merged_matches):
-    batch_major_ch_match_check(g, ops, True, merged_matches)
-    batch_major_ch_match_check(g, ops, False, merged_matches)
-
-
-def batch_major_ch_match_check(g, ops, is_tuple, merged_matches):
-    if is_tuple:
-        pattern = batch_major_ch_pattern_state_is_tuple
-    else:
-        pattern = batch_major_ch_pattern_state_is_not_tuple
-
-    # make allow_reorder be False, since we need know which is fw.
-    matcher = GraphMatcher(pattern, allow_reorder=False)
-    cell_state_match_results = list(matcher.match_ops(ops))
-    for match in cell_state_match_results:
-        lstm_fw = match.get_op("lstm_fw")
-        lstm_bw = match.get_op("lstm_bw")
-        if lstm_fw != match.get_op("lstm_fw1") or lstm_bw != match.get_op("lstm_bw1"):
-            continue
-
-        transpose_fw = lstm_fw.inputs[0]
-        rnn_input_fw = transpose_fw.input[0]
-
-        transpose_bw = lstm_bw.inputs[0]
-        reverse_bw = transpose_bw.inputs[0]
-        if reverse_bw.type != "ReverseV2":
-            continue
-
-        rnn_input_bw = reverse_bw.input[0]
-        final_pack = match.get_op("cell_state_fw_bw_tuple")
-
-        if rnn_input_fw == rnn_input_bw:
-            fw_bw_pair_name = lstm_fw.name + "," + lstm_bw.name
-            if fw_bw_pair_name not in merged_matches:
-                merged_matches[fw_bw_pair_name] = [None, None]
-                log.debug("batch_major_ch_match_check: add fw_bw pair " + fw_bw_pair_name)
-
-            assert not merged_matches[fw_bw_pair_name][1]
-            to_delete = [transpose_bw, reverse_bw]
-
-            matched_lstm = MatchedLSTM(transpose_fw.inputs[0], lstm_fw, lstm_bw, final_pack, to_delete, match)
-            matched_lstm.state_is_tuple = is_tuple
-            merged_matches[fw_bw_pair_name][1] = matched_lstm
-        else:
-            continue
-
-
-# currently we only support inputs having shapes.
-# only support batch_major right now.
-def process_bilstm_batch_major(g, ops):
-    # we use two sub-graph do pattern matching, to make sure we don't make mistakes.
-    merged_matches = {}
-    batch_major_output_match_check(g, ops, merged_matches)
-    batch_major_ch_match_checks(g, ops, merged_matches)
-
-    # for each found lstm cell, find its outer scope and collect its nodes into a dict.
-    for pair_name in merged_matches:
+def process_bilstm(g, bi_lstms):
+    for fw, bw in bi_lstms:
+        input_id = fw[0]
         log.info("=========================")
-        log.info("start handling potential bidirectional lstm " + pair_name)
-        matches = merged_matches[pair_name]
-        lstm_fw = None
-        lstm_bw = None
-        o_lstm = matches[0]
-        ch_lstm = matches[1]
-        _lstm = None
-        if o_lstm:
-            _lstm = o_lstm
-        else:
-            _lstm = ch_lstm
+        log.info("start handling potential bidirectional lstm " + input_id)
 
-        lstm_fw = _lstm.lstm_fw
-        lstm_bw = _lstm.lstm_bw
-
-        # todo: lstm input might not has a shape
-        batch_size = -1
-        time_step = -1
-        if _lstm.input.shape:
-            batch_size = _lstm.input.shape[0]
-            time_step = _lstm.input.shape[1]
-        else:
-            raise ValueError("lstm input does not has shape.")
+        lstm_fw = fw[1]
+        lstm_bw = bw[1]
 
         w_fw = get_np_val_for_const(g, lstm_fw, 1)
         w_bw = get_np_val_for_const(g, lstm_bw, 1)
@@ -187,17 +44,9 @@ def process_bilstm_batch_major(g, ops):
         B = np.concatenate((b_fw, b_bw), axis=0)
 
         all_nodes = g.get_nodes()
-        to_append = []
-        must_keep_node = []
         if len(lstm_fw.inputs) == len(lstm_bw.inputs):
             if len(lstm_fw.inputs) > 4:
-                # todo: non_const seq length
-                seq_fw = get_np_val_for_const(g, lstm_fw, 4)
-                seq_bw = get_np_val_for_const(g, lstm_bw, 4)
-                assert np.array_equal(seq_fw, seq_bw)
-                must_keep_node.append(lstm_fw.inputs[0])
-
-                h_node, c_node = process_ch_init_nodes(g, lstm_fw, lstm_bw, to_append)
+                h_node, c_node = process_ch_init_nodes(g, lstm_fw, lstm_bw, all_nodes)
         else:
             log.error("fw, bw lstm inputs num is not consistent. stop")
             continue
@@ -211,12 +60,11 @@ def process_bilstm_batch_major(g, ops):
 
         b_name = utils.make_name("B")
         b_node = g.make_const(b_name, B, skip_conversion=True)
-        lstm_inputs = [lstm_fw.input[0], w_node.output[0], r_node.output[0], b_node.output[0]]
+        lstm_inputs= [lstm_fw.input[0], w_node.output[0], r_node.output[0], b_node.output[0]]
         if len(lstm_fw.inputs) > 4:
             lstm_inputs.extend([lstm_fw.input[4], h_node.output[0], c_node.output[0]])
 
         direction = "bidirectional"
-        num_directions = 2
         if lstm_fw.get_attr("hidden_size").i == lstm_bw.get_attr("hidden_size").i:
             hidden_size = lstm_fw.get_attr("hidden_size").i
         else:
@@ -225,66 +73,62 @@ def process_bilstm_batch_major(g, ops):
 
         attr = {"direction": direction, "hidden_size": hidden_size}
         bi_lstm_node = make_onnx_node(g, "LSTM", lstm_inputs, attr=attr, output_count=3)
-        to_append.append(bi_lstm_node)
+        all_nodes.append(bi_lstm_node)
         log.info("processing output nodes")
-        if o_lstm:
-            log.info("handle o_lstm outputs")
-            # we need tranpose LSTM result to original consumer (they assume that)
-            # source [seq_length, num_directions, batch_size, hidden_size] 
-            # dest [num_directions, batch_size, seq_length, hidden_size]
-            attr = {"perm": np.array([1, 2, 0, 3], dtype=np.int64)}
-            new_trans = make_onnx_node(g, "Transpose", [bi_lstm_node.output[0]], attr)
-            g.set_shape(new_trans.output[0], (num_directions, batch_size, time_step, hidden_size))
 
-            # start to modify graph
-            g.replace_all_inputs(all_nodes, o_lstm.output_pack.output[0], new_trans.output[0])
-            to_append.append(new_trans)
-            for n in o_lstm.nodes_to_delete:
-                if n in all_nodes and n not in must_keep_node:
-                    all_nodes.remove(n)
+        slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm_node, 0, all_nodes)
+        slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm_node, 1, all_nodes)
+        slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm_node, 2, all_nodes)
 
-        if ch_lstm:
-            log.info("handle ch_lstm outputs")
-            # onnx lstm c/h: [num_directions, batch_size, hidden_size]
-            if ch_lstm.state_is_tuple:
-                # original Pack's output is [num_directions, tuple_size_h_c(e.g. 2), batch_size, hidden_size]
-                stack_ch = make_onnx_node(
-                    g, "Pack", [bi_lstm_node.output[2], bi_lstm_node.output[1]],
-                    attr={"axis": 1}, output_count=1, skip_conversion=False)
-                g.set_shape(stack_ch.output[0], (num_directions, 2, batch_size, hidden_size))
-            else:
-                # original Pack's output is [num_directions, batch_size, hidden_size*2]
-                attr = {"axis": 2}
-                stack_ch = make_onnx_node(g, "Concat", [bi_lstm_node.output[2], bi_lstm_node.output[1]], attr)
-                g.set_shape(stack_ch.output[0], (num_directions, batch_size, hidden_size*2))
+        reverse_ops = [op for op in all_nodes if is_reverse_op(op)]
+        for r_op in reverse_ops:
+            g.replace_all_inputs(all_nodes, r_op.output[0], r_op.input[0])
 
-            to_append.extend([stack_ch])
-            log.info(ch_lstm.output_pack.output[0])
-            g.replace_all_inputs(all_nodes, ch_lstm.output_pack.output[0], stack_ch.output[0])
-            all_nodes.remove(ch_lstm.output_pack)
-            for n in ch_lstm.nodes_to_delete:
-                if n in all_nodes and n not in must_keep_node:
-                    all_nodes.remove(n)
-        else:
-            print("ch_lstm is None")
-
-        all_nodes.extend(to_append)
-        g.set_nodes(all_nodes)
-
-    if merged_matches:
-        log.info("done rewriting bidirectional lstm graph")
+        to_remove = [lstm_fw.name, lstm_fw.input[1], lstm_fw.input[2], lstm_fw.input[3], 
+            lstm_fw.input[5], lstm_fw.input[6], lstm_bw.name, lstm_bw.input[1],
+            lstm_bw.input[2], lstm_bw.input[3], lstm_bw.input[5], lstm_bw.input[6]]
+        to_remove.extend([r_op.name for r_op in reverse_ops])
+        new_nodes = []
+        for n in all_nodes:
+            if n.name not in to_remove:
+                new_nodes.append(n)
+        g.set_nodes(new_nodes)
     return g.get_nodes()
+
+
+def slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm, lstm_output_index, all_nodes):
+    fw_consumers = g.find_output_consumers(lstm_fw.output[lstm_output_index])
+    bw_consumers = g.find_output_consumers(lstm_bw.output[lstm_output_index])
+
+    if lstm_output_index == 0:
+        axis = 1
+    elif lstm_output_index == 1 or lstm_output_index == 2:
+        axis = 0
+    else:
+        raise ValueError("LSTM only should has 3 outputs.")
+
+    if fw_consumers:
+        attr = {"axes": [axis], "starts": [0], "ends": [1]}
+        slice_node_fw = make_onnx_node(g, "Slice", [bi_lstm.output[lstm_output_index]], attr)
+        all_nodes.append(slice_node_fw)
+        g.replace_all_inputs(fw_consumers, lstm_fw.output[lstm_output_index], slice_node_fw.output[0])
+
+    if bw_consumers:
+        attr = {"axes": [axis], "starts": [1], "ends": [2]}
+        slice_node_bw = make_onnx_node(g, "Slice", [bi_lstm.output[lstm_output_index]], attr)
+        all_nodes.append(slice_node_bw)
+        g.replace_all_inputs(bw_consumers, lstm_bw.output[lstm_output_index], slice_node_bw.output[0])
 
 
 def check_const(g, input_id):
     node = g.get_node_by_name(input_id)
     if node and node.is_const():
-        return True, node.get_tensor_value()
+        return (True, node.get_tensor_value())
     elif g.is_initializer(input_id):
         tensor = g.get_initializer(input_id)
-        return True, numpy_helper.to_array(tensor)
+        return (True, numpy_helper.to_array(tensor))
 
-    return None, None
+    return (None, None)
 
 
 def get_np_val_for_const(g, node, input_index):
@@ -299,9 +143,9 @@ def _process_single_init_node(g, fw_init_input_id, bw_init_input_id, to_append):
     if fw_init_is_const and bw_init_is_const:
         initial_val = np.concatenate((init_fw_val, init_bw_val), axis=0)
         init_name = utils.make_name("initial")
-        init_node = g.make_const(init_name, initial_val, skip_conversion=True)
+        init_node = g.make_const(init_name, initial_val, skip_conversion = True)
     else:
-        attr = {"axis": 0}
+        attr = {"axis" : 0}
         init_node = make_onnx_node(g, "Concat", [fw_init_input_id, bw_init_input_id], attr)
         to_append.append(init_node)
 
@@ -313,3 +157,33 @@ def process_ch_init_nodes(g, lstm_fw, lstm_bw, to_append):
     c_node = _process_single_init_node(g, lstm_fw.input[6], lstm_bw.input[6], to_append)
 
     return h_node, c_node
+
+
+def rewrite_bidirectional_lstms(g, ops):
+    fw_lstm = {}
+    bw_lstm = {}
+    for n in g.get_nodes():
+        if n.type != "LSTM":
+            continue
+        input_id = n.input[0]
+        temp = n.inputs[0]
+        is_backward_lstm = False
+        if temp.type == "Transpose":
+            input_id = temp.input[0]
+            temp = temp.inputs[0]
+
+        if is_reverse_op(temp):
+            input_id = temp.input[0]
+            is_backward_lstm = True
+
+        if is_backward_lstm:
+            log.info("find bw lstm" + input_id)
+            bw_lstm[input_id] = [input_id, n]
+        else:
+            log.info("find fw lstm" + input_id)
+            fw_lstm[input_id] = [input_id, n]
+
+    bilstm_input = list(set(fw_lstm.keys()).intersection(bw_lstm.keys()))
+    bi_lstms = [(fw_lstm[input_id], bw_lstm[input_id]) for input_id in bilstm_input]
+
+    return process_bilstm(g, bi_lstms)

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -27,8 +27,8 @@ log = logging.getLogger("tf2onnx.rewriter.bilstm_rewriter")
 def process_bilstm(g, bi_lstms):
     for fw, bw in bi_lstms:
         input_id = fw[0]
-        log.info("=========================")
-        log.info("start handling potential bidirectional lstm " + input_id)
+        log.debug("=========================")
+        log.debug("start handling potential bidirectional lstm " + input_id)
 
         lstm_fw = fw[1]
         lstm_bw = bw[1]
@@ -74,7 +74,7 @@ def process_bilstm(g, bi_lstms):
         attr = {"direction": direction, "hidden_size": hidden_size}
         bi_lstm_node = make_onnx_node(g, "LSTM", lstm_inputs, attr=attr, output_count=3)
         all_nodes.append(bi_lstm_node)
-        log.info("processing output nodes")
+        log.debug("processing output nodes")
 
         slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm_node, 0, all_nodes)
         slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm_node, 1, all_nodes)
@@ -177,10 +177,10 @@ def rewrite_bidirectional_lstms(g, ops):
             is_backward_lstm = True
 
         if is_backward_lstm:
-            log.info("find bw lstm" + input_id)
+            log.debug("find bw lstm" + input_id)
             bw_lstm[input_id] = [input_id, n]
         else:
-            log.info("find fw lstm" + input_id)
+            log.debug("find fw lstm" + input_id)
             fw_lstm[input_id] = [input_id, n]
 
     bilstm_input = list(set(fw_lstm.keys()).intersection(bw_lstm.keys()))

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -67,7 +67,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
         # function are defining the multiplication with different order. So we change to match.get_op("ft") in c.inputs
         mul_nodes = [c for c in identity_consumers if c.type == "Mul" and match.get_op("ft") in c.inputs]
         if len(mul_nodes) == 1:
-            log.info("find c initializer value at " + enter_target_node_input_id)
+            log.debug("find c initializer value at " + enter_target_node_input_id)
             return enter_target_node_input_id
         elif len(mul_nodes) > 1:
             raise ValueError("multiple Mul matching found, cannot identify c initializer")
@@ -75,7 +75,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
     def ht_switch_check(self, enter_target_node_input_id, identity_consumers, match):
         concat_nodes = [c for c in identity_consumers if c == match.get_op("xh")]
         if len(concat_nodes) == 1:
-            log.info("find h initializer value at " + enter_target_node_input_id)
+            log.debug("find h initializer value at " + enter_target_node_input_id)
             return enter_target_node_input_id
         elif len(concat_nodes) > 1:
             raise ValueError(str(len(concat_nodes)) + "Concat matching found, cannot identify h initializer")
@@ -103,7 +103,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
                 h_slice = s
 
         if c_slice and h_slice:
-            log.info("find c_h shared initializer value at " + enter_target_node_input_id) 
+            log.debug("find c_h shared initializer value at " + enter_target_node_input_id) 
             return enter_target_node_input_id
 
     def process_weights_and_bias(self, rnn_weights):

--- a/tf2onnx/rewriter/rnn.py
+++ b/tf2onnx/rewriter/rnn.py
@@ -20,4 +20,4 @@ def rewrite_single_direction_lstm(g, ops):
     return r.run()
 
 def rewrite_bi_direction_lstm(g, ops): 
-    return process_bilstm_batch_major(g, ops)
+    return rewrite_bidirectional_lstms(g, ops)

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -150,7 +150,7 @@ def get_weights_from_const_node(node):
     if temp and temp.type == 'Const':
         val = temp.get_tensor_value()
         dtype = utils.ONNX_TO_NUMPY_DTYPE[temp.dtype]
-        log.info("found weights " + temp.name)
+        log.debug("found weights " + temp.name)
     else:
         log.error("weight node seems not to be Const, skip, node name is " + temp.name)
         return

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -6,9 +6,8 @@ tf2onnx.rewriter.rnn_utils - rnn support
 """
 
 import logging
-from enum import Enum
-
 import numpy as np
+from enum import Enum
 from onnx import helper
 from tf2onnx import utils
 from tf2onnx.graph import Node
@@ -22,17 +21,20 @@ class REWRITER_RESULT(Enum):
     OK = 2
     FAIL = 3
 
+
 class RnnWeight:
     def __init__(self, node, np_val, np_dtype):
         self.node = node
         self.value = np_val
         self.dtype = np_dtype
 
+
 class RnnWeights:
     def __init__(self, kernel, bias, forget_bias):
         self.kernel = kernel
         self.bias = bias
         self.forget_bias = forget_bias
+
 
 class RnnInitializers:
     def __init__(self, c_init, h_init, c_h_shared_init):
@@ -49,17 +51,22 @@ class RnnInitializers:
             self.h_init_input_id = h_init
             self.share_init_node = False
 
+
 class RnnProperties:
     def __init__(self):
+        # RNN input who are outside of rnn scope
         self.input_node = None
         self.input_id = None
-        self.connectors = None # RNN outputs consumers who is outside of rnn scope
+
+        # RNN output consumers who are outside of rnn scope
+        self.connectors = None
         self.is_backward = False
 
         self.time_major = False
-        self.x_node = None # used to serve lstm's 1st input
+        self.x_input_id = None # used to serve lstm's 1st input
         self.input_size = None
         self.hidden_size = None
+        self.batch_size_node = None
 
     def is_valid(self):
         if not self.input_node:
@@ -78,20 +85,6 @@ class RnnProperties:
         return True
 
 
-class MatchedLSTM:
-    def __init__(self, input_node, lstm_fw, lstm_bw, output_pack, nodes_to_delete, match):
-        self.input = input_node
-        self.match = match
-        self.lstm_fw = lstm_fw
-        self.lstm_bw = lstm_bw
-        self.output_pack = output_pack
-        self.state_is_tuple = None
-
-        tmp_nodes = []
-        tmp_nodes.extend(nodes_to_delete)
-        tmp_nodes.extend(match.get_nodes())
-        self.nodes_to_delete = set(tmp_nodes)
-
 # TensorFlow LSTMCell/BasicLSTMCell computation graph matching
 xc_pattern = OpTypePattern('Split', inputs=[
     OpTypePattern("Const"), # axis for split
@@ -107,6 +100,7 @@ xc_pattern = OpTypePattern('Split', inputs=[
         ]),
     ]),
 ])
+
 
 lstmcell_pattern = \
     OpTypePattern('Mul', name='ht', inputs=[
@@ -134,13 +128,16 @@ class RNNUnitType(Enum):
     LSTMCell = 0 # TF LSTMCell and BasicLSTMCell share the same pattern
     GRUCell = 1
 
+
 rnn_cell_patterns = {
     RNNUnitType.LSTMCell: lstmcell_pattern,
     RNNUnitType.GRUCell: None
 }
 
+
 def get_pattern(cell_type_name):
     return rnn_cell_patterns[cell_type_name]
+
 
 def get_weights_from_const_node(node):
     temp = node
@@ -160,6 +157,7 @@ def get_weights_from_const_node(node):
 
     return RnnWeight(node, val, dtype)
 
+
 def check_is_timemajor_transpose(node):
     # TensorFlow transpose node has perm as its second input
     if node.type != "Transpose" :
@@ -175,6 +173,7 @@ def check_is_timemajor_transpose(node):
         return True
     else:
         raise ValueError("Not supported yet")
+
 
 # todo: fix this
 def check_is_unfolded_perm(perm_node):
@@ -196,6 +195,7 @@ def check_is_unfolded_perm(perm_node):
             return True
     return False
 
+
 def make_onnx_node(g, op_type, inputs, attr=None, output_count=1, skip_conversion=True):
     if attr is None:
         attr = {}
@@ -206,3 +206,7 @@ def make_onnx_node(g, op_type, inputs, attr=None, output_count=1, skip_conversio
         g, skip_conversion = skip_conversion)
 
     return node
+
+
+def is_reverse_op(op):
+    return op.type in ("ReverseV2", "ReverseSequence")

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -25,7 +25,7 @@ class UnitRewriterBase:
 
     @staticmethod
     def print_step(level_2, level_1="find_dynamic_run_unit"):
-        log.info(level_1 + " >> " + level_2)
+        log.debug(level_1 + " >> " + level_2)
 
     def ct_switch_check(self, enter_target_node_input_id, identity_consumers, match):
         pass
@@ -82,7 +82,7 @@ class UnitRewriterBase:
         return self.g.get_nodes()
 
     def run_single_match(self, match):
-        log.info("=========================")
+        log.debug("=========================")
         self.print_step("start handling a new potential LSTM Cell")
         self.all_nodes = self.g.get_nodes()
         self.must_keep_nodes = []
@@ -92,7 +92,7 @@ class UnitRewriterBase:
             log.error("unable to find rnn scope name, skip")
             return REWRITER_RESULT.SKIP
         else:
-            log.info("rnn scope name is " + rnn_scope_name)
+            log.debug("rnn scope name is " + rnn_scope_name)
 
         self.print_step("get_weight_and_bias starts")
         rnn_weights = self.get_weight_and_bias(match)
@@ -219,7 +219,7 @@ class UnitRewriterBase:
         # output back. And the 2 reverses operators are not within the dynamic_rnn scope. 
         # So, in this case, we might get a reverse op in rnn_input_nodes. 
         if is_reverse_op(input_node_candidate):
-            log.info("found reverse pattern")
+            log.debug("found reverse pattern")
             rnn_props.is_backward = True
 
             # reverse has 2 inputs, the second is axis.
@@ -430,7 +430,7 @@ class UnitRewriterBase:
         seq_len_nodes = []
         for n in self.g.get_nodes():
             if n.name.endswith("sequence_length") and n.name.startswith(rnn_scope_name) and n.type == "Identity":
-                print("found sequence_length node ")
+
                 seq_len_nodes.append(n)
 
         seq_len_node_cnt = len(seq_len_nodes)

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -105,7 +105,10 @@ class UnitRewriterBase:
             log.error("basic LSTM Cell ct/ht initializer check failed, skip")
             return REWRITER_RESULT.SKIP
 
+        seq_len_input_node = self.find_sequence_length_node(rnn_scope_name)
         input_filter = self.get_rnn_input_blacklist(rnn_weights, rnn_inits)
+        if seq_len_input_node:
+            input_filter.append(seq_len_input_node)
 
         rnn_props = self.find_input_and_connectors(rnn_scope_name, input_filter)
         if not rnn_props.is_valid():
@@ -121,6 +124,9 @@ class UnitRewriterBase:
         rnn_props.input_size = input_size
         rnn_props.hidden_size = hidden_size
 
+        len_node, batch_size_node = self.create_nodes_batch_size_and_seq_length(rnn_props, seq_len_input_node)
+        rnn_props.batch_size_node = batch_size_node
+
         # create node
         w_name = utils.make_name("W")
         w_node = self.g.make_const(w_name, W, skip_conversion=True)
@@ -134,13 +140,10 @@ class UnitRewriterBase:
         init_h_id = None
         init_c_id = None
         if rnn_inits.share_init_node:
-            init_h_id, init_c_id = self.process_non_tuple_ch_init_nodes(rnn_inits.share_init_input_id, hidden_size)
+            init_h_id, init_c_id = self.process_non_tuple_ch_init_nodes(rnn_inits, rnn_props)
         else:
-            init_h_id, init_c_id = self.process_tuple_ch_init_nodes(rnn_inits.c_init_input_id,
-                                                                    rnn_inits.h_init_input_id, hidden_size)
+            init_h_id, init_c_id = self.process_tuple_ch_init_nodes(rnn_inits, rnn_props)
         assert init_h_id and init_c_id
-
-        len_node = self.create_seq_len_node(rnn_props)
 
         self.print_step("start to build new LSTM node")
 
@@ -153,8 +156,9 @@ class UnitRewriterBase:
             direction = "reverse"
         # todo: input_forget
         attr = {"direction": direction, "hidden_size": hidden_size}
-        lstm_input_nodes = [rnn_props.x_node, w_node, r_node, b_node, len_node]
-        lstm_inputs = list(map(lambda n: n.output[0], lstm_input_nodes))
+        lstm_input_nodes = [w_node, r_node, b_node, len_node]
+        lstm_inputs = [rnn_props.x_input_id]
+        lstm_inputs.extend(list(map(lambda n: n.output[0], lstm_input_nodes)))
         lstm_inputs.extend([init_h_id, init_c_id])
         lstm_node = make_onnx_node(self.g, "LSTM", lstm_inputs, attr, 3)
         self.all_nodes.extend([lstm_node])
@@ -203,20 +207,20 @@ class UnitRewriterBase:
         input_node_candidate = rnn_input_nodes[0][0]
         input_id_candidate = rnn_input_nodes[0][1]
 
-        # in TF bidirectional_rnn, backforward, will first reverse the inputs, then dynamic_run, then reverse 
-        # output back. And the 2 reverses operators are not within the deeper dynamic_rnn scope. 
-        # So, in this case, we might get a ReverseV2 op in rnn_input_nodes. 
-        if input_node_candidate.type in ["ReverseV2"]:
+        # in TF bidirectional_dynamic_rnn, backforward, will first reverse the inputs, then dynamic_run, then reverse
+        # output back. And the 2 reverses operators are not within the dynamic_rnn scope. 
+        # So, in this case, we might get a reverse op in rnn_input_nodes. 
+        if is_reverse_op(input_node_candidate):
             log.info("found reverse pattern")
             rnn_props.is_backward = True
 
-            # ReverseV2 has 2 inputs, the second is axis.
+            # reverse has 2 inputs, the second is axis.
             rnn_props.input_node = input_node_candidate.inputs[0]
             rnn_props.input_id = input_node_candidate.input[0]
             rnn_props.connectors = connector_nodes
             return rnn_props
         else:
-            # we should not limit the rnn_input_nodes' type be PlaceHolder or Const, 
+            # we should not limit the rnn_input_nodes' type be Placeholder or Const, 
             # because there might some Reshape/etc. ops after the Placeholder
             rnn_props.input_node = input_node_candidate
             rnn_props.input_id = input_id_candidate
@@ -305,27 +309,27 @@ class UnitRewriterBase:
         self.print_step("look for possible transpose following RNN input node")
         # todo: peepholdes P is not considered now
         input_consumers = self.g.find_output_consumers(rnn_props.input_id)
-        cur_rnn_consumers = []
+        consumers_in_rnn_scope = []
         for consumer in input_consumers:
             if not rnn_props.is_backward:
                 if consumer.name.startswith(rnn_scope_name):
-                    cur_rnn_consumers.append(consumer)
+                    consumers_in_rnn_scope.append(consumer)
             else:
-                # reversev2 might have a different name scope, so we check this way.
-                if consumer.type == "ReverseV2":
-                    cur_rnn_consumers.append(consumer)
+                # reverse op might have a different name scope, so we check this way.
+                if is_reverse_op(consumer):
+                    consumers_in_rnn_scope.append(consumer)
 
-        if len(cur_rnn_consumers) != 1:
-            log.error("RNN input node has " + str(len(cur_rnn_consumers)) +
+        if len(consumers_in_rnn_scope) != 1:
+            log.error("RNN input node has " + str(len(consumers_in_rnn_scope)) +
                       " consumers in current rnn scope " + rnn_scope_name + ", skip")
             return None
 
-        possible_transpose_after_input = cur_rnn_consumers[0]
+        possible_transpose_after_input = consumers_in_rnn_scope[0]
         if rnn_props.is_backward:
-            assert possible_transpose_after_input.type == "ReverseV2"
             self.must_keep_nodes.append(possible_transpose_after_input)
             reverse_outputs = self.g.find_output_consumers(possible_transpose_after_input.output[0])
-            assert len(reverse_outputs) == 1  # bidirectional_dynamic_rnn logic will promise this
+            if len(reverse_outputs) != 1:  # bidirectional_dynamic_rnn logic will promise this
+                raise ValueError("reverse ops has more than one outputs")
             possible_transpose_after_input = reverse_outputs[0]
 
         self.print_step("convert the transpose to onnx node if there is one found.")
@@ -338,12 +342,12 @@ class UnitRewriterBase:
         if converted_transpose:
             log.debug("detect batch-major inputs")
             rnn_props.time_major = False
-            rnn_props.x_node = converted_transpose
+            rnn_props.x_input_id = converted_transpose.output[0]
             self.all_nodes.extend([converted_transpose])
         else:
             log.debug("detect timer-major inputs")
             rnn_props.time_major = True
-            rnn_props.x_node = rnn_props.input_node
+            rnn_props.x_input_id = rnn_props.input_id
 
         return rnn_props
 
@@ -360,7 +364,14 @@ class UnitRewriterBase:
         return new_trans
 
     # todo: refine when implementing GRU
-    def process_non_tuple_ch_init_nodes(self, input_id, hidden_size):
+    def process_non_tuple_ch_init_nodes(self, rnn_inits, rnn_props):
+        input_id = rnn_inits.share_init_input_id
+        hidden_size = rnn_props.hidden_size
+
+        # todo: remove this once Fill ops is supported 
+        fill_ch_init_node = self._workaround_fill_ch_init_node(input_id, rnn_props)
+        if fill_ch_init_node: 
+            return fill_ch_init_node.output[0], fill_ch_init_node.output[0]
 
         attr = {"axes": [1], "starts": [0], "ends": [hidden_size]}
         slice_node1 = make_onnx_node(self.g, "Slice", [input_id], attr)
@@ -373,16 +384,25 @@ class UnitRewriterBase:
         unsqueeze_node_2 = make_onnx_node(self.g, "Unsqueeze", [slice_node2.output[0]], attr={"axes": [0]})
 
         self.all_nodes.extend([slice_node1, slice_node2, unsqueeze_node_1, unsqueeze_node_2])
+        self.must_keep_nodes.append(self.g.get_node_by_name(input_id))
         return unsqueeze_node_1.output[0], unsqueeze_node_2.output[0]
 
     # todo: refine when implementing GRU
-    def process_tuple_ch_init_nodes(self, c_init_input_id, h_init_input_id, hidden_size):
-        h_node_output = self.connect_initializer_node(h_init_input_id, hidden_size)
-        c_node_output = self.connect_initializer_node(c_init_input_id, hidden_size)
+    def process_tuple_ch_init_nodes(self, rnn_inits, rnn_props):
+        h_init_input_id = rnn_inits.h_init_input_id 
+        c_init_input_id = rnn_inits.c_init_input_id
+        h_node_output = self.connect_initializer_node(h_init_input_id, rnn_props)
+        c_node_output = self.connect_initializer_node(c_init_input_id, rnn_props)
         return h_node_output, c_node_output
 
-    def connect_initializer_node(self, initializer_input_id, hidden_size):
+    def connect_initializer_node(self, initializer_input_id, rnn_props):
+        # todo: remove this once Fill ops is supported
+        fill_ch_init_node = self._workaround_fill_ch_init_node(initializer_input_id, rnn_props) 
+        if fill_ch_init_node: 
+            return fill_ch_init_node.output[0]
+
         node = self.g.get_node_by_name(initializer_input_id)
+        self.must_keep_nodes.append(node)
         if node.is_const():
             val = node.get_tensor_value()
             initial_name = utils.make_name("Const")
@@ -395,51 +415,81 @@ class UnitRewriterBase:
             self.all_nodes.append(squeeze_node)
             return squeeze_node.output[0]
 
-    def create_seq_len_node(self, rnn_props):
-        # check whether input_node has valid shape
-        if rnn_props.input_node.shape:
-            self.print_step("input node has shape: parse batch_size, time_step, input_size, create seq_len const nodes")
-            if rnn_props.time_major and rnn_props.input_node.shape[1] != utils.ONNX_UNKNOWN_DIMENSION:
-                time_step = rnn_props.input_node.shape[0]
-                batch_size = rnn_props.input_node.shape[1]
-                input_size_2 = rnn_props.input_node.shape[2]
-            elif rnn_props.input_node.shape[0] != utils.ONNX_UNKNOWN_DIMENSION:
-                batch_size = rnn_props.input_node.shape[0]
-                time_step = rnn_props.input_node.shape[1]
-                input_size_2 = rnn_props.input_node.shape[2]
+    def find_sequence_length_node(self, rnn_scope_name):
+        # "sequence_length" under current rnn scope is the seq len node (if there is).
+        # this is hardcoded in dynamic_rnn().
 
-            assert rnn_props.input_size == input_size_2
-            # todo: what if batch_size = -1
-            sequence_lens = np.array([time_step for l in np.arange(batch_size)], dtype=np.int32)
-            len_name = utils.make_name("Const")
-            len_node = self.g.make_const(len_name, sequence_lens, skip_conversion=True)
-            self.g.set_shape(len_node.output[0], sequence_lens.shape)
+        seq_len_nodes = []
+        for n in self.g.get_nodes():
+            if n.name.endswith("sequence_length") and n.name.startswith(rnn_scope_name) and n.type == "Identity":
+                print("found sequence_length node ")
+                seq_len_nodes.append(n)
+
+        seq_len_node_cnt = len(seq_len_nodes)
+
+        if seq_len_node_cnt == 0:
+            return
+        elif seq_len_node_cnt == 1:
+            seq_len_identity_node = seq_len_nodes[0]
+            if not seq_len_identity_node.inputs[0].name.startswith(rnn_scope_name):
+                return seq_len_identity_node.inputs[0]
+            else:
+                raise ValueError("sequence length node should be outside of rnn scope")
         else:
-            self.print_step("prepare input nodes for new lstm node")
-            shape_node = make_onnx_node(self.g, "Shape", [rnn_props.input_id])
+            raise ValueError("there are more sequence length nodes than expected")
 
-            # LSTMCell only allow inputs of [batch, input_size], so we assume dynamic_rnn has 3 dims.
-            # Slice cannot support Int64 in OPSET 7, so we cast here.
-            attr = {"to": onnx_pb.TensorProto.FLOAT}
-            cast_shape_node = make_onnx_node(self.g, "Cast", [shape_node.output[0]], attr)
-            self.g.copy_shape(shape_node.output[0], cast_shape_node.output[0])
+    def create_nodes_batch_size_and_seq_length(self, rnn_props, seq_length_node = None):
+        # output: [time step, batch size, input size]
+        shape_node = make_onnx_node(self.g, "Shape", [rnn_props.x_input_id])
 
-            attr = {"axes": [0], "starts": [0], "ends": [1]}
-            batchsize_node = make_onnx_node(self.g, "Slice", [cast_shape_node.output[0]], attr)
+        # LSTMCell only allow inputs of [batch size, input_size], so we assume dynamic_rnn has 3 dims.
+        # Slice cannot support Int64 in OPSET 7, so we cast here.
+        attr = {"to": onnx_pb.TensorProto.FLOAT}
+        cast_shape_node = make_onnx_node(self.g, "Cast", [shape_node.output[0]], attr)
+        self.g.copy_shape(shape_node.output[0], cast_shape_node.output[0])
 
-            attr = {"to": onnx_pb.TensorProto.INT64}
-            repeat_node = make_onnx_node(self.g, 'Cast', [batchsize_node.output[0]], attr)
+        attr = {"axes": [0], "starts": [1], "ends": [2]}
+        batchsize_node = make_onnx_node(self.g, "Slice", [cast_shape_node.output[0]], attr)
 
-            attr = {"axes": [0], "starts": [1], "ends": [2]}
+        # Tile's repeats must be INT64
+        attr = {"to": onnx_pb.TensorProto.INT64}
+        repeat_node = make_onnx_node(self.g, 'Cast', [batchsize_node.output[0]], attr)
+
+        self.all_nodes.extend([shape_node, cast_shape_node, batchsize_node, repeat_node])
+
+        if not seq_length_node:
+            attr = {"axes" : [0], "starts": [0], "ends": [1]}
             timestep_node = make_onnx_node(self.g, 'Slice', [cast_shape_node.output[0]], attr)
 
             tile_node = make_onnx_node(self.g, 'Tile', [timestep_node.output[0], repeat_node.output[0]])
 
             attr = {"to": onnx_pb.TensorProto.INT32}  # LSTM sequence_lens needs to be int32
-            cast_back_node = make_onnx_node(self.g, 'Cast', [tile_node.output[0]], attr)
+            seq_length_node = make_onnx_node(self.g, 'Cast', [tile_node.output[0]], attr)
 
-            len_node = cast_back_node
-            self.all_nodes.extend([shape_node, cast_shape_node,
-                                   timestep_node, batchsize_node, repeat_node, tile_node, len_node])
+            self.all_nodes.extend([timestep_node, tile_node, seq_length_node])
 
-        return len_node
+        return seq_length_node, batchsize_node
+
+    def _workaround_fill_ch_init_node(self, initializer_input_id, rnn_props):
+        node = self.g.get_node_by_name(initializer_input_id)
+        if node.type != "Fill":
+            return 
+
+        fill_val = node.inputs[1].get_tensor_value()[0]
+        fill_val_dtype = utils.ONNX_TO_NUMPY_DTYPE[node.inputs[1].dtype]
+
+        # this must be int64, since Concat's input data type must be consistent.
+        num_direction_node = self.g.make_const(utils.make_name("Const"), np.array([1], dtype=np.float32))
+        h_node = self.g.make_const(utils.make_name("Const"), np.array([rnn_props.hidden_size], dtype=np.float32))
+        b_node = rnn_props.batch_size_node
+        # Concat in OPSET7 does not support int64.
+        tile_shape = make_onnx_node(self.g, "Concat", [num_direction_node.output[0], b_node.output[0], h_node.output[0]], attr={"axis": 0})
+
+        # Tile's repeats must be INT64
+        attr = {"to": onnx_pb.TensorProto.INT64}
+        tile_shape_int64 = make_onnx_node(self.g, 'Cast', [tile_shape.output[0]], attr)
+
+        const_node = self.g.make_const(utils.make_name("Const"), np.array([[[fill_val]]], dtype=fill_val_dtype))
+        tile_node = make_onnx_node(self.g, 'Tile', [const_node.output[0], tile_shape_int64.output[0]])
+        self.all_nodes.extend([tile_shape, tile_shape_int64, tile_node])
+        return tile_node

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1567,7 +1567,10 @@ def tf_optimize(sess, inputs, outputs, graph_def, fold_constant=None):
     """Optimize tensorflow graph for inference."""
     transforms = []
     if fold_constant:
-        transforms.append("fold_constants(ignore_errors=true)")
+        transforms.extend([
+            "fold_constants(ignore_errors=true)",
+            "remove_attribute(attribute_name=_class)", # remove node colocation attributes
+        ])
 
     transforms.extend([
         "fold_batch_norms",


### PR DESCRIPTION
1. change bilstm-rewriter to use simpler strategy. 
2. add case coverage for user specified sequence_length. 
3. allow initializer_c/h Fill zero assignment with dynamic shape [dynamic batch size node, hidden_size_fixed_number]. 
4. set shape for some lstm outputs, this will be helpful for ConcatV2 axis=-1 conversion. 
5. clean up debug information to make the console neat. 