### PR TITLE
add get_node_by_output to differentiate get_node_by_name

### DIFF
--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -104,7 +104,7 @@ def process_bigru(g, bi_grus):
             n for n in old_x_consumers if n.type == "GRU"]
         if not old_x_has_gru_as_consumer:
             log.debug("plan to remove useless reverse op in bw")
-            reverse_node = g.get_node_by_name(gru_bw_old_x)
+            reverse_node = g.get_node_by_output(gru_bw_old_x)
 
             if reverse_node.type == "Transpose":
                 reverse_node = reverse_node.inputs[0]

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -92,7 +92,7 @@ def process_bilstm(g, bi_lstms):
         old_x_has_lstm_as_consumer = [n for n in old_x_consumers if n.type == "LSTM"]
         if not old_x_has_lstm_as_consumer:
             log.debug("plan to remove useless reverse op in bw")
-            reverse_node = g.get_node_by_name(lstm_bw_old_x)
+            reverse_node = g.get_node_by_output(lstm_bw_old_x)
 
             if reverse_node.type == "Transpose":
                 reverse_node = reverse_node.inputs[0]
@@ -143,7 +143,7 @@ def slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm, lstm_
 
 
 def check_const(g, input_id):
-    node = g.get_node_by_name(input_id)
+    node = g.get_node_by_output(input_id)
     if node and node.is_const():
         return (True, node.get_tensor_value())
     if g.is_initializer(input_id):

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -104,7 +104,7 @@ class CustomRnnRewriter(LoopRewriterBase):
         found_time = False
         is_rnn_out_ta = True
         for enter_name, val in context.loop_variables.items():
-            enter_input_node = self.g.get_node_by_name(val.enter_input_id)
+            enter_input_node = self.g.get_node_by_output(val.enter_input_id)
             if val.is_tensor_array:
                 ta_name = enter_input_node.get_attr("tensor_array_name").s.decode("utf-8")
                 if not ta_name.startswith(ta_array_name_prefix):
@@ -233,7 +233,7 @@ class CustomRnnRewriter(LoopRewriterBase):
         all_vars += [val for _, val in context.other_loop_vars.items()]
         for val in all_vars:
             # remove the node to cut off a starting node of the cell (e.g. loop body).
-            nodes_to_remove.append(self.g.get_node_by_name(val.switch_true_identity_output_id))
+            nodes_to_remove.append(self.g.get_node_by_output(val.switch_true_identity_output_id))
 
             # connect NextIteration to an invalid node, to cut off a ending node of the cell.
             next_iter_nodes = [n for n in self.g.get_nodes() if n.type == "NextIteration"]
@@ -241,7 +241,7 @@ class CustomRnnRewriter(LoopRewriterBase):
 
         for input_ta in context.input_tas:
             # remove the node to cut off connection between scan_input and the cell.
-            nodes_to_remove.append(self.g.get_node_by_name(input_ta.output_id))
+            nodes_to_remove.append(self.g.get_node_by_output(input_ta.output_id))
 
         for output_ta in context.output_tas:
             # remove the node to cut off connection between scan_output and the cell.
@@ -356,7 +356,7 @@ class CustomRnnRewriter(LoopRewriterBase):
             # connect Enter's output to Enter's input
             self.g.replace_all_inputs(self.g.get_nodes(), enter_node.output[0], enter_node.input[0])
 
-            nodes = self.g._extract_sub_graph_nodes(self.g.get_node_by_name(enter_node.input[0]))
+            nodes = self.g._extract_sub_graph_nodes(self.g.get_node_by_output(enter_node.input[0]))
 
             other_enter_input_ids.append(enter_node.input[0])
 

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -121,7 +121,7 @@ class GRUUnitRewriter(UnitRewriterBase):
     def _output_switch_check(self, enter_target_node_input_id, identity_consumers, match):
         ta_write_nodes = [c for c in identity_consumers if is_tensor_array_write_op(c)]
         if len(ta_write_nodes) == 1:
-            enter_target_node = self.g.get_node_by_name(enter_target_node_input_id)
+            enter_target_node = self.g.get_node_by_output(enter_target_node_input_id)
             if is_tensor_array_op(enter_target_node):
                 log.debug("found output switch node")
                 return enter_target_node_input_id
@@ -188,7 +188,7 @@ class GRUUnitRewriter(UnitRewriterBase):
     def get_rnn_input_blacklist(self, rnn_weights, rnn_props):
         var_init_nodes = []
         for _, init_input_id in rnn_props.var_initializers.items():
-            init_node = self.g.get_node_by_name(init_input_id)
+            init_node = self.g.get_node_by_output(init_input_id)
             var_init_nodes.append(init_node)
         blacklist_inputs = []
         blacklist_inputs.extend(var_init_nodes)
@@ -266,7 +266,7 @@ class GRUUnitRewriter(UnitRewriterBase):
         if fill_ch_init_node:
             return fill_ch_init_node.output[0]
 
