### PR TITLE
Move from the deprecated FastGFile to GFile

### DIFF
--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -88,7 +88,7 @@ def main():
         extra_opset = None
 
     graph_def = tf.GraphDef()
-    with tf.gfile.FastGFile(args.input, 'rb') as f:
+    with tf.gfile.GFile(args.input, 'rb') as f:
         graph_def.ParseFromString(f.read())
 
     # todo: consider to enable const folding by default?


### PR DESCRIPTION
tf.gfile.FastGFile is deprecated and will be removed in a future version.