### PR TITLE
body graph inputs need to be in order, but {} in python3.5 and python…

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -317,7 +317,9 @@ class Graph(object):
         self._nodes_by_name = {}
         self._output_to_node_name = {}
         self.shapes = {}
-        self._model_inputs = {}
+
+        # use explicit ordered dict because model input for body graph is sensitive to input order.
+        self._model_inputs = collections.OrderedDict()
         self._target = set(target)
         self._dtypes = dtypes
 


### PR DESCRIPTION
body graph inputs need to be in order, but {} in python3.5 and python…3.6+ have different behavior.

since python3.6, {} is guaranteed the order of insertion. in older version, the order is not guaranteed. 