### PR TITLE
placeholder_with_default_op

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -428,12 +428,20 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
-    def test_placeholder_with_default(self):
+    def test_placeholder_with_default_use_default(self):
         x_val = np.array([1.0, 2.0, -3.0, -4.0], dtype=np.float32).reshape((2, 2))
-        y = tf.constant(x_val, name="y")
-        x = tf.placeholder_with_default(y, x_val.shape, name=_TFINPUT)
-        _ = tf.identity(x, name=_TFOUTPUT)
-        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        x = tf.constant(x_val, name="x")
+        y = tf.placeholder_with_default(x, x_val.shape, name=_TFINPUT)
+        _ = tf.identity(y, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {})
+
+    def test_placeholder_with_default_use_feed(self):
+        x_val = np.array([1.0, 2.0, -3.0, -4.0], dtype=np.float32).reshape((2, 2))
+        x = tf.constant(x_val, name="x")
+        y = tf.placeholder_with_default(x, x_val.shape, name=_TFINPUT)
+        _ = tf.identity(y, name=_TFOUTPUT)
+        x_feed_val = np.array([11.0, 22.0, -33.0, -44.0], dtype=np.float32).reshape((2, 2))
+        self._run_test_case([_OUTPUT], {_INPUT: x_feed_val})
 
     @unittest.skipIf(*onnxruntime_check("Add"))
     def test_add_bcast(self):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -216,7 +216,6 @@ class Node(object):
         # track shapes in _output_shapes
         self.graph.set_shape(t.name, t.dims)
 
-
     def get_body_graphs(self):
         return self.graph.contained_graphs.get(self.name, None)
 
@@ -355,9 +354,9 @@ class Graph(object):
     def initializers(self):
         return self._initializers
 
-    def is_target(self, name):
-        """Return True if target platform is name."""
-        return name in self._target
+    def is_target(self, *names):
+        """Return True if target platform contains any name."""
+        return any(name in self._target for name in names)
 
     def is_initializer(self, name):
         """Check the name is a constant value. name is in format - node_name:<int>."""
@@ -614,6 +613,7 @@ class Graph(object):
 
     def topological_sort(self, ops):
         """Topological sort of graph."""
+
         def _push_stack(stack, node, in_stack):
             stack.append(node)
             if node in in_stack:
@@ -708,7 +708,6 @@ class Graph(object):
                                                  initializer.data_type,
                                                  initializer.dims)
             input_with_initializers.append(val)
-
 
         # todo(pengwa): clean up initializer related code.
         # create input_tensor_values


### PR DESCRIPTION
To simulate TF placeholder_with_default behavior, convert const default value to initializer.
user can specify input to override default value in initializer when running session, or specify no input so default value is used.

if the placeholder_with_default default value is non a const node, fall back to placeholder, default value is ignored. 