### PR TITLE
Support sparse_softmax_cross_entropy_with_logits op with large class

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1410,6 +1410,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
         self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val})
 
+    @unittest.skipIf(*support_op_with_target('rs6', 'SparseSoftmaxCrossEntropyWithLogits'))
     def test_sparse_softmax_cross_entropy_with_logits_large_class(self):
         num_class = 30000
         label_val = np.array([3374, 2127, 10002, 48]).astype(np.int32)
@@ -1418,8 +1419,8 @@ class BackendTests(Tf2OnnxBackendTestBase):
         label = tf.placeholder(tf.int32, shape=[None], name=_TFINPUT)
         logits = tf.placeholder(tf.float32, shape=[None, num_class], name=_TFINPUT1)
 
-        res1 = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=label, logits=logits)
-        _ = tf.identity(res1, name=_TFOUTPUT)
+        res = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=label, logits=logits)
+        _ = tf.identity(res, name=_TFOUTPUT)
 
         self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val})
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1410,6 +1410,19 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
         self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val})
 
+    def test_sparse_softmax_cross_entropy_with_logits_large_class(self):
+        num_class = 30000
+        label_val = np.array([3374, 2127, 10002, 48]).astype(np.int32)
+        logits_val = np.random.random((len(label_val), num_class)).astype(np.float32)
+
+        label = tf.placeholder(tf.int32, shape=[None], name=_TFINPUT)
+        logits = tf.placeholder(tf.float32, shape=[None, num_class], name=_TFINPUT1)
+
+        res1 = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=label, logits=logits)
+        _ = tf.identity(res1, name=_TFOUTPUT)
+
+        self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val})
+
 
 if __name__ == '__main__':
     Tf2OnnxBackendTestBase.trigger(BackendTests)