-        node = self.g.get_node_by_name(initializer_input_id)
+        node = self.g.get_node_by_output(initializer_input_id)
         if node.is_const():
             val = node.get_tensor_value()
             initial_name = utils.make_name("Const")

--- a/tf2onnx/rewriter/loop_rewriter_base.py
+++ b/tf2onnx/rewriter/loop_rewriter_base.py
@@ -135,7 +135,7 @@ class LoopRewriterBase:
             raise ValueError("unexpected number of switch false consumers")
 
         is_ta = False
-        if is_tensor_array_op(self.g.get_node_by_name(target_node_input_id)):
+        if is_tensor_array_op(self.g.get_node_by_output(target_node_input_id)):
             is_ta = True
 
         loop_var = LoopVariable(enter_node.name, target_node_input_id, last_iteration_output_id,
@@ -146,7 +146,7 @@ class LoopRewriterBase:
 
     def _tune_shape_for_loop_ta_var(self, loop_var):
         if loop_var.is_tensor_array:
-            ta_write_node = self.g.get_node_by_name(loop_var.next_iteration_input_id)
+            ta_write_node = self.g.get_node_by_output(loop_var.next_iteration_input_id)
             if not is_tensor_array_write_op(ta_write_node):
                 raise ValueError("ta var nextiteration is not following ta write op")
 
@@ -201,7 +201,7 @@ class LoopRewriterBase:
         log.debug("output ids %s ", output_ids)
         nodes = []
         q = deque()
-        output_nodes = [g.get_node_by_name(output_id) for output_id in output_ids]
+        output_nodes = [g.get_node_by_output(output_id) for output_id in output_ids]
         handled_nodes = []
         q.extend(output_nodes)
         nodes.extend(output_nodes)
@@ -217,7 +217,7 @@ class LoopRewriterBase:
 
             n_inputs = set(n.input)
             for i in n_inputs:
-                input_node = g.get_node_by_name(i)
+                input_node = g.get_node_by_output(i)
                 if i in input_ids:
                     log.debug("terminate the input search at %s", i)
                 elif not input_node:
@@ -240,7 +240,7 @@ class LoopRewriterBase:
             implicit_inputs = n.get_implicit_inputs(require_input_in_cur_graph=True)
             n_inputs = set(implicit_inputs)
             for i in n_inputs:
-                input_node = g.get_node_by_name(i)
+                input_node = g.get_node_by_output(i)
                 if i in input_ids:
                     log.debug("terminate the input search at %s", i)
                 elif not input_node:

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -129,7 +129,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
     def _output_switch_check(self, enter_target_node_input_id, identity_consumers, match):
         ta_write_nodes = [c for c in identity_consumers if is_tensor_array_write_op(c)]
         if len(ta_write_nodes) == 1:
-            enter_target_node = self.g.get_node_by_name(enter_target_node_input_id)
+            enter_target_node = self.g.get_node_by_output(enter_target_node_input_id)
             if is_tensor_array_op(enter_target_node):
                 log.debug("found output switch node")
                 return enter_target_node_input_id
@@ -239,7 +239,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
         if fill_ch_init_node:
             return fill_ch_init_node.output[0]
 
-        node = self.g.get_node_by_name(initializer_input_id)
+        node = self.g.get_node_by_output(initializer_input_id)
         if node.is_const():
             val = node.get_tensor_value()
             initial_name = utils.make_name("Const")

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -235,7 +235,7 @@ class UnitRewriterBase(object):
     def get_rnn_input_blacklist(self, rnn_weights, rnn_props):
         var_init_nodes = []
         for _, init_input_id in rnn_props.var_initializers.items():
-            init_node = self.g.get_node_by_name(init_input_id)
+            init_node = self.g.get_node_by_output(init_input_id)
             var_init_nodes.append(init_node)
 
         # weight/bias inputs, and c/h initializers are dynamic_rnn/LSTMCell's parameters.
@@ -414,7 +414,7 @@ class UnitRewriterBase(object):
         log.debug(level_1 + " >> " + level_2)
 
     def _workaround_fill_ch_init_node(self, initializer_input_id, rnn_props):
-        node = self.g.get_node_by_name(initializer_input_id)
+        node = self.g.get_node_by_output(initializer_input_id)
         if node.type != "Fill":
             return None
 

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1259,8 +1259,6 @@ def multinomial_op(ctx, node, name, args):
 def topk_op(ctx, node, name, args):
     # T values, int32 indices = TopKV2(T input, int32 k, @bool sorted=true, @realnumbertype T)
     # T values, I indices = TopK(T x, @int axis=-1, @int k). I: int64
-    # todo (pengwa): need change get_node_by_name to better handle cases where node output name is
-    # not strictly aligned with node name.
     nodes = []
     topk_node_name = node.name
     topk_output1 = node.output[0]


### PR DESCRIPTION
for example a node has name A
while in most case, its output would be called A:0, A;1, ...

while sometimes, we need update A to have an output called B:0. So get_node_by_name won't work correctly in this case when we pass B:0 to it. 