### PR TITLE
fix bilstm/bigru bug when bw lst/gru's output is not followed by reve…

### DIFF
--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -14,8 +14,8 @@ import logging
 import numpy as np
 from tf2onnx import utils
 from tf2onnx.rewriter.rnn_utils import is_reverse_op, make_onnx_node
-from tf2onnx.rewriter.bilstm_rewriter import slice_bilstm_for_original_lstm_consumers
-from tf2onnx.rewriter.bilstm_rewriter import get_np_val_for_const, _process_single_init_node
+from tf2onnx.rewriter.bilstm_rewriter import slice_bilstm_for_original_lstm_consumers \
+     get_reverse_nodes_after_y_output, get_np_val_for_const, _process_single_init_node
 
 
 logging.basicConfig(level=logging.INFO)
@@ -151,8 +151,10 @@ def rewrite_bidirectional_grus(g, ops):
             is_backward_gru = True
 
         if is_backward_gru:
-            log.debug("find bw gru %s", input_id)
-            bw_gru[input_id] = [input_id, n]
+            # make sure reverse gru output will be reversed back
+            if get_reverse_nodes_after_y_output(g, n):
+                log.debug("find bw gru %s", input_id)
+                bw_gru[input_id] = [input_id, n]
         else:
             log.debug("find fw gru %s", input_id)
             fw_gru[input_id] = [input_id, n]

--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -14,7 +14,7 @@ import logging
 import numpy as np
 from tf2onnx import utils
 from tf2onnx.rewriter.rnn_utils import is_reverse_op, make_onnx_node
-from tf2onnx.rewriter.bilstm_rewriter import slice_bilstm_for_original_lstm_consumers \
+from tf2onnx.rewriter.bilstm_rewriter import slice_bilstm_for_original_lstm_consumers,\
      get_reverse_nodes_after_y_output, get_np_val_for_const, _process_single_init_node
 
 

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -115,7 +115,7 @@ def slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm, lstm_
 
     if lstm_output_index == 0:
         axis = 1
-
+        # remove reverse op for lstm_bw
         reverse_nodes = get_reverse_nodes_after_y_output(g, lstm_bw)
         if not reverse_nodes:
             raise ValueError("should not happen y_output is not followed with reverse node")
@@ -215,7 +215,6 @@ def rewrite_bidirectional_lstms(g, ops):
 def get_reverse_nodes_after_y_output(g, lstm_bw):
     bw_consumers = g.find_output_consumers(lstm_bw.output[0])
 
-    # remove reverse op for lstm_bw
     # todo: figure out a better way to remove reverse op
     squeeze_nodes = [c for c in bw_consumers if c.type == "Squeeze"]
     s_cnt = len(squeeze_nodes)

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -115,29 +115,15 @@ def slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm, lstm_
 
     if lstm_output_index == 0:
         axis = 1
-        # remove reverse op for lstm_bw
-        # todo: figure out a better way to remove reverse op
-        squeeze_nodes = [c for c in bw_consumers if c.type == "Squeeze"]
-        s_cnt = len(squeeze_nodes)
-        if s_cnt > 1:
-            raise ValueError("unexpected number of squeeze following LSTM 1st output")
-        elif s_cnt == 1:
-            s = squeeze_nodes[0]
-            trans_nodes = g.find_output_consumers(s.output[0])
-            if len(trans_nodes) == 1:
-                if trans_nodes[0].type == "Transpose":
-                    reverse_nodes = g.find_output_consumers(trans_nodes[0].output[0])
-                elif is_reverse_op(trans_nodes[0]):
-                    reverse_nodes = trans_nodes
-                else:
-                    raise ValueError("not found reverse op, unexpected")
 
-                for r_op in reverse_nodes:
-                    log.debug("remove reverse op called %s", r_op.name)
-                    g.replace_all_inputs(all_nodes, r_op.output[0], r_op.input[0])
-                    to_remove.append(r_op.name)
-            else:
-                raise ValueError("unexpected number of transpose after LSTM 1st output")
+        reverse_nodes = get_reverse_nodes_after_y_output(g, lstm_bw)
+        if not reverse_nodes:
+            raise ValueError("should not happen y_output is not followed with reverse node")
+
+        for r_op in reverse_nodes:
+            log.debug("remove reverse op called %s", r_op.name)
+            g.replace_all_inputs(all_nodes, r_op.output[0], r_op.input[0])
+            to_remove.append(r_op.name)
     elif lstm_output_index in [1, 2]:
         axis = 0
     else:
@@ -212,8 +198,10 @@ def rewrite_bidirectional_lstms(g, ops):
             is_backward_lstm = True
 
         if is_backward_lstm:
-            log.debug("find bw lstm %s", input_id)
-            bw_lstm[input_id] = [input_id, n]
+            # make sure reverse lstm output will be reversed back
+            if get_reverse_nodes_after_y_output(g, n):
+                log.debug("find bw lstm %s", input_id)
+                bw_lstm[input_id] = [input_id, n]
         else:
             log.debug("find fw lstm %s", input_id)
             fw_lstm[input_id] = [input_id, n]
@@ -222,3 +210,36 @@ def rewrite_bidirectional_lstms(g, ops):
     bi_lstms = [(fw_lstm[input_id], bw_lstm[input_id]) for input_id in bilstm_input]
 
     return process_bilstm(g, bi_lstms)
