### PR TITLE
fix few issues for real models

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -487,10 +487,31 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(mi, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
 
-    def test_sequeeze(self):
+    def test_sequeeze_no_axis_specified(self):
         x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2, 1))
         x = tf.placeholder(tf.float32, [2, 2, 1], name=_TFINPUT)
         x_ = tf.squeeze(x)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    def test_sequeeze_positive_axis(self):
+        x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2, 1))
+        x = tf.placeholder(tf.float32, [2, 2, 1], name=_TFINPUT)
+        x_ = tf.squeeze(x, [2])
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    def test_sequeeze_negative_axis(self):
+        x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2, 1))
+        x = tf.placeholder(tf.float32, [2, 2, 1], name=_TFINPUT)
+        x_ = tf.squeeze(x, [-1])
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    def test_sequeeze_mixed_axis(self):
+        x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((1, 2, 2, 1))
+        x = tf.placeholder(tf.float32, [1, 2, 2, 1], name=_TFINPUT)
+        x_ = tf.squeeze(x, [0, -1])
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 

--- a/tf2onnx/__init__.py
+++ b/tf2onnx/__init__.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-__all__ = ["utils", "graph_matcher", "graph", "tfonnx"]
+__all__ = ["utils", "graph_matcher", "graph", "tfonnx", "shape_inference"]
 
 from .version import version as __version__
-from tf2onnx import tfonnx, utils, graph, graph_matcher  # pylint: disable=wrong-import-order
+from tf2onnx import tfonnx, utils, graph, graph_matcher, shape_inference  # pylint: disable=wrong-import-order

--- a/tf2onnx/function/select.py
+++ b/tf2onnx/function/select.py
@@ -39,7 +39,7 @@ def select_op8(ctx, node, name, args):
                             shapes=[shape_node_output_shape], dtypes=[onnx_pb.TensorProto.INT64])
     nodes.append(shape_node)
 
-    # todo(pengwa), move those leveraging rewrite_incomplete_type_support_onnxruntime after shap inferencing
+    # todo(pengwa), move those leveraging rewrite_incomplete_type_support_onnxruntime after shape inferencing
     # bug is fixed.
     # workaround: onnxruntime does not support Split-2, add cases before and after.
     target_dtype = onnx_pb.TensorProto.FLOAT

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -216,6 +216,11 @@ class CustomRnnRewriter(LoopRewriterBase):
             input_ta.index_input_id = ta_read_node.input[1]
             input_ta.output_id = match.get_op("ta_read").output[0]
 
