### PR TITLE
fix some bugs

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1306,6 +1306,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
         tf.reset_default_graph()
+
         x_val = np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3],
                           [4, 5, 6], [4, 5, 6], [1, 1, 1],
                           [0, 0, 0], [7, 8, 9], [0, 0, 0]
@@ -1316,6 +1317,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
         tf.reset_default_graph()
+
         x_val_shape = [5, 5, 7, 8, 9]
         x_val = np.random.randint(0, 100, x_val_shape).astype(np.float32)
         x = tf.placeholder(tf.float32, [None, 5, 7, 8, 9], name=_TFINPUT)
@@ -1336,6 +1338,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
         tf.reset_default_graph()
+
         x_val = np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3],
                           [4, 5, 6], [4, 5, 6], [1, 1, 1],
                           [0, 0, 0], [7, 8, 9], [0, 0, 0]
@@ -1346,6 +1349,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
         tf.reset_default_graph()
+
         x_val_shape = [5, 5, 7, 8, 9]
         x_val = np.random.randint(0, 100, x_val_shape).astype(np.float32)
         x = tf.placeholder(tf.float32, [5, None, 7, 8, 9], name=_TFINPUT)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1309,6 +1309,27 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
+    @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so scan op is not supported")
+    def test_reverse_sequence_time_major_two_dimension(self):
+        x_val = np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3],
+                          [4, 5, 6], [4, 5, 6], [1, 1, 1],
+                          [0, 0, 0], [7, 8, 9], [0, 0, 0]
+                         ],
+                         dtype=np.float32)
+        x = tf.placeholder(tf.float32, [9, None], name=_TFINPUT)
+        x_ = tf.reverse_sequence(x, seq_axis=0, batch_axis=1, seq_lengths=[9, 9, 9])
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
+    @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so scan op is not supported")
+    def test_reverse_sequence_time_major_larger_rank(self):
+        x_val_shape = [5, 5, 7, 8, 9]
+        x_val = np.random.randint(0, 100, x_val_shape).astype(np.float32)
+        x = tf.placeholder(tf.float32, [5, None, 7, 8, 9], name=_TFINPUT)
+        x_ = tf.reverse_sequence(x, seq_axis=0, batch_axis=1, seq_lengths=[5, 5, 5, 5, 5])
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+
     # @unittest.skipIf(OPSET < 8, "supported with opset 8 or better")
     @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so Select op is not supported")
     def test_where(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -607,6 +607,16 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(mi, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
 
+    @unittest.skipIf(*onnxruntime_check("Greater"))
+    def test_greater_unsupport_type(self):
+        x_val1 = np.array([4, 2, 4, 1], dtype=np.int32).reshape((2, 2))
+        x_val2 = np.array([2, 4, 4, 1], dtype=np.int32).reshape((2, 2))
+        x1 = tf.placeholder(tf.int32, [2, 2], name=_TFINPUT)
+        x2 = tf.placeholder(tf.int32, [2, 2], name=_TFINPUT1)
+        mi = tf.greater(x1, x2)
+        _ = tf.identity(mi, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
+
     def test_sequeeze_no_axis_specified(self):
         x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2, 1))
         x = tf.placeholder(tf.float32, [2, 2, 1], name=_TFINPUT)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1305,6 +1305,23 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_ = tf.reverse_sequence(x, seq_axis=1, batch_axis=0, seq_lengths=[2, 3, 1])
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+        x_val = np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3],
+                          [4, 5, 6], [4, 5, 6], [1, 1, 1],
+                          [0, 0, 0], [7, 8, 9], [0, 0, 0]
+                         ],
+                         dtype=np.float32)
+        x = tf.placeholder(tf.float32, [None, 3], name=_TFINPUT)
+        x_ = tf.reverse_sequence(x, seq_axis=1, batch_axis=0, seq_lengths=[3]*9)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+        x_val_shape = [5, 5, 7, 8, 9]
+        x_val = np.random.randint(0, 100, x_val_shape).astype(np.float32)
+        x = tf.placeholder(tf.float32, [None, 5, 7, 8, 9], name=_TFINPUT)
+        x_ = tf.reverse_sequence(x, seq_axis=1, batch_axis=0, seq_lengths=[5, 5, 5, 5, 5])
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
     # @unittest.skipIf(OPSET < 8, "supported with opset 8 or better")
     @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so scan op is not supported")
@@ -1318,9 +1335,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_ = tf.reverse_sequence(x, seq_axis=0, batch_axis=1, seq_lengths=[2, 3, 1])
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
-
-    @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so scan op is not supported")
-    def test_reverse_sequence_time_major_two_dimension(self):
+        tf.reset_default_graph()
         x_val = np.array([[1, 2, 3], [1, 2, 3], [1, 2, 3],
                           [4, 5, 6], [4, 5, 6], [1, 1, 1],
                           [0, 0, 0], [7, 8, 9], [0, 0, 0]
@@ -1330,9 +1345,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_ = tf.reverse_sequence(x, seq_axis=0, batch_axis=1, seq_lengths=[9, 9, 9])
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
-
-    @unittest.skip("FIXME: the newest onnxruntime wheel hasn't been published to PYPI, so scan op is not supported")
-    def test_reverse_sequence_time_major_larger_rank(self):
+        tf.reset_default_graph()
         x_val_shape = [5, 5, 7, 8, 9]
         x_val = np.random.randint(0, 100, x_val_shape).astype(np.float32)
         x = tf.placeholder(tf.float32, [5, None, 7, 8, 9], name=_TFINPUT)

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1511,7 +1511,7 @@ def reverse_op8(ctx, node, name, args):
         old_dtype = ctx.get_dtype(node.input[0])
         perm_val = [1, 0]
         rank = len(old_shape)
-        utils.make_sure(rank>=2, "rank of reverse_sequence input {} is at least 2".format(node.input[0]))
+        utils.make_sure(rank >= 2, "rank of reverse_sequence input {} is at least 2".format(node.input[0]))
         perm_val += list(range(2, rank))
         trans_node = ctx.insert_new_node_on_input(node, "Transpose", node.input[0], perm=perm_val)
         new_shape = spatial_map(old_shape, perm_val)


### PR DESCRIPTION
- greater: in opset7, greater only accepts float, float16 and double input. If inputs are other types, we need to cast them to supported type first.
- reverse_sequence: in the time major setting, current converter only supports 3-dimension sequences, it's easy to generate it to 2 and larger dimensions.