--- a/tf2onnx/function/__init__.py
+++ b/tf2onnx/function/__init__.py
@@ -6,4 +6,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ["gathernd", "select"]
+from .gathernd import gathernd_op
+from .range import range_op7
+from .select import select_op8
+from .sparse_softmax_cross_entropy_with_logits import sparse_softmax_cross_entropy_with_logits_op
+
+__all__ = ["gathernd_op", "range_op7", "select_op8", "sparse_softmax_cross_entropy_with_logits_op"]

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -38,7 +38,7 @@ def make_gathernd_inner_loop(ctx, params, index, dtype):
     gather = ctx.make_node("Gather", [cur_name, index_i.output[0]], attr={"axis": 0})
     squeeze = ctx.make_node("Squeeze", [gather.output[0]], attr={"axes": [0]}, outputs=[result_name])
     body_nodes.extend([index_i.op, gather.op, squeeze.op,
-                       utils.make_onnx_identity(cond_name, cond_out_name)])
+                       utils.make_onnx_identity(cond_name, cond_out_name)]
     body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_inner_body"), body_inputs, body_outputs)
     inner_loop = ctx.make_node("Loop", [trip_node.output[0],
                                         cond_const.output[0],

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -5,16 +5,16 @@
 tf2onnx.tf2onnx - gathernd op conversion
 """
 import numpy as np
-from onnx import helper, onnx_pb
+from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
 from tf2onnx.utils import make_onnx_inputs_outputs
 
 # pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
 
-INT64_MAX = np.iinfo(np.int64)
+INT64_MAX = np.iinfo(np.int64).max
 
-def make_gathernd_inner_loop(ctx, params, index, dtype):
+def make_gathernd_inner_loop(ctx, params, index, name, dtype):
     """create the inner loop for GatherNd."""
     # gather_cur = params
     # for (int i=0; i<size(index); i++)
@@ -28,34 +28,31 @@ def make_gathernd_inner_loop(ctx, params, index, dtype):
     cond_out_name = utils.make_name("cond_out")
     cur_name = utils.make_name("gather_cur")
     result_name = utils.make_name("res")
-    body_inputs = [make_onnx_inputs_outputs(trip_name, onnx_pb.TensorProto.INT64, []),
-                   make_onnx_inputs_outputs(cond_name, onnx_pb.TensorProto.BOOL, []),
+    body_inputs = [make_onnx_inputs_outputs(trip_name, TensorProto.INT64, []),
+                   make_onnx_inputs_outputs(cond_name, TensorProto.BOOL, []),
                    make_onnx_inputs_outputs(cur_name, dtype, [])]
-    body_outputs = [make_onnx_inputs_outputs(cond_out_name, onnx_pb.TensorProto.BOOL, [],),
+    body_outputs = [make_onnx_inputs_outputs(cond_out_name, TensorProto.BOOL, [],),
                     make_onnx_inputs_outputs(result_name, dtype, [])]
     body_nodes = []
     index_i = ctx.make_node("Gather", [index.output[0], trip_name], attr={"axis": 0})
     gather = ctx.make_node("Gather", [cur_name, index_i.output[0]], attr={"axis": 0})
     squeeze = ctx.make_node("Squeeze", [gather.output[0]], attr={"axes": [0]}, outputs=[result_name])
     body_nodes.extend([index_i.op, gather.op, squeeze.op,
-                       utils.make_onnx_identity(cond_name, cond_out_name)]
+                       utils.make_onnx_identity(cond_name, cond_out_name)])
     body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_inner_body"), body_inputs, body_outputs)
     inner_loop = ctx.make_node("Loop", [trip_node.output[0],
                                         cond_const.output[0],
                                         params],
+                               name=name,
                                attr={"body": body_graph})
     nodes.append(inner_loop.op)
     return nodes, inner_loop
 
-def gathernd_op(ctx, node, name, args):
-    """GatherNd op."""
-    # T output = GatherNd(T Input, INT32/INT64 indices)
+
+def make_gathernd_subgraph(ctx, params, indices, output, name, t_params):
+    """make GatherNd op."""
+    # Tparams output = GatherNd(Tparams params, Tidx indices)
     nodes = []
-    params = node.input[0]
-    indices = node.input[1]
-    # same as the attr Tparams
-    node_dtype = ctx.get_dtype(params)
-    utils.make_sure(node_dtype, "Dtype of {} is None".format(indices))
     # reshape indices into [sum(indices[:-1]), indices[-1]]
     indices_shape = ctx.make_node("Shape", [indices], dtypes=[TensorProto.INT64])
     outter_shape = ctx.make_node("Slice",
@@ -86,17 +83,21 @@ def gathernd_op(ctx, node, name, args):
     dummy_name = utils.make_name("dummy")
     dummy_out_name = utils.make_name("dummy_out")
     result_name = utils.make_name("res")
-    body_inputs = [make_onnx_inputs_outputs(trip_name, onnx_pb.TensorProto.INT64, []),
-                   make_onnx_inputs_outputs(cond_name, onnx_pb.TensorProto.BOOL, []),
-                   make_onnx_inputs_outputs(dummy_name, node_dtype, [])]
-    body_outputs = [make_onnx_inputs_outputs(cond_out_name, onnx_pb.TensorProto.BOOL, [],),
-                    make_onnx_inputs_outputs(dummy_out_name, node_dtype, []),
-                    make_onnx_inputs_outputs(result_name, node_dtype, [])]
+    body_inputs = [make_onnx_inputs_outputs(trip_name, TensorProto.INT64, []),
+                   make_onnx_inputs_outputs(cond_name, TensorProto.BOOL, []),
+                   make_onnx_inputs_outputs(dummy_name, t_params, [])]
+    body_outputs = [make_onnx_inputs_outputs(cond_out_name, TensorProto.BOOL, [],),
+                    make_onnx_inputs_outputs(dummy_out_name, t_params, []),
+                    make_onnx_inputs_outputs(result_name, t_params, [])]
     body_nodes = []
     index = ctx.make_node("Gather", [flatten_indices.output[0], trip_name], attr={"axis": 0})
     index_squeeze = ctx.make_node("Squeeze", [index.output[0]], attr={"axes": [0]})
     # inner loop to gather result
-    inner_loop_nodes, inner_loop = make_gathernd_inner_loop(ctx, params, index_squeeze, node_dtype)
+    inner_loop_nodes, inner_loop = make_gathernd_inner_loop(ctx,
+                                                            params,
+                                                            index_squeeze,
+                                                            "{}_inner_loop".format(name),
+                                                            t_params)
     body_nodes.extend([index.op, index_squeeze.op] + inner_loop_nodes +
                       [utils.make_onnx_identity(cond_name, cond_out_name),
                        utils.make_onnx_identity(dummy_name, dummy_out_name),
@@ -105,6 +106,7 @@ def gathernd_op(ctx, node, name, args):
     gathernd_loop = ctx.make_node("Loop",
                                   [outter_shape_sum.output[0], cond_const.output[0], params],
                                   output_count=2,
+                                  name="{}_loop".format(name),
                                   attr={"body": body_graph})
     nodes.append(gathernd_loop)
     # reshape to target shape
@@ -130,7 +132,7 @@ def gathernd_op(ctx, node, name, args):
                                  dtypes=[TensorProto.INT64])
     output_reshape = ctx.make_node("Reshape",
                                    [gathernd_loop.output[1], output_shape.output[0]],
-                                   outputs=[node.output[0]])
+                                   outputs=[output])
     nodes.extend([inner_loop_shape,
                   inner_loop_shape_,
                   output_inner_shape,
@@ -138,3 +140,14 @@ def gathernd_op(ctx, node, name, args):
                   output_shape,
                   output_reshape])
     return nodes
+
+def gathernd_op(ctx, node, name, args):
+    """GatherNd op."""
+    # Tparams output = GatherNd(Tparams params, Tidx indices)
+    params = node.input[0]
+    indices = node.input[1]
+    output = node.output[0]
+    # same as the attr Tparams
+    t_params = ctx.get_dtype(params)
+    utils.make_sure(t_params, "Dtype of {} is None".format(indices))
+    return make_gathernd_subgraph(ctx, params, indices, output, name, t_params)

--- a/tf2onnx/function/range.py
+++ b/tf2onnx/function/range.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+tf2onnx.tf2onnx - range op conversion
+"""
+import numpy as np
+from onnx import helper, onnx_pb
+from onnx.onnx_pb import TensorProto
+from tf2onnx import utils
+
+# pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
+def make_range_const(ctx,
+                     start_node,
+                     limit_node,
+                     delta_node,
+                     output,
+                     name,
+                     dtype):
+    """make Range subgraph if all inputs are const."""
+    # T range = Range(T start, T limit, T delta)
+    # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
+    base_name = utils.make_name(name)
+    start = start_node.get_tensor()
+    limit = limit_node.get_tensor()
+    delta = delta_node.get_tensor()
+    val = np.arange(start, limit, delta, dtype=start.dtype)
+    const_range = ctx.make_const(base_name, val)
+    return ctx.make_node("Identity", [const_range.output[0]], dtypes=[dtype], outputs=[output])
+
+def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
+    """make Range subgraph."""
+    # T range = Range(T start, T limit, T delta)
+    # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
+    base_name = utils.make_name(name)
+
+    nodes = []
+
+    # trip_count
+    diff_node = ctx.make_node("Sub",
+                              [limit, start],
+                              op_name_scope=base_name,
+                              name=utils.make_name("diff"))
+    diff_output = diff_node.output[0]
+    nodes.append(diff_node)
+
+    delta_cast = delta
+    if dtype in [onnx_pb.TensorProto.INT32, onnx_pb.TensorProto.INT64]:
+        cast_node = ctx.make_node("Cast", [diff_output], op_name_scope=base_name,
+                                  name="cast_diff", attr={"to": onnx_pb.TensorProto.FLOAT})
+        nodes.append(cast_node)
+        diff_output = cast_node.output[0]
+
+        cast_node = ctx.make_node("Cast", [delta], op_name_scope=base_name, name="cast_delta",
+                                  attr={"to": onnx_pb.TensorProto.FLOAT})
+        nodes.append(cast_node)
+        delta_cast = cast_node.output[0]
+
+    div_node = ctx.make_node("Div", [diff_output, delta_cast], op_name_scope=base_name, name="div")
+    nodes.append(div_node)
+
+    ceil_node = ctx.make_node("Ceil", [div_node.output[0]], op_name_scope=base_name, name="ceil")
+    nodes.append(ceil_node)
+
+    trip_count_node = ctx.make_node("Cast", [ceil_node.output[0]], op_name_scope=base_name, name="trip_cnt",
+                                    attr={"to": onnx_pb.TensorProto.INT64})
+    nodes.append(trip_count_node)
+
+    # cond
+    # Use initializer here since Constant OP before opset 9 does not support bool type
+    cond_name = "{}_cond".format(base_name)
+    ctx.make_const(cond_name, np.ones((), dtype=bool))
+
+    # body
+    body_inputs = [utils.make_onnx_inputs_outputs("i", onnx_pb.TensorProto.INT64, []),
+                   utils.make_onnx_inputs_outputs("cond", onnx_pb.TensorProto.BOOL, []),
+                   utils.make_onnx_inputs_outputs("prev", dtype, [])]
+    body_outputs = [utils.make_onnx_inputs_outputs("cond_out", onnx_pb.TensorProto.BOOL, []),
+                    utils.make_onnx_inputs_outputs("current", dtype, []),
+                    utils.make_onnx_inputs_outputs("range", dtype, [])]
+    body_nodes = []
+    body_nodes.append(utils.make_onnx_identity("cond", "cond_out"))
+    body_nodes.append(helper.make_node("Add", ["prev", delta], ["current"], name=utils.make_name("add")))
+    body_nodes.append(utils.make_onnx_identity("prev", "range"))
+    body_graph = helper.make_graph(body_nodes, utils.make_name("{}_body".format(base_name)), body_inputs, body_outputs)
+
+    # loop
+    loop_inputs = [trip_count_node.output[0], cond_name, start]
+    loop_node = ctx.make_node("Loop", loop_inputs, output_count=2, op_name_scope=base_name, name="loop",
+                              attr={"body": body_graph})
+    nodes.append(loop_node)
+
+    identity_node = ctx.make_node("Identity", [loop_node.output[1]], name=base_name, dtypes=[dtype], outputs=[output])
+    nodes.append(identity_node)
+
+    return nodes
+
+def range_op7(ctx, node, name, args):
+    """Range."""
+    # T range = Range(T start, T limit, T delta)
+    # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
+    start_node = node.inputs[0]
+    limit_node = node.inputs[1]
+    delta_node = node.inputs[2]
+
+    output_name = node.output[0]
+    dtype = node.get_attr_int("Tidx")
+    if start_node.is_const() and limit_node.is_const() and delta_node.is_const():
+        return make_range_const(ctx,
+                                start_node,
+                                limit_node,
+                                delta_node,
+                                output_name,
+                                name,
+                                dtype)
+    return make_range_subgraph(ctx,
+                               start_node.output[0],
+                               limit_node.output[0],
+                               delta_node.output[0],
+                               output_name,
+                               name,
+                               dtype)

--- a/tf2onnx/function/range.py
+++ b/tf2onnx/function/range.py
@@ -5,34 +5,29 @@
 tf2onnx.tf2onnx - range op conversion
 """
 import numpy as np
-from onnx import helper, onnx_pb
+from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
 
-# pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
-def make_range_const(ctx,
-                     start_node,
-                     limit_node,
-                     delta_node,
-                     output,
-                     name,
-                     dtype):
+# pylint: disable=unused-argument,missing-docstring
+def make_range_const(ctx, start, limit, delta, output, scope_name, dtype):
     """make Range subgraph if all inputs are const."""
     # T range = Range(T start, T limit, T delta)
     # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
-    base_name = utils.make_name(name)
-    start = start_node.get_tensor()
-    limit = limit_node.get_tensor()
-    delta = delta_node.get_tensor()
+    base_name = utils.make_name(scope_name)
+    start = ctx.get_node_by_output(start).get_tensor()
+    limit = ctx.get_node_by_output(limit).get_tensor()
+    delta = ctx.get_node_by_output(delta).get_tensor()
     val = np.arange(start, limit, delta, dtype=start.dtype)
     const_range = ctx.make_const(base_name, val)
     return ctx.make_node("Identity", [const_range.output[0]], dtypes=[dtype], outputs=[output])
 
-def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
+
+def make_range_non_const(ctx, start, limit, delta, output, scope_name, dtype):
     """make Range subgraph."""
     # T range = Range(T start, T limit, T delta)
     # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
-    base_name = utils.make_name(name)
+    base_name = utils.make_name(scope_name)
 
     nodes = []
 
@@ -45,14 +40,14 @@ def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
     nodes.append(diff_node)
 
     delta_cast = delta
-    if dtype in [onnx_pb.TensorProto.INT32, onnx_pb.TensorProto.INT64]:
+    if dtype in [TensorProto.INT32, TensorProto.INT64]:
         cast_node = ctx.make_node("Cast", [diff_output], op_name_scope=base_name,
-                                  name="cast_diff", attr={"to": onnx_pb.TensorProto.FLOAT})
+                                  name="cast_diff", attr={"to": TensorProto.FLOAT})
         nodes.append(cast_node)
         diff_output = cast_node.output[0]
 
         cast_node = ctx.make_node("Cast", [delta], op_name_scope=base_name, name="cast_delta",
-                                  attr={"to": onnx_pb.TensorProto.FLOAT})
+                                  attr={"to": TensorProto.FLOAT})
         nodes.append(cast_node)
         delta_cast = cast_node.output[0]
 
@@ -63,7 +58,7 @@ def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
     nodes.append(ceil_node)
 
     trip_count_node = ctx.make_node("Cast", [ceil_node.output[0]], op_name_scope=base_name, name="trip_cnt",
-                                    attr={"to": onnx_pb.TensorProto.INT64})
+                                    attr={"to": TensorProto.INT64})
     nodes.append(trip_count_node)
 
     # cond
@@ -72,10 +67,10 @@ def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
     ctx.make_const(cond_name, np.ones((), dtype=bool))
 
     # body
-    body_inputs = [utils.make_onnx_inputs_outputs("i", onnx_pb.TensorProto.INT64, []),
-                   utils.make_onnx_inputs_outputs("cond", onnx_pb.TensorProto.BOOL, []),
+    body_inputs = [utils.make_onnx_inputs_outputs("i", TensorProto.INT64, []),
+                   utils.make_onnx_inputs_outputs("cond", TensorProto.BOOL, []),
                    utils.make_onnx_inputs_outputs("prev", dtype, [])]
-    body_outputs = [utils.make_onnx_inputs_outputs("cond_out", onnx_pb.TensorProto.BOOL, []),
+    body_outputs = [utils.make_onnx_inputs_outputs("cond_out", TensorProto.BOOL, []),
                     utils.make_onnx_inputs_outputs("current", dtype, []),
                     utils.make_onnx_inputs_outputs("range", dtype, [])]
     body_nodes = []
@@ -95,28 +90,18 @@ def make_range_subgraph(ctx, start, limit, delta, output, name, dtype):
 
     return nodes
 
+
+def make_range(ctx, start, limit, delta, output, scope_name, dtype):
+    if all(ctx.get_node_by_output(n).is_const() for n in [start, limit, delta]):
+        return make_range_const(ctx, start, limit, delta, output, scope_name, dtype)
+    return make_range_non_const(ctx, start, limit, delta, output, scope_name, dtype)
+
+
 def range_op7(ctx, node, name, args):
     """Range."""
     # T range = Range(T start, T limit, T delta)
     # V v_final_and_scan_outputs = Loop(int64 M, B cond, V v_initial)
-    start_node = node.inputs[0]
-    limit_node = node.inputs[1]
-    delta_node = node.inputs[2]
-
-    output_name = node.output[0]
     dtype = node.get_attr_int("Tidx")
-    if start_node.is_const() and limit_node.is_const() and delta_node.is_const():
-        return make_range_const(ctx,
-                                start_node,
-                                limit_node,
-                                delta_node,
-                                output_name,
-                                name,
-                                dtype)
-    return make_range_subgraph(ctx,
-                               start_node.output[0],
-                               limit_node.output[0],
-                               delta_node.output[0],
-                               output_name,
-                               name,
-                               dtype)
+    utils.make_sure(dtype, "Tidx of {} is None".format(node.name))
+    return make_range(ctx, node.input[0], node.input[1], node.input[2],
+                      node.output[0], name, dtype)

--- a/tf2onnx/function/select.py
+++ b/tf2onnx/function/select.py
@@ -12,7 +12,7 @@ from tf2onnx.graph import Node
 from tf2onnx.utils import port_name, make_sure
 
 
-# pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
+# pylint: disable=unused-argument,missing-docstring
 
 
 def select_op8(ctx, node, name, args):

--- a/tf2onnx/function/select.py
+++ b/tf2onnx/function/select.py
@@ -5,7 +5,7 @@
 tf2onnx.tf2onnx - select op conversion
 """
 import numpy as np
-from onnx import helper, onnx_pb
+from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
 from tf2onnx.graph import Node
@@ -39,13 +39,13 @@ def select_op8(ctx, node, name, args):
         # create nodes getting shape of condition
         shape_node_output_shape = [rank]
         shape_node = ctx.make_node("Shape", [node.input[0]], op_name_scope=node.name,
-                                   shapes=[shape_node_output_shape], dtypes=[onnx_pb.TensorProto.INT64])
+                                   shapes=[shape_node_output_shape], dtypes=[TensorProto.INT64])
         nodes.append(shape_node)
 
         # todo(pengwa), move those leveraging rewrite_incomplete_type_support_onnxruntime after shape inferencing
         # bug is fixed.
         # workaround: onnxruntime does not support Split-2, add cases before and after.
-        target_dtype = onnx_pb.TensorProto.FLOAT
+        target_dtype = TensorProto.FLOAT
         shape_f_node = ctx.make_node("Cast", [shape_node.output[0]], attr={"to": target_dtype},
                                      shapes=[shape_node_output_shape], dtypes=[target_dtype],
                                      op_name_scope=node.name)
@@ -63,7 +63,7 @@ def select_op8(ctx, node, name, args):
         for i in range(rank):
             output_id = split_node.output[i]
             output_shape = ctx.get_shape(output_id)
-            target_dtype = onnx_pb.TensorProto.INT64
+            target_dtype = TensorProto.INT64
             shape_i_node = ctx.make_node("Cast", [output_id], attr={"to": target_dtype},
                                          shapes=[output_shape], dtypes=[target_dtype],
                                          op_name_scope=node.name)

--- a/tf2onnx/function/sparse_softmax_cross_entropy_with_logits.py
+++ b/tf2onnx/function/sparse_softmax_cross_entropy_with_logits.py
@@ -1,0 +1,101 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+tf2onnx.tf2onnx - sparse_softmax_cross_entropy_with_logits op conversion
+"""
+import numpy as np
+from onnx import helper
+from onnx.onnx_pb import TensorProto
+from tf2onnx import utils
+from tf2onnx.function.range import make_range_subgraph
+from tf2onnx.function.gathernd import make_gathernd_subgraph
+from tf2onnx.utils import make_onnx_inputs_outputs
+
+# pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
+
+def sparse_softmax_cross_entropy_with_logits_op(ctx, node, name, args):
+    # make subgraph to implement one_hot, idea comes from onehot_op
+    indices_name = node.input[1]
+    indices_shape = ctx.get_shape(indices_name)
+    if len(indices_shape) != 1:
+        # TODO: this works for rank=1 but tensorflow supports more than this.
+        # Same principle should work but we need to implement our own eye.
+        raise ValueError("onehot op: only rank1 is supported")
+    logit_name = node.input[0]
+    depth = ctx.get_shape(logit_name)[-1]
+    # if number of classes is unknown or too large
+    if depth == utils.ONNX_UNKNOWN_DIMENSION or depth > 20000:
+        return sparse_softmax_cross_entropy_with_logits_op_by_gathernd(ctx, node, name, args)
+    logit_dtype = ctx.get_dtype(logit_name)
+    utils.make_sure(logit_dtype, "Dtype of {} is None".format(logit_name))
+
+    dtype = utils.ONNX_TO_NUMPY_DTYPE[logit_dtype]
+    eye = np.eye(depth).astype(dtype)
+    const_name = utils.make_name("const_eye")
+    const_eye = ctx.make_const(name=const_name, np_val=eye)
+    onehot = ctx.make_node(op_type="Gather", inputs=[const_eye.output[0], indices_name], attr={"axis": 0})
+    log_softmax = ctx.make_node(op_type="LogSoftmax", inputs=[logit_name])
+    # implement tf.multiply(np.float32(-1.0), tf.reduce_sum(tf.multiply(one_hot, log_softmax), axis=1))
+    mul1 = ctx.make_node(op_type="Mul", inputs=[onehot.output[0], log_softmax.output[0]])
+    reduce_sum = ctx.make_node(op_type="ReduceSum", inputs=[mul1.output[0]], attr={"axes": [1]})
+    const_name = utils.make_name("const_negative_one")
+    const_negative_one = ctx.make_const(name=const_name, np_val=np.array(-1).astype(dtype))
+    mul2 = ctx.make_node(op_type="Mul", inputs=[const_negative_one.output[0], reduce_sum.output[0]])
+    res = ctx.make_node(op_type="Squeeze", inputs=[mul2.output[0]], outputs=[node.output[0]], attr={"axes": [1]})
+
+    return [onehot, log_softmax, mul1, reduce_sum, mul2, res]
+
+
+def sparse_softmax_cross_entropy_with_logits_op_by_gathernd(ctx, node, name, args):
+    nodes = []
+    # make subgraph to implement one_hot, idea comes from onehot_op
+    indices_name = node.input[1]
+    indices_shape = ctx.get_shape(indices_name)
+    if len(indices_shape) != 1:
+        # TODO: this works for rank=1 but tensorflow supports more than this.
+        # Same principle should work but we need to implement our own eye.
+        raise ValueError("onehot op: only rank1 is supported")
+    logit_name = node.input[0]
+    logit_dtype = ctx.get_dtype(logit_name)
+    utils.make_sure(logit_dtype, "Dtype of {} is None".format(logit_name))
+    indices_dtype = ctx.get_dtype(indices_name)
+    if indices_dtype != TensorProto.INT64:
+        indices_cast = ctx.make_node("Cast", [indices_name], attr={"to": TensorProto.INT64})
+        nodes.append(indices_cast)
+        indices_name = indices_cast.output[0]
+    indices_size = ctx.make_node("Size", [indices_name])
+    indices_unsqueeze = ctx.make_node("Unsqueeze", [indices_name], attr={"axes": [1]})
+    zero_const = ctx.make_const(utils.make_name("zero"), np.array(0, dtype=np.int64))
+    one_const = ctx.make_const(utils.make_name("one"), np.array(1, dtype=np.int64))
+    id_name = utils.make_name("sparse_softmax_id")
+    id_output = utils.port_name(id_name)
+    nodes.extend(make_range_subgraph(ctx,
+                                     zero_const.output[0],
+                                     indices_size.output[0],
+                                     one_const.output[0],
+                                     id_output,
+                                     id_name,
+                                     TensorProto.INT64))
+    id_unsqueeze = ctx.make_node("Unsqueeze", [id_output], attr={"axes": [1]})
+    indices_with_id = ctx.make_node("Concat",
+                                    [id_unsqueeze.output[0], indices_unsqueeze.output[0]],
+                                    attr={"axis": 1})
+    log_softmax = ctx.make_node(op_type="LogSoftmax", inputs=[logit_name], dtypes=[logit_dtype])
+    gathernd_name = utils.make_name("sparse_softmax_gathernd")
+    gathernd_output = utils.port_name(gathernd_name)
+    nodes.extend(make_gathernd_subgraph(ctx,
+                                        log_softmax.output[0],
+                                        indices_with_id.output[0],
+                                        gathernd_output,
+                                        gathernd_name,
+                                        logit_dtype))
+    const_name = utils.make_name("const_negative_one")
+    const_negative_one = ctx.make_const(const_name, np.array(-1).astype(utils.ONNX_TO_NUMPY_DTYPE[logit_dtype]))
+    mul2 = ctx.make_node(op_type="Mul", inputs=[const_negative_one.output[0], gathernd_output])
+    res = ctx.make_node(op_type="Squeeze",
+                        inputs=[mul2.output[0]], outputs=[node.output[0]],
+                        attr={"axes": [1]})
+
+    nodes.extend([indices_size, indices_unsqueeze, id_unsqueeze, indices_with_id, log_softmax, mul2, res])
+    return nodes

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -21,10 +21,7 @@ from tensorflow.tools.graph_transforms import TransformGraph
 
 import tf2onnx
 from tf2onnx import utils
-from tf2onnx.function.gathernd import gathernd_op
-from tf2onnx.function.range import range_op7
-from tf2onnx.function.select import select_op8
-from tf2onnx.function.sparse_softmax_cross_entropy_with_logits import sparse_softmax_cross_entropy_with_logits_op
+from tf2onnx.function import *  # pylint: disable=wildcard-import
 from tf2onnx.graph import Node, Graph
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.random_uniform import rewrite_random_uniform, rewrite_random_uniform_fold_const


### PR DESCRIPTION
- When the number of label category is too large, the current converter will generate a huge eye matrix which cannot be stored in protobuf. This PR uses `GatherNd` to circumvent the problem.
- Put some complex conversion code (`Range`, `SparseSoftmax...`) into `function/` dir.  
- Wrap `Range` and `GatherNd` conversion functions.