### PR TITLE
Support `GatherNd` op using two-layers `Loop` and `Gather`

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -96,7 +96,7 @@ def support_op_conversion_since(opset, op):
 
 
 def support_op_with_target(target, op):
-    return [TARGET != target, op + " conversion is only supported with target " + str(target)]
+    return [target not in TARGET, op + " conversion is only supported with target " + str(target)]
 
 
 def onnxruntime_check(op):
@@ -512,11 +512,28 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_ = tf.gather_nd(x, tf.constant(indices))
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+
+        x_val = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float32)
+        indices = np.array([[0], [2], [4], [7]], dtype=np.int32)
+        x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
+        x_ = tf.gather_nd(x, tf.constant(indices))
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
     @unittest.skipIf(*support_op_with_target('rs6', 'GatherNd'))
     def test_gathernd_less_index(self):
         x_val = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
         indices = np.array([[[0], [1]], [[2], [0]]], dtype=np.int32)
+        x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
+        x_ = tf.gather_nd(x, tf.constant(indices))
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+
+        # shape: 2*2*2
+        x_val = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.float32)
+        indices = np.array([[[0, 0], [0, 1]], [[1, 0], [1, 1]]], dtype=np.int32)
         x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
         x_ = tf.gather_nd(x, tf.constant(indices))
         _ = tf.identity(x_, name=_TFOUTPUT)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -23,6 +23,7 @@ from backend_test_base import Tf2OnnxBackendTestBase
 # to change the behavior of annotation. If need, pick the backend here.
 OPSET = Tf2OnnxBackendTestBase.OPSET
 BACKEND = Tf2OnnxBackendTestBase.BACKEND
+TARGET = Tf2OnnxBackendTestBase.TARGET
 
 NCHW_TO_NHWC = [0, 2, 3, 1]
 NHWC_TO_NCHW = [0, 3, 1, 2]
@@ -92,6 +93,10 @@ def get_conv_getdata(kind=1):
 
 def support_op_conversion_since(opset, op):
     return [OPSET < opset, op + " conversion is covered since opset " + str(opset)]
+
+
+def support_op_with_target(target, op):
+    return [TARGET != target, op + " conversion is only supported with target " + str(target)]
 
 
 def onnxruntime_check(op):
@@ -496,6 +501,24 @@ class BackendTests(Tf2OnnxBackendTestBase):
         idx_flattened = np.array([i * x_val.shape[1] + idx for i in range(0, x_val.shape[0])])
         x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
         x_ = tf.gather(tf.reshape(x, [-1]), tf.constant(idx_flattened))
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    @unittest.skipIf(*support_op_with_target('rs6', 'GatherNd'))
+    def test_gathernd(self):
+        x_val = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
+        indices = np.array([[[0, 1], [1, 1]], [[1, 2], [0, 2]]], dtype=np.int32)
+        x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
+        x_ = tf.gather_nd(x, tf.constant(indices))
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    @unittest.skipIf(*support_op_with_target('rs6', 'GatherNd'))
+    def test_gathernd_less_index(self):
+        x_val = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
+        indices = np.array([[[0], [1]], [[2], [0]]], dtype=np.int32)
+        x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
+        x_ = tf.gather_nd(x, tf.constant(indices))
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 

--- a/tf2onnx/function/__init__.py
+++ b/tf2onnx/function/__init__.py
@@ -6,4 +6,4 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ["select"]
+__all__ = ["select", "gathernd"]

--- a/tf2onnx/function/__init__.py
+++ b/tf2onnx/function/__init__.py
@@ -6,4 +6,4 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ["select", "gathernd"]
+__all__ = ["gathernd", "select"]

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -4,16 +4,18 @@
 """
 tf2onnx.tf2onnx - gathernd op conversion
 """
-import sys
 import numpy as np
 from onnx import helper, onnx_pb
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
 from tf2onnx.utils import make_onnx_inputs_outputs
 
-
 # pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
+
+INT64_MAX = np.iinfo(np.int64)
+
 def make_gathernd_inner_loop(ctx, params, index, dtype):
+    """create the inner loop for GatherNd."""
     # gather_cur = params
     # for (int i=0; i<size(index); i++)
     #   gather_res = gather(gather_cur, index[i])