+            input_shape = self.g.get_shape(input_ta.data_input_id)
+            output_shape = self.g.get_shape(input_ta.output_id)
+            if output_shape is None and input_shape is not None:
+                self.g.set_shape(input_ta.output_id, input_shape[1:])
+
             context.input_tas.append(input_ta)
 
             log.debug("input ta %s - data input (%s) shape: %s, output (%s) shape: %s", ta_read_node.name,
@@ -534,7 +539,7 @@ class CustomRnnLateRewriter(object):
                 if shape is None:
                     shape = self.g.get_shape(init_input_id)
                     if i >= input_count - num_scan_inputs:
-                        loop_input_shape = list(shape)[2:] # delete [1, time,]
+                        loop_input_shape = list(shape)[2:]  # delete [1, time,]
                     else:
                         loop_input_shape = list(shape)
                 else:

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -1,0 +1,192 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+tf2onnx.shape_inference - shape inference function for tf2onnx
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import re
+import six
+import logging
+import numpy as np
+import tensorflow as tf
+from tf2onnx import utils
+from tensorflow.core.framework import types_pb2, tensor_pb2
+from google.protobuf import text_format
+from onnx import helper, onnx_pb, defs, numpy_helper
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("tf2onnx")
+
+
+def infer_shape_for_graph(g):
+    no_shape_updated = True
+    while no_shape_updated:
+        no_shape_updated = False
+        for o in g.get_nodes():
+            updated = infer_shape_for_node(g, o)
+            if updated:
+                no_shape_updated = True
+
+
+def infer_shape_for_node(g, node):
+    has_unknown_output_shape = False
+    for out in node.output:
+        out_dtype = g.get_shape(out)
+        if out_dtype is None:
+            has_unknown_output_shape = True
+            break
+
+    if not has_unknown_output_shape:
+        return False
+
+    # for those ops, we don't expect all input shapes available to infer output shapes.
+    ret = infer_output_shapes_with_partial_inputs(g, node)
+    if ret is not None:
+        return ret
+
+    # for ops, we need all input shapes ready to infer output shapes.
+    are_all_input_shape_ready = True
+    no_shape = []
+    for i in node.input:
+        if g.get_shape(i) is None:
+            are_all_input_shape_ready = False
+            no_shape.append(i)
+
+    if not are_all_input_shape_ready:
+        log.debug("node %s has inputs don't have shape specified, they are: %s", node.name, no_shape)
+        return False
+
+    if node.type in ["Cast", "Enter", "Floor", "ReverseSequence", "Sigmoid", "Tanh", "Identity"]:
+        return set_shape_from_input(g, node.input[0], node.output[0])
+    if node.type in ["Add", "GreaterEqual", "Mul", "RealDiv", "Sub"]:
+        return set_shape_from_inputs_broadcast(g, node.input, node.output[0])
+    elif node.type == "Placeholder":
+        # if placeholder shape is not found, try to get it from "shape" attribute.
+        shape_attr = node.get_attr("shape")
+        new_shape = None
+        if shape_attr.type == onnx_pb.TensorProto.INT32:
+            new_shape = shape_attr.ints
+        elif shape_attr.type == onnx_pb.TensorProto.FLOAT:
+            # for scalar placeholder, it's type is float
+            val = shape_attr.floats
+            if val:
+                raise ValueError("placeholder shape has floats value, and not scalar value")
+            else:
+                new_shape = ()
+
+        if new_shape is not None:
+            g.set_shape(node.output[0], new_shape)
+            log.debug("set placeholder node [%s] with new shape %s", node.output[0], new_shape)
+            return True
+    elif node.type == "RandomUniform":
+        shape_node = node.inputs[0]
+        if not shape_node or shape_node.type != "Shape":
+            return False
+        return set_shape_from_input(g, shape_node.input[0], node.output[0])
+
+    return False
+
+
+def infer_output_shapes_with_partial_inputs(g, node):
+    if node.type == "Merge":
+        s1 = g.get_shape(node.input[0])
+        s2 = g.get_shape(node.input[1])
+        new_shape = s1
+        if s1 is None:
+            new_shape = s2
+
+        if new_shape is not None:
+            g.set_shape(node.input[0], new_shape)
+            g.set_shape(node.input[1], new_shape)
+            g.set_shape(node.output[0], new_shape)
+            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            return True
+        return False
+    elif node.type == "Switch":
+        new_shape = g.get_shape(node.input[0])
+        if new_shape is not None:
+            g.set_shape(node.output[0], new_shape)
+            g.set_shape(node.output[1], new_shape)
+            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            log.debug("set [%s] with new shape %s", node.output[1], new_shape)
+            return True
+        return False
+    elif node.type == "Select":
+        new_shape = g.get_shape(node.input[1])
+        if new_shape is None:
+            new_shape = g.get_shape(node.input[2])
+        if new_shape is not None:
+            g.set_shape(node.output[0], new_shape)
+            g.set_shape(node.input[1], new_shape)
+            g.set_shape(node.input[2], new_shape)
+            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            return True
+        return False
+    return None
+
+
+def set_shape_from_input(g, input_id, output_id):
+    new_shape = g.get_shape(input_id)
+    if new_shape is not None:
+        g.set_shape(output_id, new_shape)
+        log.debug("set [%s] with new shape %s", output_id, new_shape)
+        return True
+    return False
+
+
+def set_shape_from_inputs_broadcast(g, input_ids, output_id):
+    s1 = g.get_shape(input_ids[0])
+    s2 = g.get_shape(input_ids[1])
+    new_shape = broadcast_shape_inference(s1, s2)
+    if new_shape is not None:
+        g.set_shape(output_id, new_shape)
+        log.debug("set [%s] with new shape %s", output_id, new_shape)
+        return True
+    return False
+
+
+def broadcast_shape_inference(shape_0, shape_1):
+    if shape_0 is None:
+        return shape_1
+    if shape_1 is None:
+        return shape_0
+
+    # two dimensions are compatible when they are equal, or one of them is 1
+    # compare from last dim
+    if len(shape_0) > len(shape_1):
+        tmp = shape_0
+        shape_0 = shape_1
+        shape_1 = tmp
+
+    new_shape = shape_1
+    l = len(shape_0)
+    if len(shape_1) == 0:
+        return shape_0
+
+    i = l - 1
+    while i >= 0:
+        if shape_0[i] == shape_1[i]:
+            # do nothing
+            pass
+        elif shape_0[i] == 1:
+            # do nothing
+            pass
+        elif shape_1[i] == 1:
+            new_shape[i] = shape_0[i]
+        # maybe one of them is -1, we can use the other one as real shape.
+        elif shape_0[i] == -1:
+            new_shape == shape_1[i]
+        elif shape_1[i] == -1:
+            new_shape == shape_0[i]
+        else:
+            log.warning("two shapes not possible to broadcast, %s, %s", shape_0, shape_1)
+            return None
+        i -= 1
+    return new_shape

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -8,8 +8,8 @@ tf2onnx.shape_inference - shape inference function for tf2onnx
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from onnx import onnx_pb
 import logging
+from onnx import onnx_pb
 
 
 # pylint: disable=logging-not-lazy,missing-docstring,consider-swap-variables

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -31,6 +31,7 @@ from tf2onnx.rewriter.rnn import rewrite_single_direction_gru
 from tf2onnx.rewriter.rnn import rewrite_single_direction_grublock
 from tf2onnx.rewriter.rnn import rewrite_single_direction_lstm, rewrite_bi_direction_lstm
 from tf2onnx.rewriter.rnn_utils import is_tensor_array_op
+from tf2onnx.shape_inference import infer_shape_for_graph, set_shape_from_inputs_broadcast
 from tf2onnx.utils import port_name
 
 logging.basicConfig(level=logging.INFO)
@@ -397,7 +398,7 @@ def square_op(ctx, node, name, args):
 
 def squeeze_op(ctx, node, name, args):
     # T output = Squeeze(T input, @list(int) squeeze_dims)
-    # T squeezed = Squeeze(T data, @AttrType.INTS axes)
+    # T squeezed = Squeeze(T data, @AttrType.INTS axes), axes are list of positive integers.
     axis = node.get_attr("axis")
     if not axis:
         axis = node.get_attr("squeeze_dims")
@@ -407,8 +408,11 @@ def squeeze_op(ctx, node, name, args):
         del node.attr["axis"]
 
     shape = ctx.get_shape(node.input[0])
+    utils.make_sure(shape is not None, "squeeze input shape cannot be None")
+    shape_len = len(shape)
     if axis and axis.ints:
         axis = axis.ints
+        axis = [a + shape_len if a < 0 else a for a in axis]
     else:
         axis = [i for i, j in enumerate(shape) if j == 1]
     node.set_attr("axes", axis)
@@ -1255,14 +1259,26 @@ def multinomial_op(ctx, node, name, args):
 def topk_op(ctx, node, name, args):
     # T values, int32 indices = TopKV2(T input, int32 k, @bool sorted=true, @realnumbertype T)
     # T values, I indices = TopK(T x, @int axis=-1, @int k). I: int64
-    k = node.inputs[1].get_tensor_value()
-    node.set_attr("k", k[0])
-    node.type = "TopK"
-    ctx.remove_input(node, node.input[1])
+    nodes = []
+    topk_node_name = node.name
+    topk_output1 = node.output[0]
+    topk_output2 = node.output[1]
 
-    # the second of TopK operator must be INT64 per ONNX requires
-    ctx.override_dtype(port_name(name, 1), onnx_pb.TensorProto.INT64)
-    return node
+    new_topk_name = utils.make_name(topk_node_name)
+    k = node.inputs[1].get_tensor_value()[0]
+    new_topk_node = Node(helper.make_node("TopK", [node.input[0]],
+                                          [topk_output1, utils.port_name(new_topk_name, 1)],
+                                          name=new_topk_name, k=k), ctx)
+    nodes.append(new_topk_node)
+
+    new_cast_name = utils.make_name(topk_node_name)
+    cast_to_int32 = Node(helper.make_node("Cast", [new_topk_node.output[1]],
+                                     [topk_output2],
+                                     name=new_cast_name,
+                                     to=onnx_pb.TensorProto.INT32,
+                                     ), ctx)
+    nodes.append(cast_to_int32)
+    return nodes
 
 
 def tile_op7(ctx, node, name, args):
@@ -2153,23 +2169,29 @@ def rewrite_logical_compare_with_equal(g, ops):
                                                   to=onnx_pb.TensorProto.FLOAT), g)
                 greater_input_ids.append(new_output)
                 g.set_dtype(cast_node.output[0], onnx_pb.TensorProto.FLOAT)
