### PR TITLE
Infer shape from outputs

### DIFF
--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -29,6 +29,26 @@ def infer_shape_for_graph(g):
                 no_shape_updated = True
 
 
+def infer_shape_from_outputs(g, node):
+    # if all inputs have shape, no more effort needed
+    are_all_input_shape_ready = True
+    for i in node.input:
+        if g.get_shape(i) is None:
+            are_all_input_shape_ready = False
+    if are_all_input_shape_ready:
+        return False
+    if node.type == "Select":
+        new_shape = g.get_shape(node.input[1])
+        if new_shape is None:
+            new_shape = g.get_shape(node.input[2])
+        if new_shape is not None:
+            g.set_shape(node.input[1], new_shape)
+            g.set_shape(node.input[2], new_shape)
+            log.debug("set [%s, %s] with new shape %s", node.input[1], node.input[2], new_shape)
+            return True
+    return False
+
+
 def infer_shape_for_node(g, node):
     has_unknown_output_shape = False
     for out in node.output:
@@ -38,7 +58,7 @@ def infer_shape_for_node(g, node):
             break
 
     if not has_unknown_output_shape:
-        return False
+        return infer_shape_from_outputs(g, node)
 
     # for those ops, we don't expect all input shapes available to infer output shapes.
     ret = infer_output_shapes_with_partial_inputs(g, node)


### PR DESCRIPTION
When outputs shape of `Select` is available, we can infer inputs shape from it. 