@@ -62,7 +64,7 @@ def gathernd_op(ctx, node, name, args):
                                  dtypes=[TensorProto.INT64])
     inner_shape = ctx.make_node("Slice",
                                 [indices_shape.output[0]],
-                                attr={"axes": [0], "ends": [sys.maxsize], "starts": [-1]},
+                                attr={"axes": [0], "ends": [INT64_MAX], "starts": [-1]},
                                 dtypes=[TensorProto.INT64])
     outter_shape_sum = ctx.make_node("ReduceSum",
                                      [outter_shape.output[0]],
@@ -116,7 +118,7 @@ def gathernd_op(ctx, node, name, args):
                                       dtypes=[TensorProto.INT64])
     output_inner_shape = ctx.make_node("Slice",
                                        [inner_loop_shape_.output[0]],
-                                       attr={"axes": [0], "ends": [sys.maxsize], "starts": [1]},
+                                       attr={"axes": [0], "ends": [INT64_MAX], "starts": [1]},
                                        dtypes=[TensorProto.INT64])
     output_shape_ = ctx.make_node("Concat",
                                   [outter_shape.output[0], output_inner_shape.output[0]],

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -1,0 +1,127 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+tf2onnx.tf2onnx - gathernd op conversion
+"""
+import sys
+import numpy as np
+from onnx import helper, onnx_pb
+from onnx.onnx_pb import TensorProto
+from tf2onnx import utils
+
+
+# pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
+def make_gathernd_inner_loop(ctx, params, index, dtype):
+    # gather_cur = params
+    # for (int i=0; i<size(index); i++)
+    #   gather_res = gather(gather_cur, index[i])
+    nodes = []
+    trip_node = ctx.make_node("Size", [index.output[0]])
+    nodes.append(trip_node.op)
+    cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
+    body_inputs = [helper.make_tensor_value_info("inner_i", onnx_pb.TensorProto.INT64, []),
+                   helper.make_tensor_value_info("inner_cond", onnx_pb.TensorProto.BOOL, []),
+                   helper.make_tensor_value_info("gathernd_cur", dtype, [])]
+    body_outputs = [helper.make_tensor_value_info("inner_cond_out", onnx_pb.TensorProto.BOOL, [],),
+                    helper.make_tensor_value_info("inner_res", dtype, [])]
+    body_nodes = []
+    index_i = ctx.make_node("Gather", [index.output[0], "inner_i"], attr={"axis": 0})
+    gather = ctx.make_node("Gather", ["gathernd_cur", index_i.output[0]], attr={"axis": 0})
+    squeeze = ctx.make_node("Squeeze", [gather.output[0]], attr={"axes": [0]}, outputs=["inner_res"])
+    body_nodes.extend([index_i.op, gather.op, squeeze.op])
+    body_nodes.append(utils.make_onnx_identity("inner_cond", "inner_cond_out"))
+    body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_inner_body"), body_inputs, body_outputs)
+    inner_loop = ctx.make_node("Loop", [trip_node.output[0],
+                                        cond_const.output[0],
+                                        params],
+                               attr={"body": body_graph})
+    nodes.append(inner_loop.op)
+    return nodes, inner_loop
+
+def gathernd_op(ctx, node, name, args):
+    """GatherNd op."""
+    # T output = GatherNd(T Input, INT32/INT64 indices)
+    nodes = []
+    params = node.input[0]
+    indices = node.input[1]
+    # same as the attr Tparams
+    node_dtype = ctx.get_dtype(params)
+    utils.make_sure(node_dtype, "Dtype of {} is None".format(indices))
+    # reshape indices into [sum(indices[:-1]), indices[-1]]
+    indices_shape = ctx.make_node("Shape", [indices], dtypes=[TensorProto.INT64])
+    outter_shape = ctx.make_node("Slice",
+                                 [indices_shape.output[0]],
+                                 attr={"axes": [0], "ends": [-1], "starts": [0]},
+                                 dtypes=[TensorProto.INT64])
+    inner_shape = ctx.make_node("Slice",
+                                [indices_shape.output[0]],
+                                attr={"axes": [0], "ends": [sys.maxsize], "starts": [-1]},
+                                dtypes=[TensorProto.INT64])
+    outter_shape_sum = ctx.make_node("ReduceSum",
+                                     [outter_shape.output[0]],
+                                     attr={"axes": [0], "keepdims": 1},
+                                     dtypes=[TensorProto.INT64])
+    flatten_shape = ctx.make_node("Concat",
+                                  [outter_shape_sum.output[0], inner_shape.output[0]],
+                                  attr={"axis": 0},
+                                  dtypes=[TensorProto.INT64])
+    flatten_indices = ctx.make_node("Reshape", [indices, flatten_shape.output[0]])
+    nodes.extend([indices_shape, outter_shape, inner_shape, outter_shape_sum, flatten_shape, flatten_indices])
+    # outter loop for each index
+    # for (int i=0; i<outter_shape_sum; i++) inner_loop(params, flatten_indices[i])
+    cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
+    dummy_const = ctx.make_const(utils.make_name("dummy"), np.ones((), dtype=np.int64))
+    body_inputs = [helper.make_tensor_value_info("i", onnx_pb.TensorProto.INT64, []),
+                   helper.make_tensor_value_info("cond", onnx_pb.TensorProto.BOOL, []),
+                   helper.make_tensor_value_info("params", node_dtype, [])]
+    body_outputs = [helper.make_tensor_value_info("cond_out", onnx_pb.TensorProto.BOOL, [],),
+                    helper.make_tensor_value_info("params_out", node_dtype, []),
+                    helper.make_tensor_value_info("result", node_dtype, [])]
+    body_nodes = []
+    index = ctx.make_node("Gather", [flatten_indices.output[0], "i"], attr={"axis": 0})
+    index_squeeze = ctx.make_node("Squeeze", [index.output[0]], attr={"axes": [0]})
+    # inner loop to gather result
+    inner_loop_nodes, inner_loop = make_gathernd_inner_loop(ctx, "params", index_squeeze, node_dtype)
+    body_nodes.extend([index.op, index_squeeze.op])
+    body_nodes.extend(inner_loop_nodes)
+    body_nodes.append(utils.make_onnx_identity("cond", "cond_out"))
+    body_nodes.append(utils.make_onnx_identity("params", "params_out"))
+    body_nodes.append(utils.make_onnx_identity(inner_loop.output[0], "result"))
+    body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_body"), body_inputs, body_outputs)
+    gathernd_loop = ctx.make_node("Loop",
+                                  [outter_shape_sum.output[0], cond_const.output[0], params],
+                                  output_count=2,
+                                  attr={"body": body_graph})
+    nodes.append(gathernd_loop)
+    # reshape to target shape
+    # output shape of gathernd: indices.shape[:-1] + gathernd_output.shape[1:]
+    inner_loop_shape = ctx.make_node("Shape", [gathernd_loop.output[1]], dtypes=[TensorProto.INT64])
+    # workaround in case gathernd_loop is 1-dimensional
+    one_const = ctx.make_const(utils.make_name("one"), np.array([1], dtype=np.int64))
+    inner_loop_shape_ = ctx.make_node("Concat",
+                                      [inner_loop_shape.output[0], one_const.output[0]],
+                                      attr={"axis": 0},
+                                      dtypes=[TensorProto.INT64])
+    output_inner_shape = ctx.make_node("Slice",
+                                       [inner_loop_shape_.output[0]],
+                                       attr={"axes": [0], "ends": [sys.maxsize], "starts": [1]},
+                                       dtypes=[TensorProto.INT64])
+    output_shape_ = ctx.make_node("Concat",
+                                  [outter_shape.output[0], output_inner_shape.output[0]],
+                                  attr={"axis": 0},
+                                  dtypes=[TensorProto.INT64])
+    output_shape = ctx.make_node("Slice",
+                                 [output_shape_.output[0]],
+                                 attr={"axes": [0], "ends": [-1], "starts": [0]},
+                                 dtypes=[TensorProto.INT64])
+    output_reshape = ctx.make_node("Reshape",
+                                   [gathernd_loop.output[1], output_shape.output[0]],
+                                   outputs=[node.output[0]])
+    nodes.extend([inner_loop_shape,
+                  inner_loop_shape_,
+                  output_inner_shape,
+                  output_shape_,
+                  output_shape,
+                  output_reshape])
+    return nodes

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -22,6 +22,7 @@ from tensorflow.tools.graph_transforms import TransformGraph
 import tf2onnx
 from tf2onnx import utils
 from tf2onnx.function.select import select_op8
+from tf2onnx.function.gathernd import gathernd_op
 from tf2onnx.graph import Node, Graph
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.random_uniform import rewrite_random_uniform, rewrite_random_uniform_fold_const
@@ -1745,6 +1746,7 @@ def sparse_softmax_cross_entropy_with_logits_op(ctx, node, name, args):
 
     return [onehot, log_softmax, mul1, reduce_sum, mul2, res]
 
+
 # map tensorflow ops to onnx ops. The format below is
 # "TFOP": func_to_map, ["OnnxOp", ...]
 #
@@ -1776,6 +1778,7 @@ _OPSET_4 = {
     "Flatten": (direct_op, []),
     "Gather": (direct_op, ["Gather"]),
     "GatherV2": (gatherv2_op, ["Gather"]),
+    "GatherNd": (gathernd_op, ["GatherNd"]),
     "Greater": (broadcast_op, []),
     "Identity": (identity_op, ["Identity"]),
     "Less": (broadcast_op, []),
@@ -2271,7 +2274,7 @@ def rewrite_incomplete_type_support_rs5(g, ops):
 
 
 def rewrite_incomplete_type_support_rs6(g, ops):
-    return rewrite_incomplete_type_support(g, ops, ["Slice", "Split", "Tile", "Transpose"])
+    return rewrite_incomplete_type_support(g, ops, ["ReduceSum", "Slice", "Split", "Tile", "Transpose"])
 
 
 def tensorflow_onnx_mapping(g, continue_on_error, custom_op_handlers):


### PR DESCRIPTION
- Support `GatherNd` op using two-layers `Loop` and `Gather`
- Disable `GatherNd` tests unless with the target "rs6"