-                g.copy_shape(ge_op.input[0], cast_node.output[0])
+                g.copy_shape(input_id, cast_node.output[0])
                 nodes_to_append.append(cast_node)
 
         op_name = utils.make_name("Greater")
         out_name = port_name(op_name)
         g_node = Node(helper.make_node("Greater", greater_input_ids, [out_name], name=op_name), g)
+        g.set_dtype(out_name, onnx_pb.TensorProto.BOOL)
+        set_shape_from_inputs_broadcast(g, greater_input_ids, out_name)
+        new_shape = g.get_shape(out_name)
         nodes_to_append.append(g_node)
 
         op_name = utils.make_name("Equal")
         out_name = port_name(op_name)
         e_node = Node(helper.make_node("Equal", ge_op.input, [out_name], name=op_name), g)
+        g.set_dtype(out_name, onnx_pb.TensorProto.BOOL)
+        g.set_shape(out_name, new_shape)
         nodes_to_append.append(e_node)
 
         ge_op.type = "LogicalOr"
         ge_op.input[0] = g_node.output[0]
         ge_op.input[1] = e_node.output[0]
-
+        g.set_dtype(ge_op.output[0], onnx_pb.TensorProto.BOOL)
+        g.set_shape(ge_op.output[0], new_shape)
         ops.extend(nodes_to_append)
     return ops
 