+
+
+def get_reverse_nodes_after_y_output(g, lstm_bw):
+    bw_consumers = g.find_output_consumers(lstm_bw.output[0])
+
+    # remove reverse op for lstm_bw
+    # todo: figure out a better way to remove reverse op
+    squeeze_nodes = [c for c in bw_consumers if c.type == "Squeeze"]
+    s_cnt = len(squeeze_nodes)
+    if s_cnt == 1:
+        s = squeeze_nodes[0]
+        trans_nodes = g.find_output_consumers(s.output[0])
+        if len(trans_nodes) == 1:
+            if trans_nodes[0].type == "Transpose":
+                reverse_nodes = g.find_output_consumers(trans_nodes[0].output[0])
+            elif is_reverse_op(trans_nodes[0]):
+                reverse_nodes = trans_nodes
+            else:
+                log.debug("not found reverse op, unexpected")
+                return None
+
+            are_all_reverse = all([is_reverse_op(r_op) for r_op in reverse_nodes])
+            if are_all_reverse:
+                return reverse_nodes
+
+            log.debug("bw y output is used followed by reverse node")
+            return None
+
+        log.debug("unexpected number of transpose after LSTM 1st output:%s", s_cnt)
+        return None
+
+    log.debug("unexpected number of squeeze following LSTM 1st output:%s", s_cnt)
+    return None

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -15,7 +15,7 @@ from tf2onnx.graph import Graph, Node
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase, Context
 from tf2onnx.rewriter.rnn_utils import is_tensor_array_gather_op, is_tensor_array_write_op, \
-     is_placeholder_op, make_onnx_node
+     make_onnx_node
 from tf2onnx.rewriter.rnn_utils import BodyGraphDict, REWRITER_RESULT, SubGraphMetadata
 from tf2onnx.tfonnx import utils
 
@@ -350,19 +350,7 @@ class CustomRnnRewriter(LoopRewriterBase):
 
             nodes = self.g._extract_sub_graph_nodes(self.g.get_node_by_name(enter_node.input[0]))
 
-            # if the enter target subgraph contains planeholder, then we keep record that as cell boundary.
-            has_placeholder = None
-            for n in nodes:
-                if is_placeholder_op(n):
-                    has_placeholder = True
-                    break
-
-            # if there is placeholder in the Enter's input graph, then we think we should consider the Enter's input
-            # nodes as cell's input; otherwise, we think the input graph should be part of cell graph.
-            if has_placeholder is True:
-                log.debug("Enter input id [%s] is a subgraph containing placeholder, so make it cell boundary",
-                          enter_node.input[0])
-                other_enter_input_ids.append(enter_node.input[0])
+            other_enter_input_ids.append(enter_node.input[0])
 
         body_graph_meta.other_enter_input_ids = other_enter_input_ids
 

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging
-import sys
 import numpy as np
 
 from tf2onnx import utils
@@ -70,15 +69,15 @@ class GRUUnitRewriter(UnitRewriterBase):
         hidden_kernel = get_weights_from_const_node(match.get_op("hidden_kernel"))
         hidden_bias = get_weights_from_const_node(match.get_op("hidden_bias"))
         if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
-            log.error("rnn weights check failed, skip")
-            sys.exit(-1)
-        else:
-            log.debug("find needed weights")
-            res = {'gate_kernel': gate_kernel,
-                   "gate_bias": gate_bias,
-                   "hidden_kernel": hidden_kernel,
-                   "hidden_bias": hidden_bias}
-            return res
+            log.debug("rnn weights check failed, skip")
+            return None
+
+        log.debug("find needed weights")
+        res = {"gate_kernel": gate_kernel,
+               "gate_bias": gate_bias,
+               "hidden_kernel": hidden_kernel,
+               "hidden_bias": hidden_bias}
+        return res
 
     def find_inputs(self, rnn_scope_name, rnn_props, match, input_blacklist=None):
         concat_node = match.get_op("cell_inputs")

--- a/tf2onnx/rewriter/grublock_rewriter.py
+++ b/tf2onnx/rewriter/grublock_rewriter.py
@@ -57,8 +57,7 @@ class GRUBlockUnitRewriter(GRUUnitRewriter):
         hidden_kernel = get_weights_from_const_node(node.inputs[3].inputs[0])
         hidden_bias = get_weights_from_const_node(node.inputs[5].inputs[0])
         if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
-            log.error("rnn weights check failed, skip")
-            sys.exit(-1)
+            log.debug("rnn weights check failed, skip")
             return None
         log.debug("find needed weights")
         res = {"gate_kernel": gate_kernel,

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -74,7 +74,7 @@ class RnnProperties:
 
     def is_valid(self):
         if not self.input_node:
-            log.error("no input node found for current rnn, skip")
+            log.debug("no input node found for current rnn, skip")
             return False
         log.debug("input node with port id %s", self.input_id)
         return True
@@ -246,7 +246,7 @@ def get_weights_from_const_node(node):
         dtype = utils.ONNX_TO_NUMPY_DTYPE[temp.dtype]
         log.debug("found weights %s", temp.name)
     else:
-        log.error("weight node seems not to be Const, skip, node name is %s", temp.name)
+        log.debug("weight node seems not to be Const, skip, node name is %s", temp.name)
         return None
 
     return RnnWeight(node, val, dtype)

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -170,7 +170,7 @@ class UnitRewriterBase(object):
                 if not loop_cond_op:
                     loop_cond_op = n
                 else:
-                    log.error("only a LoopCond is expected, rnn scope name:%s", rnn_scope_name)
+                    log.debug("only a LoopCond is expected, rnn scope name:%s", rnn_scope_name)
                     return None
 
         if loop_cond_op is None:


### PR DESCRIPTION
…rse nodes

in a real model, if the author explicitly define a fw lstm, and a bw lstm, feed the input and reversed input respectively, then don't reverse the bw lstm ouput back. In this case, bilstm assumes that the reverse exists after bw lstm y output, so it replaced the wrong node. 

Here we will check the reverse node existence before doing bilstm rewriting. 