@@ -2375,6 +2397,9 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
     onnx_nodes, op_cnt, attr_cnt, output_shapes, dtypes = tensorflow_to_onnx(tf_graph, shape_override)
 
     g = Graph(onnx_nodes, output_shapes, dtypes, target, opset, extra_opset, output_names)
+
+    infer_shape_for_graph(g)
+
     if inputs_as_nchw:
         transpose_inputs(g, inputs_as_nchw)
 

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1259,6 +1259,8 @@ def multinomial_op(ctx, node, name, args):
 def topk_op(ctx, node, name, args):
     # T values, int32 indices = TopKV2(T input, int32 k, @bool sorted=true, @realnumbertype T)
     # T values, I indices = TopK(T x, @int axis=-1, @int k). I: int64
+    # todo (pengwa): need change get_node_by_name to better handle cases where node output name is
+    # not strictly aligned with node name.
     nodes = []
     topk_node_name = node.name
     topk_output1 = node.output[0]
@@ -1273,10 +1275,8 @@ def topk_op(ctx, node, name, args):
 
     new_cast_name = utils.make_name(topk_node_name)
     cast_to_int32 = Node(helper.make_node("Cast", [new_topk_node.output[1]],
-                                     [topk_output2],
-                                     name=new_cast_name,
-                                     to=onnx_pb.TensorProto.INT32,
-                                     ), ctx)
+                                          [topk_output2], name=new_cast_name, to=onnx_pb.TensorProto.INT32),
+                         ctx)
     nodes.append(cast_to_int32)
     return nodes
 


### PR DESCRIPTION
1. squeeze axis must be positive in onnx. Fix conversion issue for squeeze. add ut cases.
2. tf graph won't give us all the output shapes even on newer version tf, though it's very easy to infer the shape of missing ones. so add shape_inference.py doing this before all conversion logic (even the rewriter, because rewriter also need the shape infos).
3. other issue like shape/dtype not set, causing later conversion logic failed.
4. refine topk_op using two separate nodes represent 2 results. This require additional change on get_node_by_name, which would be done later.