### PR TITLE
Tf.while loop support & custom rnn refactoring

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts=--cov=tf2onnx --ignore=tests/test_custom_rnncell.py --ignore=tests/test_const_fold.py
+addopts=--cov=tf2onnx --ignore=tests/test_custom_rnncell.py --ignore=tests/test_const_fold.py --ignore=tests/test_loops.py
 #testpaths=tests/test_*.py

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -251,9 +251,9 @@ class Tf2OnnxGraphTests(unittest.TestCase):
 
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { kernel [op_type=Reshape] Conv2D__3 [op_type=Transpose] Conv2D__2 [op_type=Transpose] '
+                'digraph { Conv2D__2 [op_type=Transpose] kernel [op_type=Reshape] Conv2D__3 [op_type=Transpose] '
                 'Conv2D [op_type=Conv] Conv2D__4 [op_type=Transpose] output [op_type=Identity] '
-                'k:0 -> kernel "kernel/shape":0 -> kernel kernel:0 -> Conv2D__3 input1:0 -> Conv2D__2 '
+                'input1:0 -> Conv2D__2 k:0 -> kernel "kernel/shape":0 -> kernel kernel:0 -> Conv2D__3 '
                 'Conv2D__2:0 -> Conv2D Conv2D__3:0 -> Conv2D Conv2D:0 -> Conv2D__4 Conv2D__4:0 -> output }',
                 onnx_to_graphviz(g))
 

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -12,9 +12,6 @@ import unittest
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.contrib import rnn
-from tensorflow.python.ops import init_ops
-from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -1,0 +1,167 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""Unit Tests for while loops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.contrib import rnn
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import variable_scope
+from backend_test_base import Tf2OnnxBackendTestBase
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
+
+class LoopTests(Tf2OnnxBackendTestBase):
+
+    def test_simple_while_loop(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        c = lambda i: tf.less(i, 10)
+        b = lambda i: tf.add(i, 1)
+        r = tf.while_loop(c, b, [i])
+
+        _ = tf.identity(r, name="output")
+        input_names_with_port = ["input_1:0"]
+        feed_dict = {"input_1:0": np.array(0, dtype=np.int32)}
+
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+
+    def test_simple_while_loop_2(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        c = lambda i: tf.logical_and(tf.less(i, 10), tf.greater_equal(i, 3))
+        b = lambda i: tf.add(i, 1)
+        r = tf.while_loop(c, b, [i])
+
+        _ = tf.identity(r, name="output")
+        input_names_with_port = ["input_1:0"]
+        feed_dict = {"input_1:0": np.array(3, dtype=np.int32)}
+
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+
+    def test_while_loop_with_ta_write(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        output_ta = tf.TensorArray(dtype=tf.int32, size=0, dynamic_size=True)
+
+        # todo: we cannot support i >= 3 for now, because in this case, TensorArray by default will
+        # leave 0 for in the first 3 index.
+        c = lambda i, *_: tf.logical_and(tf.less(i, 10), i >= 0)
+        def b(i, out_ta):
+            new_i = tf.add(i, 1)
+            out_ta_new = out_ta.write(i, i)
+            return new_i, out_ta_new
+
+        i_final, ta_final = tf.while_loop(c, b, [i, output_ta])
+        r = ta_final.stack()
+        _ = tf.identity(r, name="output")
+        _ = tf.identity(i_final, name="i")
+        input_names_with_port = ["input_1:0"]
+        feed_dict = {"input_1:0": np.array(0, dtype=np.int32)}
+
+        output_names_with_port = ["output:0", "i:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+
+    def test_while_loop_with_ta_read(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        inputs = tf.placeholder(tf.float32, (10,), name="input_2")
+        inputs_2 = tf.identity(inputs)
+        input_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs_2)
+
+        inputs_3 = tf.placeholder(tf.float32, (10,), name="input_3")
+        inputs_3_identity = tf.identity(inputs_3)
+        input_ta_3 = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs_3_identity)
+
+        c = lambda i, *_: tf.logical_and(tf.less(i, 10), i >= 0)
+        res = tf.constant(0.)
+        res2 = tf.constant(1.)
+        def b(i, res, res2):
+            new_i = tf.add(i, 1)
+            x = input_ta.read(i)
+            x = x + 3
+            y = input_ta_3.read(i) + res2
+            return new_i, x, y
+
+        i_final, x_final, y_final = tf.while_loop(c, b, [i, res, res2])
+        _ = tf.identity(i_final, name="i")
+        _ = tf.identity(x_final, name="x")
+        _ = tf.identity(y_final, name="y")
+        input_names_with_port = ["input_1:0", "input_2:0", "input_3:0"]
+        feed_dict = {"input_1:0": np.array(0, dtype=np.int32),
+                     "input_2:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32),
+                     "input_3:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32)}
+
+        output_names_with_port = ["i:0", "x:0", "y:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+    @unittest.skip("bug in onnxruntime")
+    def test_while_loop_with_ta_read_reference_outer_input_directly(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        inputs = tf.placeholder(tf.float32, (10,), name="input_2")
+        input_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs)
+
+        inputs_3 = tf.placeholder(tf.float32, (10,), name="input_3")
+        input_ta_3 = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs_3)
+
+        c = lambda i, *_: tf.logical_and(tf.less(i, 10), i >= 0)
+        res = tf.constant(0.)
+        res2 = tf.constant(1.)
+        def b(i, res, res2):
+            new_i = tf.add(i, 1)
+            x = input_ta.read(i)
+            x = x + 3
+            y = input_ta_3.read(i) + res2
+            return new_i, x, y
+
+        i_final, x_final, y_final = tf.while_loop(c, b, [i, res, res2])
+        _ = tf.identity(i_final, name="i")
+        _ = tf.identity(x_final, name="x")
+        _ = tf.identity(y_final, name="y")
+        input_names_with_port = ["input_1:0", "input_2:0", "input_3:0"]
+        feed_dict = {"input_1:0": np.array(0, dtype=np.int32),
+                     "input_2:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32),
+                     "input_3:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32)}
+
+        output_names_with_port = ["i:0", "x:0", "y:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+
+    def test_while_loop_with_ta_read_and_write(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        inputs = tf.placeholder(tf.float32, (10,), name="input_2")
+
+        inputs_2 = tf.identity(inputs)
+        input_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs_2)
+        output_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True)
+
+        c = lambda i, *_: tf.logical_and(tf.less(i, 10), i >= 0)
+
+        def b(i, out_ta):
+            new_i = tf.add(i, 1)
+            x = input_ta.read(i)
+            x = x + 3
+            out_ta_new = out_ta.write(i, x)
+            return new_i, out_ta_new
+
+        i_final, out_final = tf.while_loop(c, b, [i, output_ta])
+        _ = tf.identity(i_final, name="i")
+        _ = tf.identity(out_final.stack(), name="output_ta")
+        input_names_with_port = ["input_1:0", "input_2:0"]
+        feed_dict = {"input_1:0": np.array(0, dtype=np.int32),
+                     "input_2:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32)}
+
+        output_names_with_port = ["i:0", "output_ta:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
+if __name__ == '__main__':
+    Tf2OnnxBackendTestBase.trigger(LoopTests)

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -8,6 +8,7 @@ import numpy as np
 from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
+from tf2onnx.graph import Graph
 from tf2onnx.utils import make_onnx_inputs_outputs
 
 # pylint: disable=unused-argument,missing-docstring
@@ -17,36 +18,41 @@ INT64_MAX = np.iinfo(np.int64).max
 def _make_gathernd_inner_loop(ctx, params, index, dtype):
     """create the inner loop for GatherNd."""
     # gather_cur = params
-    # for (int i=0; i<size(index); i++)
+    # for (int i = 0; i < size(index); i++)
     #   gather_res = gather(gather_cur, index[i])
     scope_name = utils.make_name("gathernd_inner_loop")
     nodes = []
     trip_node = ctx.make_node("Size", [index.output[0]])
-    nodes.append(trip_node.op)
+    nodes.append(trip_node)
     cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
     trip_name = utils.make_name("i")
     cond_name = utils.make_name("cond")
     cond_out_name = utils.make_name("cond_out")
     cur_name = utils.make_name("gather_cur")
     result_name = utils.make_name("res")
-    body_inputs = [make_onnx_inputs_outputs(trip_name, TensorProto.INT64, []),
-                   make_onnx_inputs_outputs(cond_name, TensorProto.BOOL, []),
-                   make_onnx_inputs_outputs(cur_name, dtype, [])]
-    body_outputs = [make_onnx_inputs_outputs(cond_out_name, TensorProto.BOOL, [],),
-                    make_onnx_inputs_outputs(result_name, dtype, [])]
-    body_nodes = []
-    index_i = ctx.make_node("Gather", [index.output[0], trip_name], attr={"axis": 0})
-    gather = ctx.make_node("Gather", [cur_name, index_i.output[0]], attr={"axis": 0})
-    squeeze = ctx.make_node("Squeeze", [gather.output[0]], attr={"axes": [0]}, outputs=[result_name])
-    body_nodes.extend([index_i.op, gather.op, squeeze.op,
-                       utils.make_onnx_identity(cond_name, cond_out_name)])
-    body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_inner_body"), body_inputs, body_outputs)
+
+    # body graph creation
+    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset, extra_opset=ctx._extra_opset, output_names=[])
+
+    index_i = g.make_node("Gather", [index.output[0], trip_name], attr={"axis": 0})
+    gather = g.make_node("Gather", [cur_name, index_i.output[0]], attr={"axis": 0})
+    squeeze = g.make_node("Squeeze", [gather.output[0]], attr={"axes": [0]}, outputs=[result_name])
+    cond = g.make_node("Identity", [cond_name], outputs=[cond_out_name])
+    g.set_nodes([index_i, gather, squeeze, cond])
+
+    g.add_graph_input(trip_name, TensorProto.INT64, [])
+    g.add_graph_input(cond_name, TensorProto.BOOL, [])
+    g.add_graph_input(cur_name, dtype, [])
+
+    g.add_graph_output(cond_out_name, TensorProto.BOOL, [])
+    g.add_graph_output(result_name, dtype, [])
+
     inner_loop = ctx.make_node("Loop", [trip_node.output[0],
                                         cond_const.output[0],
                                         params],
-                               op_name_scope=scope_name,
-                               attr={"body": body_graph})
-    nodes.append(inner_loop.op)
+                               op_name_scope=scope_name, skip_conversion=False)
+    inner_loop.set_body_graph_as_attr("body", g)
+    nodes.append(inner_loop)
     return nodes, inner_loop
 
 
@@ -79,36 +85,42 @@ def make_gathernd(ctx, params, indices, output, scope_name, t_params):
     # for (int i=0; i<outter_shape_sum; i++) inner_loop(params, flatten_indices[i])
     cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
     dummy_const = ctx.make_const(utils.make_name("dummy"), np.ones((), dtype=np.int64))
+
+    # body graph creation
+    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset, extra_opset=ctx._extra_opset, output_names=[])
     trip_name = utils.make_name("i")
     cond_name = utils.make_name("cond")
     cond_out_name = utils.make_name("cond_out")
     dummy_name = utils.make_name("dummy")
     dummy_out_name = utils.make_name("dummy_out")
     result_name = utils.make_name("res")
-    body_inputs = [make_onnx_inputs_outputs(trip_name, TensorProto.INT64, []),
-                   make_onnx_inputs_outputs(cond_name, TensorProto.BOOL, []),
-                   make_onnx_inputs_outputs(dummy_name, t_params, [])]
-    body_outputs = [make_onnx_inputs_outputs(cond_out_name, TensorProto.BOOL, [],),
-                    make_onnx_inputs_outputs(dummy_out_name, t_params, []),
-                    make_onnx_inputs_outputs(result_name, t_params, [])]
-    body_nodes = []
-    index = ctx.make_node("Gather", [flatten_indices.output[0], trip_name], attr={"axis": 0})
-    index_squeeze = ctx.make_node("Squeeze", [index.output[0]], attr={"axes": [0]})
+
+    index = g.make_node("Gather", [flatten_indices.output[0], trip_name], attr={"axis": 0})
+    index_squeeze = g.make_node("Squeeze", [index.output[0]], attr={"axes": [0]})
     # inner loop to gather result
-    inner_loop_nodes, inner_loop = _make_gathernd_inner_loop(ctx,
+    nodes_to_append, inner_loop = _make_gathernd_inner_loop(g,
                                                              params,
                                                              index_squeeze,
                                                              t_params)
-    body_nodes.extend([index.op, index_squeeze.op] + inner_loop_nodes +
-                      [utils.make_onnx_identity(cond_name, cond_out_name),
-                       utils.make_onnx_identity(dummy_name, dummy_out_name),
-                       utils.make_onnx_identity(inner_loop.output[0], result_name)])
-    body_graph = helper.make_graph(body_nodes, utils.make_name("gathernd_body"), body_inputs, body_outputs)
+    g.set_nodes(nodes_to_append +
+                      [index, index_squeeze,
+                       g.make_node("Identity", [cond_name], outputs=[cond_out_name]),
+                       g.make_node("Identity", [dummy_name], outputs=[dummy_out_name]),
+                       g.make_node("Identity", [inner_loop.output[0]], outputs=[result_name])])
+
+    g.add_graph_input(trip_name, TensorProto.INT64, [])
+    g.add_graph_input(cond_name, TensorProto.BOOL, [])
+    g.add_graph_input(dummy_name, t_params, [])
+
+    g.add_graph_output(cond_out_name, TensorProto.BOOL, [])
+    g.add_graph_output(dummy_out_name, t_params, []),
+    g.add_graph_output(result_name, t_params, [])
+
     gathernd_loop = ctx.make_node("Loop",
                                   [outter_shape_sum.output[0], cond_const.output[0], params],
                                   output_count=2,
-                                  op_name_scope=scope_name,
-                                  attr={"body": body_graph})
+                                  op_name_scope=scope_name, skip_conversion=False)
+    gathernd_loop.set_body_graph_as_attr("body", g)
     nodes.append(gathernd_loop)
     # reshape to target shape
     # output shape of gathernd: indices.shape[:-1] + gathernd_output.shape[1:]

--- a/tf2onnx/function/matrixbandpart.py
+++ b/tf2onnx/function/matrixbandpart.py
@@ -2,9 +2,8 @@
 tf2onnx.tf2onnx - matrixbandpart op conversion
 """
 import numpy as np
-from onnx import helper, onnx_pb
+from onnx import onnx_pb
 from tf2onnx import utils
-from tf2onnx.graph import Graph
 from tf2onnx.utils import make_sure
 
 
@@ -39,13 +38,13 @@ def matrixbandpart_op(ctx, node, name, args):
     nodes.append(one_line)
 
     # 2: "loop" to generate mask matrix: generate col or row of matrix one by one
-    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset, extra_opset=ctx._extra_opset, output_names=[])
+    g = ctx.create_new_graph_with_same_config()
     node_name = utils.make_name("const_zero_bool")
     const_zero_bool = ctx.make_const(name=node_name, np_val=np.array([[0]]).astype(np.bool))
     slice_node = g.make_node(op_type="Slice", inputs=["line"],
-                               attr={"axes": [counter_axis], "starts": [0], "ends": [-1]})
+                             attr={"axes": [counter_axis], "starts": [0], "ends": [-1]})
     new_line = g.make_node(op_type="Concat", inputs=[const_zero_bool.output[0], slice_node.output[0]],
-                             outputs=["line_out"], attr={"axis": counter_axis})
+                           outputs=["line_out"], attr={"axis": counter_axis})
     body_nodes = [slice_node, new_line,
                   g.make_node("Identity", ["cond"], outputs=["cond_out"]),
                   g.make_node("Identity", ["line"], outputs=["res"])]

--- a/tf2onnx/function/matrixbandpart.py
+++ b/tf2onnx/function/matrixbandpart.py
@@ -4,6 +4,7 @@ tf2onnx.tf2onnx - matrixbandpart op conversion
 import numpy as np
 from onnx import helper, onnx_pb
 from tf2onnx import utils
+from tf2onnx.graph import Graph
 from tf2onnx.utils import make_sure
 
 
@@ -38,23 +39,25 @@ def matrixbandpart_op(ctx, node, name, args):
     nodes.append(one_line)
 
     # 2: "loop" to generate mask matrix: generate col or row of matrix one by one
-    body_ins = [utils.make_onnx_inputs_outputs("trip", onnx_pb.TensorProto.INT64, []),
-                utils.make_onnx_inputs_outputs("cond", onnx_pb.TensorProto.BOOL, []),
-                utils.make_onnx_inputs_outputs("line", onnx_pb.TensorProto.BOOL, [-1, -1])]
-    body_outs = [utils.make_onnx_inputs_outputs("cond_out", onnx_pb.TensorProto.BOOL, []),
-                 utils.make_onnx_inputs_outputs("line_out", onnx_pb.TensorProto.BOOL, [-1, -1]),
-                 utils.make_onnx_inputs_outputs("res", onnx_pb.TensorProto.BOOL, [-1, -1])]
-    # body graph
+    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset, extra_opset=ctx._extra_opset, output_names=[])
     node_name = utils.make_name("const_zero_bool")
     const_zero_bool = ctx.make_const(name=node_name, np_val=np.array([[0]]).astype(np.bool))
-    slice_node = ctx.make_node(op_type="Slice", inputs=["line"],
+    slice_node = g.make_node(op_type="Slice", inputs=["line"],
                                attr={"axes": [counter_axis], "starts": [0], "ends": [-1]})
-    new_line = ctx.make_node(op_type="Concat", inputs=[const_zero_bool.output[0], slice_node.output[0]],
+    new_line = g.make_node(op_type="Concat", inputs=[const_zero_bool.output[0], slice_node.output[0]],
                              outputs=["line_out"], attr={"axis": counter_axis})
-    body_nodes = [slice_node.op, new_line.op,
-                  utils.make_onnx_identity("cond", "cond_out"),
-                  utils.make_onnx_identity("line", "res")]
-    body_graph = helper.make_graph(body_nodes, utils.make_name("MatrixBandPart_body"), body_ins, body_outs)
+    body_nodes = [slice_node, new_line,
+                  g.make_node("Identity", ["cond"], outputs=["cond_out"]),
+                  g.make_node("Identity", ["line"], outputs=["res"])]
+    g.set_nodes(body_nodes)
+    g.add_graph_input("trip", onnx_pb.TensorProto.INT64, [])
+    g.add_graph_input("cond", onnx_pb.TensorProto.BOOL, [])
+    g.add_graph_input("line", onnx_pb.TensorProto.BOOL, [-1, -1])
+
+    g.add_graph_output("cond_out", onnx_pb.TensorProto.BOOL, [])
+    g.add_graph_output("line_out", onnx_pb.TensorProto.BOOL, [-1, -1])
+    g.add_graph_output("res", onnx_pb.TensorProto.BOOL, [-1, -1])
+
     # initial value of body vars
     shape = ctx.make_node(op_type="Shape", inputs=[node.input[0]])  # dtype of result is int64
     nodes.append(shape)
@@ -67,8 +70,8 @@ def matrixbandpart_op(ctx, node, name, args):
     cond = ctx.make_const(name=node_name, np_val=np.array(1).astype(np.bool)).output[0]
     col_init = one_line.output[0]
 
-    loop_node = ctx.make_node(op_type="Loop", inputs=[trip_cnt, cond, col_init], output_count=2,
-                              attr={"body": body_graph})
+    loop_node = ctx.make_node(op_type="Loop", inputs=[trip_cnt, cond, col_init], output_count=2)
+    loop_node.set_body_graph_as_attr("body", g)
     nodes.append(loop_node)
     # convert generated mask matrix from bool to right shape and data type
     squeeze = ctx.make_node(op_type="Squeeze", inputs=[loop_node.output[1]], attr={"axes": [squeeze_axis]})

--- a/tf2onnx/function/range.py
+++ b/tf2onnx/function/range.py
@@ -5,12 +5,12 @@
 tf2onnx.tf2onnx - range op conversion
 """
 import numpy as np
-from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
-from tf2onnx.graph import Graph
 
 # pylint: disable=unused-argument,missing-docstring
+
+
 def make_range_const(ctx, start, limit, delta, output, scope_name, dtype):
     """make Range subgraph if all inputs are const."""
     # T range = Range(T start, T limit, T delta)
@@ -68,7 +68,7 @@ def make_range_non_const(ctx, start, limit, delta, output, scope_name, dtype):
     ctx.make_const(cond_name, np.ones((), dtype=bool))
 
     # body
-    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset, extra_opset=ctx._extra_opset, output_names=[])
+    g = ctx.create_new_graph_with_same_config()
     body_nodes = [g.make_node("Identity", ["cond"], outputs=["cond_out"]),
                   g.make_node("Add", ["prev", delta], outputs=["current"], name=utils.make_name("add")),
                   g.make_node("Identity", ["prev"], outputs=["range"])]

--- a/tf2onnx/function/select.py
+++ b/tf2onnx/function/select.py
@@ -8,7 +8,7 @@ import numpy as np
 from onnx import helper
 from onnx.onnx_pb import TensorProto
 from tf2onnx import utils
-from tf2onnx.graph import Node
+from tf2onnx.graph import Node, Graph
 from tf2onnx.utils import port_name, make_sure
 
 
@@ -22,12 +22,9 @@ def select_op8(ctx, node, name, args):
 
     nodes = []
     true_data_type = ctx.get_dtype(node.input[1])
-    false_data_type = ctx.get_dtype(node.input[2])
     true_data_shape = ctx.get_shape(node.input[1])
-    false_data_shape = ctx.get_shape(node.input[2])
-    make_sure(true_data_type == false_data_type, "select true val and false val have different data types.")
-    make_sure(np.array_equal(true_data_shape, false_data_shape),
-              "select true val and false val have different output shapes.")
+    make_sure(true_data_type is not None, "select true data dtype cannot be None")
+    make_sure(true_data_shape is not None, "select true data shape cannot be None")
 
     condition_shape = ctx.get_shape(node.input[0])
     utils.make_sure(condition_shape is not None, "condition shape is None")
@@ -71,20 +68,19 @@ def select_op8(ctx, node, name, args):
             nodes.append(shape_i_node)
         # workaround ends
 
-        onnx_nodes = create_loop_op(node.input, true_data_type, true_data_shape, trip_cnts, rank)
-        new_nodes = [Node(n, ctx, skip_conversion=True) for n in onnx_nodes]
-        nodes.extend(new_nodes)
-        loop_node = new_nodes[-1]
+        onnx_nodes = create_loop_op(ctx, node.input, true_data_type, true_data_shape, trip_cnts, rank)
+        nodes.extend(onnx_nodes)
+        loop_node = onnx_nodes[-1]
+
         val_output_id = loop_node.output[1]
     elif rank == 0:
-        if_onnx_node, val_output_id = create_if_op(node.input, true_data_type, true_data_shape)
-        if_node = Node(if_onnx_node, ctx, skip_conversion=True)
+        if_node, val_output_id = create_if_op(ctx, node.input, true_data_type, true_data_shape)
         nodes.append(if_node)
 
     ctx.copy_shape(node.output[0], val_output_id)
     ctx.set_dtype(node.output[0], true_data_type)
 
-    output_node = ctx.make_node("Identity", [val_output_id], name=node.name,
+    output_node = ctx.make_node("Identity", [val_output_id], outputs=node.output,
                                 shapes=[ctx.get_shape(val_output_id)], dtypes=[true_data_type])
     nodes.append(output_node)
 
@@ -95,82 +91,67 @@ def select_op8(ctx, node, name, args):
 # 0: condition data to gather on
 # 1: true result to gather on
 # 2: false result to father on
-def create_loop_op(gather_input_ids, output_type, output_shape, trip_count_input_ids, rank):
+def create_loop_op(g, gather_input_ids, output_type, output_shape, trip_count_input_ids, rank):
     nodes = []
-
-    cond_var_name = utils.make_name("condition")
-    true = helper.make_tensor(cond_var_name, TensorProto.BOOL, (), [True])
-    init_cond = helper.make_node("Constant", [], [cond_var_name], value=true, name=cond_var_name)
-    nodes.append(init_cond)
+    cond_var_name = utils.make_name("cond_var")
+    g.make_const(cond_var_name, np.array(True, dtype=np.bool))
 
     # Loop requires at least a variable, add a useless fake variable.
     fake_val_name = utils.make_name("fake_var")
-    fake_var_init_val = helper.make_tensor(fake_val_name, TensorProto.FLOAT, (), [0.0])
-    fake_var_init_node = helper.make_node("Constant", [], [fake_val_name],
-                                          value=fake_var_init_val, name=fake_val_name)
-    nodes.append(fake_var_init_node)
+    g.make_const(fake_val_name, np.array(0.0, dtype=np.float32))
 
     if rank < 1:
         raise ValueError("rank is < 1")
     trip_count_input_id = trip_count_input_ids[-1 * rank]
 
-    op_name = utils.make_name("loop")
-    fake_var_output_id = port_name(op_name)
     loop_inputs = [trip_count_input_id,  # trip count
                    cond_var_name,  # termination condition
                    fake_val_name  # initial value of loop-carried dependencies
                   ]
-    loop_scan_output_id = port_name(op_name, 1)
-
-    loop_body = create_loop_body_graph(gather_input_ids, output_type, output_shape, trip_count_input_ids, rank, op_name)
-    loop_node = helper.make_node("Loop", loop_inputs, [fake_var_output_id, loop_scan_output_id],
-                                 name=op_name, body=loop_body)
+    # define an extra scan output
+    loop_node = g.make_node("Loop", loop_inputs, output_count=2, op_name_scope="select_loop", skip_conversion=False)
+    loop_body = create_loop_body_graph(gather_input_ids, output_type, output_shape, trip_count_input_ids, rank, loop_node.name)
+    loop_node.set_body_graph_as_attr("body", loop_body)
     nodes.append(loop_node)
     return nodes
 
 
-def get_inputs_for_current_iteration(input_id, iter_index):
+def get_inputs_for_current_iteration(g, input_id, iter_index):
     nodes = []
-    op_name = utils.make_name("Gather")
-    cond_gather_out_name = port_name(op_name)
-    cond_gather_node = helper.make_node("Gather", [input_id, iter_index], [cond_gather_out_name],
-                                        name=op_name)
+    cond_gather_node = g.make_node("Gather", [input_id, iter_index])
     nodes.append(cond_gather_node)
 
-    op_name = utils.make_name("Squeeze")
-    cur_cond_val_out_name = port_name(op_name)
-    cur_cond_val_scalar_node = helper.make_node("Squeeze", [cond_gather_out_name], [cur_cond_val_out_name],
-                                                name=op_name, axes=[0])
+    cur_cond_val_scalar_node = g.make_node("Squeeze", [cond_gather_node.output[0]], attr={"axes": [0]})
     nodes.append(cur_cond_val_scalar_node)
 
-    return nodes, cur_cond_val_out_name
+    return nodes, cur_cond_val_scalar_node.output[0]
 
 
 def create_loop_body_graph(gather_input_ids, output_data_type, output_shape, trip_count_input_ids, rank, loop_name):
+    g = Graph([], output_shapes={}, dtypes={}, target=None, opset=None, extra_opset=None, output_names=[])
     nodes = []
     iter_name = utils.make_name("i")
     cond_name = utils.make_name("cond")
     fake_var_name = utils.make_name("fake_var")
-    graph_inputs = [
-        utils.make_onnx_inputs_outputs(iter_name, TensorProto.INT64, (1,)),  # iteration_num
-        utils.make_onnx_inputs_outputs(cond_name, TensorProto.BOOL, ()),  # condition
-        utils.make_onnx_inputs_outputs(fake_var_name, TensorProto.FLOAT, ())  # loop-carried dependency
-        ]
+
+    g.add_graph_input(iter_name, TensorProto.INT64, (1,))  # iteration_num
+    g.add_graph_input(cond_name, TensorProto.BOOL, ()),  # condition
+    g.add_graph_input(fake_var_name, TensorProto.FLOAT, ())  # loop-carried dependency
 
     # get the i'th value of condition
     cond_input_id = gather_input_ids[0]
-    new_nodes, cond_input_id_for_current_iter = get_inputs_for_current_iteration(cond_input_id, iter_name)
+    new_nodes, cond_input_id_for_current_iter = get_inputs_for_current_iteration(g, cond_input_id, iter_name)
     nodes.extend(new_nodes)
 
     # get the i'th value of true values
     true_input_id = gather_input_ids[1]
-    new_nodes, true_input_id_for_current_iter = get_inputs_for_current_iteration(true_input_id, iter_name)
+    new_nodes, true_input_id_for_current_iter = get_inputs_for_current_iteration(g, true_input_id, iter_name)
     nodes.extend(new_nodes)
 
 
     # get the i'th value of false values
     false_input_id = gather_input_ids[2]
-    new_nodes, false_input_id_for_current_iter = get_inputs_for_current_iteration(false_input_id, iter_name)
+    new_nodes, false_input_id_for_current_iter = get_inputs_for_current_iteration(g, false_input_id, iter_name)
     nodes.extend(new_nodes)
 
     input_ids_for_current_iter = [cond_input_id_for_current_iter, true_input_id_for_current_iter,
@@ -178,86 +159,87 @@ def create_loop_body_graph(gather_input_ids, output_data_type, output_shape, tri
     output_id = None
     rank = rank - 1
     if rank >= 1:
-        nodes_1 = create_loop_op(input_ids_for_current_iter, output_data_type, output_shape[1:],
+        nodes_1 = create_loop_op(g, input_ids_for_current_iter, output_data_type, output_shape[1:],
                                  trip_count_input_ids, rank)
         loop_1 = nodes_1[-1]
         output_id = loop_1.output[1]
         nodes.extend(nodes_1)
     elif rank == 0:
-        if_node, if_node_output_id = create_if_op(input_ids_for_current_iter, output_data_type, output_shape[1:])
+        if_node, if_node_output_id = create_if_op(g, input_ids_for_current_iter, output_data_type, output_shape[1:])
         output_id = if_node_output_id
         nodes.append(if_node)
 
     output_identity_name = utils.make_name("loop_output")
     loop_output_id = utils.port_name(output_identity_name)
-    loop_output_node = helper.make_node(
+    loop_output_node = g.make_node(
         'Identity',
         [output_id],
-        [loop_output_id],
+        outputs=[loop_output_id],
         name=output_identity_name
     )
     nodes.append(loop_output_node)
 
     cond_identity_name = utils.make_name("cond_output")
     cond_output_id = utils.port_name(cond_identity_name)
-    identity_node = helper.make_node(
+    identity_node = g.make_node(
         'Identity',
         [cond_name],
-        [cond_output_id],
+        outputs=[cond_output_id],
         name=cond_identity_name
     )
     nodes.append(identity_node)
 
     fake_var_identity_name = utils.make_name("fake_var_output")
     fake_var_output_id = utils.port_name(fake_var_identity_name)
-    identity_node = helper.make_node(
+    identity_node = g.make_node(
         'Identity',
         [fake_var_name],
-        [fake_var_output_id],
+        outputs=[fake_var_output_id],
         name=fake_var_identity_name
     )
     nodes.append(identity_node)
 
-    graph_outputs = [utils.make_onnx_inputs_outputs(cond_output_id, TensorProto.BOOL, ()),
-                     utils.make_onnx_inputs_outputs(fake_var_output_id, TensorProto.FLOAT, ()),
-                     utils.make_onnx_inputs_outputs(loop_output_id, output_data_type, output_shape[1:])]
+    g.set_nodes(nodes)
+    g.outputs = [cond_output_id, fake_var_output_id, loop_output_id]
+    g.set_dtype(cond_output_id, TensorProto.BOOL)
+    g.set_shape(cond_output_id, ())
+    g.set_dtype(fake_var_output_id, TensorProto.FLOAT)
+    g.set_shape(fake_var_output_id, ())
+    g.set_dtype(loop_output_id, output_data_type)
+    g.set_shape(loop_output_id, output_shape[1:])
 
-    body_graph = helper.make_graph(nodes, utils.make_name(loop_name + "-body-graph"), graph_inputs,
-                                   graph_outputs)
-    return body_graph
+    return g
 
 
-def create_if_op(input_ids, output_data_type, output_shape):
+def create_if_op(g, input_ids, output_data_type, output_shape):
     op_name = utils.make_name("If")
     true_graph = create_body_graph_for_if_branch(output_data_type, output_shape, input_ids[1], op_name)
     false_graph = create_body_graph_for_if_branch(output_data_type, output_shape, input_ids[2], op_name)
     out_name = port_name(op_name)
 
     # output a scalar
-    if_node = helper.make_node("If", [input_ids[0]], [out_name], name=op_name, then_branch=true_graph,
-                               else_branch=false_graph)
+    if_node = g.make_node("If", [input_ids[0]], outputs=[out_name], name=op_name, skip_conversion=False)
+    if_node.set_body_graph_as_attr("then_branch", true_graph)
+    if_node.set_body_graph_as_attr("else_branch", false_graph)
     return if_node, out_name
 
 
 def create_body_graph_for_if_branch(data_type, output_shape, chosen_cur_cond_val_out_name, op_name):
+    g = Graph([], output_shapes={}, dtypes={}, target=None, opset=None, extra_opset=None, output_names=[])
     nodes = []
-
     name = utils.make_name("Identity")
-    identity_node = helper.make_node(
+    identity_node = g.make_node(
         'Identity',
-        [chosen_cur_cond_val_out_name],
-        ['y'],
+        inputs=[chosen_cur_cond_val_out_name],
+        outputs=['y'],
         name=name
     )
     nodes.append(identity_node)
 
-    # create one output
-    y = utils.make_onnx_inputs_outputs('y', data_type, output_shape)
+    g.outputs = ["y"]
+    g.set_dtype("y", data_type)
+    g.set_shape("y", output_shape)
 
-    graph_def = helper.make_graph(
-        nodes,
-        utils.make_name(op_name +'-body-graph'),
-        [],
-        [y],
-    )
-    return graph_def
+    g.set_nodes(nodes)
+
+    return g

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -44,13 +44,7 @@ class Node(object):
         # dict to original attributes
         for a in node.attribute:
             self._attr[a.name] = a
-        # try to find a dtype for this node
-        dtype = graph.get_dtype(node.name)
-        if not dtype:
-            dtype = self._attr.get("dtype")
-            if dtype:
-                dtype = dtype.i
-        self._dtype = dtype
+
         self.data_format = self.get_attr("data_format")
         if self.data_format:
             self.data_format = self.data_format.s.decode("utf-8")
@@ -238,15 +232,6 @@ class Node(object):
         # track shapes in _output_shapes
         self.graph.set_shape(t.name, t.dims)
 
-    @property
-    def dtype(self):
-        """Return dtype."""
-        return self._dtype
-
-    @dtype.setter
-    def dtype(self, val):
-        """Set dtype."""
-        self._dtype = val
 
     def get_body_graphs(self):
         return self.graph.contained_graphs.get(self.name, None)
@@ -283,49 +268,33 @@ class Node(object):
         if attr:
             self._op.attribute.extend(attr)
 
-    def get_implicit_inputs(self, require_input_in_cur_graph=False):
+    def get_implicit_inputs(self, recursive=True):
         """Get implicit inputs if the node has attributes being GraphProto."""
-        body_graphs = [a.g for a in self.attr_onnx.values() if a.HasField('g')]
-        outer_scope_node_input_ids = set()
-        for sub_g in body_graphs:
-            outer_scope_node_input_ids |= self._get_implicit_inputs(sub_g)
+        output_available_in_cur_graph = set()
+        all_node_inputs = set()
 
-        if require_input_in_cur_graph:
-            # only find referenced node in current graph
-            implicit_inputs_in_current_graph = set()
-            for input_id in outer_scope_node_input_ids:
-                n = self.graph.get_node_by_output(input_id)
-                if n is None:
-                    if not self.graph.is_initializer(input_id):
-                        if input_id not in self.graph.inputs:
-                            continue
-                implicit_inputs_in_current_graph.add(input_id)
-            return implicit_inputs_in_current_graph
-        return outer_scope_node_input_ids
+        graphs = []
+        body_graphs = self.get_body_graphs()
+        if body_graphs:
+            graphs.extend(body_graphs.values())
 
-    @staticmethod
-    def _get_implicit_inputs(onnx_graph, recursive=True):
-        """Get implicit inputs for specified onnx graph."""
-        node_map = set()
-        for n in onnx_graph.node:
-            node_map |= set(n.output)
+        while graphs:
+            graph = graphs.pop()
+            for n in graph.get_nodes():
+                output_available_in_cur_graph |= set(n.output)
+                for i in n.input:
+                    all_node_inputs.add(i)
 
-        for n in onnx_graph.input:
-            node_map.add(n.name)
+                if recursive:
+                    b_graphs = n.get_body_graphs()
+                    if b_graphs:
+                        graphs.extend(b_graphs.values())
 
-        outer_scope_node_input_ids = set()
-        for n in onnx_graph.node:
-            for i in n.input:
-                if i not in node_map:
-                    outer_scope_node_input_ids.add(i)
+            # exclude graph inputs
+            for n in graph.inputs:
+                output_available_in_cur_graph.add(n)
 
-        if recursive:
-            for n in onnx_graph.node:
-                for attr in n.attribute:
-                    sub_g = attr.g
-                    if sub_g:
-                        outer_scope_node_input_ids |= Node._get_implicit_inputs(sub_g)
-
+        outer_scope_node_input_ids = all_node_inputs - output_available_in_cur_graph
         return outer_scope_node_input_ids
 
 
@@ -381,11 +350,10 @@ class Graph(object):
                         new_output_node = self.make_node("Identity", [new_out], outputs=[o],
                                                          op_name_scope="graph_outputs")
                         to_append.append(new_output_node)
-
+                        self.set_node_by_name(n)
                         self.copy_shape(o, new_out)
-                        self.set_dtype(new_out, self.get_dtype(o))
+                        self.copy_dtype(o, new_out)
 
-                self.set_node_by_name(n)
             ops.extend(to_append)
 
         self.set_nodes(ops)
@@ -445,6 +413,11 @@ class Graph(object):
             else:
                 raw_attr[a] = v
         onnx_node = helper.make_node(op_type, inputs, outputs, name=name, **raw_attr)
+
+        if op_type in ["If", "Loop", "Scan"]:
+            # we force the op containing inner graphs not skipped during conversion.
+            skip_conversion = False
+
         node = Node(onnx_node, self, skip_conversion=skip_conversion)
         if onnx_attrs:
             _ = [node.set_attr_onnx(a) for a in onnx_attrs]
@@ -479,7 +452,7 @@ class Graph(object):
         """Get node list."""
         return self._nodes
 
-    def get_node_by_output(self, output, search_in_parent_graphs=False):
+    def get_node_by_output(self, output, search_in_parent_graphs=True):
         """Get node by node output id recursively going through nested graphs.
         Args:
             search_in_parent_graphs: search in all parent graphs
@@ -548,36 +521,38 @@ class Graph(object):
 
     def add_graph_input(self, name, dtype=None, shape=None):
         """Add placeholder node as graph's input."""
-        if not dtype:
+        if dtype is None:
             dtype = self.get_dtype(name)
 
-        if not shape:
+        if shape is None:
             shape = self.get_shape(name)
 
         if name not in self.inputs:
-            utils.make_sure(dtype is not None, "input dtype should not be None")
-            utils.make_sure(shape is not None, "input shape should not be None")
+            utils.make_sure(shape is not None, "shape for input %s should not be None", name)
+            utils.make_sure(dtype is not None, "dtype for input %s should not be None", name)
+            # append firstly then the input can be retrieved
+            # to get/set shape/dtype.
+            self.inputs.append(name)
             self.set_shape(name, shape)
             self.set_dtype(name, dtype)
-            self.inputs.append(name)
         else:
             raise ValueError("graph input " + name + " already exists")
 
     def add_graph_output(self, name, dtype=None, shape=None):
         """Add node output as graph's output."""
-        if not dtype:
+        # todo(pengwa): check output existence
+        if dtype is None:
             dtype = self.get_dtype(name)
 
-        if not shape:
+        if shape is None:
             shape = self.get_shape(name)
 
         if name not in self.outputs:
-            utils.make_sure(shape is not None, "output shape should not be None")
-            utils.make_sure(dtype is not None, "output dtype should not be None")
-
+            utils.make_sure(shape is not None, "shape for output %s should not be None", name)
+            utils.make_sure(dtype is not None, "dtype for output %s should not be None", name)
+            self.outputs.append(name)
             self.set_shape(name, shape)
             self.set_dtype(name, dtype)
-            self.outputs.append(name)
         else:
             raise ValueError("graph output " + name + " already exists")
 
@@ -605,11 +580,13 @@ class Graph(object):
 
     def get_dtype(self, name):
         """Get dtype for node."""
-        return self._dtypes.get(name)
+        node = self.get_node_by_output(name, search_in_parent_graphs=True)
+        return node.graph._dtypes.get(name) if node else None
 
     def set_dtype(self, name, dtype):
         """Set dtype for node."""
-        self._dtypes[name] = dtype
+        node = self.get_node_by_output(name, search_in_parent_graphs=True)
+        node.graph._dtypes[name] = dtype
 
     def copy_dtype(self, src_name, dst_name):
         """Copy dtype from another node."""
@@ -618,8 +595,9 @@ class Graph(object):
 
     def get_shape(self, name):
         """Get shape for node."""
-        assert isinstance(name, six.text_type)
-        shape = self._output_shapes.get(name)
+        utils.make_sure(isinstance(name, six.text_type), "get_shape name is invalid type: %s", name)
+        node = self.get_node_by_output(name, search_in_parent_graphs=True)
+        shape = node.graph._output_shapes.get(name) if node else None
         if shape:
             for i, v in enumerate(shape):
                 if v is None:
@@ -628,13 +606,15 @@ class Graph(object):
             # default is -1.
             if shape[0] == -1:
                 shape[0] = utils.ONNX_UNKNOWN_DIMENSION
+            return shape
         return shape
 
     def set_shape(self, name, val):
         """Set new shape of node."""
         if isinstance(val, np.ndarray):
             val = val.tolist()
-        self._output_shapes[name] = val
+        node = self.get_node_by_output(name, search_in_parent_graphs=True)
+        node.graph._output_shapes[name] = val
 
     def copy_shape(self, input_name, output_name):
         """Copy shape from another node."""
@@ -960,15 +940,21 @@ class Graph(object):
             a set of nodes
         """
         res_set = set()
+        if not dest_node:
+            return res_set
+
         processing_set = set([dest_node])
         while processing_set:
             top_node = processing_set.pop()
             res_set.add(top_node)
-            implicit_inputs = [self.get_node_by_output(node_output) for node_output in top_node.get_implicit_inputs()]
-            for node in top_node.inputs + implicit_inputs:
+            all_inputs = top_node.input + list(top_node.get_implicit_inputs())
+            for input_id in all_inputs:
+                # we don't care about nested graph here, just handle current graph cropping.
+                node = self.get_node_by_output(input_id, search_in_parent_graphs=False)
                 if not node:
                     # some node (for example Scan) has optional inputs, which
                     # might has empty input.
+                    # subgraph might has input defined in outer graph
                     continue
                 if node not in res_set:
                     if input_checker and input_checker(node) is False:
@@ -1137,6 +1123,13 @@ class GraphUtil(object):
                 raise ValueError("failed to parse tensor value from Constant node")
 
         GraphUtil._parse_graph_input(g, graph_proto)
+
+        for n in g.get_nodes():
+            for attr_name, attr_val in n.attr.items():
+                if attr_val.HasField('g'):
+                    # it was assumed that the a.g has inferred shapes/dtypes.
+                    sub_g = GraphUtil.create_graph_from_onnx_graph(attr_val.g)
+                    n.set_body_graph_as_attr(attr_name, sub_g)
         return g
 
     @staticmethod

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1100,10 +1100,6 @@ class GraphUtil(object):
         output_shapes.update(shapes)
         output_dtypes.update(dtypes)
 
-        shapes, dtypes = GraphUtil._parse_shape_and_type_from_value_infos(graph_proto.input)
-        output_shapes.update(shapes)
-        output_dtypes.update(dtypes)
-
         non_const_nodes = []
         const_nodes = []
         for n in graph_proto.node:
@@ -1183,9 +1179,8 @@ class GraphUtil(object):
     @staticmethod
     def _parse_graph_input(g, graph_proto):
         """Get graph inputs not defined as initializers and put into Graph object."""
-        for input_value_info in graph_proto.input:
-            if g.is_initializer(input_value_info.name):
-                continue
-            shape = g.get_shape(input_value_info.name)
-            dtype = g.get_dtype(input_value_info.name)
-            g.add_graph_input(input_value_info.name, dtype, shape)
+        shapes, dtypes = GraphUtil._parse_shape_and_type_from_value_infos(graph_proto.input)
+        for name in shapes:
+            shape = shapes[name]
+            dtype = dtypes[name]
+            g.add_graph_input(name, dtype, shape)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -978,6 +978,9 @@ class Graph(object):
             a list of nodes
         """
         res_set = set()
+        if not outputs_name:
+            return list(res_set)
+
         for output in outputs_name:
             node = self.get_node_by_output(output)
             res_set = res_set.union(self._extract_sub_graph_nodes(node, input_checker))
@@ -994,8 +997,11 @@ class Graph(object):
 
     def delete_unused_nodes(self, outputs_name):
         """Delete nodes not in subgraph ending with output_names."""
-        related_nodes = self.extract_sub_graph_nodes(outputs_name)
-        self.set_nodes(related_nodes)
+        if outputs_name:
+            related_nodes = self.extract_sub_graph_nodes(outputs_name)
+            self.set_nodes(related_nodes)
+        else:
+            print("WARINING: outputs not specified, delete_unused_nodes not taking effect.")
 
 
 class GraphUtil(object):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -21,7 +21,8 @@ from tf2onnx.utils import port_name, find_opset
 from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
 
 
-# pylint: disable=broad-except
+# todo(pengwa): remove protected-access later
+# pylint: disable=broad-except,protected-access
 
 
 class Node(object):
@@ -357,6 +358,11 @@ class Graph(object):
             ops.extend(to_append)
 
         self.set_nodes(ops)
+
+    def create_new_graph_with_same_config(self):
+        """Create a clean graph inheriting current graph's configuration."""
+        return Graph([], output_shapes={}, dtypes={}, target=self._target, opset=self._opset,
+                     extra_opset=self._extra_opset, output_names=[])
 
     @property
     def opset(self):

--- a/tf2onnx/rewriter/__init__.py
+++ b/tf2onnx/rewriter/__init__.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 __all__ = [
     "custom_rnn_rewriter",
     "gru_rewriter",
+    "loop_rewriter",
     "loop_rewriter_base",
     "lstm_rewriter",
     "random_uniform",

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -12,11 +12,8 @@ import sys
 import traceback
 from onnx import onnx_pb
 import numpy as np
-from tf2onnx.graph import Graph
-from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase, Context
-from tf2onnx.rewriter.rnn_utils import is_tensor_array_gather_op, is_tensor_array_write_op
-from tf2onnx.rewriter.rnn_utils import BodyGraphDict, REWRITER_RESULT, SubGraphMetadata
+from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT
 from tf2onnx.tfonnx import utils
 
 
@@ -35,9 +32,6 @@ class CustomRnnContext(Context):
 
 
 class CustomRnnRewriter(LoopRewriterBase):
-    def __init__(self, g):
-        super(CustomRnnRewriter, self).__init__(g)
-
     def create_context(self):
         return CustomRnnContext()
 
@@ -130,7 +124,8 @@ class CustomRnnRewriter(LoopRewriterBase):
             for input_tensor_info in scan_props.scan_inputs:
                 scan_body_g.add_graph_input(input_tensor_info.id, input_tensor_info.dtype, input_tensor_info.shape)
 
-            scan_node = self._create_scan_node(context, scan_props, state_inputs_initial_values + scan_inputs_initial_values)
+            scan_node = self._create_scan_node(context, scan_props,
+                                               state_inputs_initial_values + scan_inputs_initial_values)
             if not scan_node:
                 log.error("failed to create scan node during rewrite")
                 return REWRITER_RESULT.FAIL

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -22,7 +22,6 @@ from tf2onnx.tfonnx import utils
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("tf2onnx.rewriter.custom_rnn_rewriter")
-INVLAID_INPUT_ID = "invalid:0"
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
 
@@ -30,45 +29,14 @@ INVLAID_INPUT_ID = "invalid:0"
 class CustomRnnContext(Context):
     def __init__(self):
         super(CustomRnnContext, self).__init__()
-        self.other_loop_vars = {}
         self.rnn_scope = None
-
-        self.output_tas = []
-        self.input_tas = []
         self.time_var = None
         self.iteration_var = None
-
-
-class TensorArrayProp(object):
-    def __init__(self):
-        self.index_input_id = None
-        self.data_input_id = None
-        self.output_id = None
-
-
-class ScanProperties(object):
-    def __init__(self, initial_state_and_scan_inputs, loop_state_inputs,
-                 loop_state_outputs, loop_scan_inputs, loop_scan_outputs):
-        self.initial_state_and_scan_inputs = initial_state_and_scan_inputs
-        self.loop_state_inputs = loop_state_inputs
-        self.loop_state_outputs = loop_state_outputs
-        self.loop_scan_inputs = loop_scan_inputs
-        self.loop_scan_outputs = loop_scan_outputs
 
 
 class CustomRnnRewriter(LoopRewriterBase):
     def __init__(self, g):
         super(CustomRnnRewriter, self).__init__(g)
-        self.rnn_input_pattern = \
-            OpTypePattern('TensorArrayReadV3', name='ta_read', inputs=[
-                OpTypePattern("Enter", name="ta_enter", inputs=[
-                    OpTypePattern("TensorArrayV3")
-                ]),
-                OpTypePattern('*'),
-                OpTypePattern("Enter", name="ta_scatter_enter", inputs=[
-                    OpTypePattern("TensorArrayScatterV3", name="ta_input_scatter")
-                ]),
-            ])
 
     def create_context(self):
         return CustomRnnContext()
@@ -101,8 +69,8 @@ class CustomRnnRewriter(LoopRewriterBase):
         iteration_counter_name = context.while_context_scope + "iteration_counter"
 
         found_time = False
-        is_rnn_out_ta = True
-        for enter_name, val in context.loop_variables.items():
+        is_rnn_out_ta = None
+        for val in context.loop_properties.all_variables.values():
             enter_input_node = self.g.get_node_by_output(val.enter_input_id)
             if val.is_tensor_array:
                 ta_name = enter_input_node.get_attr("tensor_array_name").s.decode("utf-8")
@@ -113,10 +81,9 @@ class CustomRnnRewriter(LoopRewriterBase):
                 context.time_var = val
             elif enter_input_node.name == iteration_counter_name:
                 context.iteration_var = val
-            else:
-                context.other_loop_vars[enter_name] = val
 
-        if not (found_time and is_rnn_out_ta):
+
+        if not found_time or is_rnn_out_ta is False:
             log.debug("this should not be a dynamic_rnn loop, found_time: %s, is_rnn_out_ta: %s",
                       found_time, is_rnn_out_ta)
             return False
@@ -131,262 +98,109 @@ class CustomRnnRewriter(LoopRewriterBase):
             return False
 
         self._parse_time_var(context)
-        self._parse_output_ta(context)
-        self._parse_input_ta(context)
 
-        if not (context.input_tas or context.output_tas):
-            log.debug("this should not be a dynamic_rnn loop, no ta input or output are found")
+        if not context.loop_properties.tensor_array_inputs:
+            log.debug("this should not be a dynamic_rnn loop, no ta input is found")
             return False
         return True
 
     def rewrite(self, context):
         log.debug("enter rewrite function")
-        scan_node = None
         try:
-            to_remove = self._cut_off_connection_for_cell(context)
-            all_nodes = self.g.get_nodes()
-            for n in set(to_remove):
-                if n in all_nodes:
-                    all_nodes.remove(n)
-            self.g.set_nodes(all_nodes)
+            scan_props = context.loop_properties
+            nodes_to_append = []
 
-            scan_props, nodes_to_append = self._compose_cell_inputs_and_outputs(context)
-            scan_node = self._create_scan_node(context, scan_props)
+            state_inputs_initial_values = []
+            for state_input in scan_props.state_inputs_initial_values:
+                nodes = self._adapt_scan_sequence_input_or_output("input", state_input, False)
+                state_inputs_initial_values.append(nodes[-1].output[0])
+                nodes_to_append.extend(nodes)
+
+            scan_inputs_initial_values = []
+            for scan_input in scan_props.scan_inputs_initial_values:
+                nodes = self._adapt_scan_sequence_input_or_output("input", scan_input, False)
+                scan_inputs_initial_values.append(nodes[-1].output[0])
+                nodes_to_append.extend(nodes)
+
+            cell_g_info = context.cell_graph
+            scan_body_g = LoopRewriterBase.construct_graph_from_nodes(self.g, cell_g_info.nodes, cell_g_info.outputs)
+            for input_tensor_info in scan_props.state_inputs:
+                scan_body_g.add_graph_input(input_tensor_info.id, input_tensor_info.dtype, input_tensor_info.shape)
+
+            for input_tensor_info in scan_props.scan_inputs:
+                scan_body_g.add_graph_input(input_tensor_info.id, input_tensor_info.dtype, input_tensor_info.shape)
+
+            scan_node = self._create_scan_node(context, scan_props, state_inputs_initial_values + scan_inputs_initial_values)
             if not scan_node:
                 log.error("failed to create scan node during rewrite")
                 return REWRITER_RESULT.FAIL
+
+            scan_node.set_body_graph_as_attr("body", scan_body_g)
             nodes_to_append.append(scan_node)
-
-            _ = self._extract_and_register_cell_graph_info(context, scan_props, scan_node)
-
             to_append = self._connect_scan_with_output(context, scan_node)
             nodes_to_append.extend(to_append)
+
             all_nodes = self.g.get_nodes()
             all_nodes.extend(nodes_to_append)
             self.g.set_nodes(all_nodes)
 
             return REWRITER_RESULT.OK
+
         except Exception as ex:
             tb = traceback.format_exc()
-            if scan_node and BodyGraphDict.has_body_graph_info(scan_node.name):
-                BodyGraphDict.pop_body_graph_info(scan_node.name)
-                log.error("remove scan node body graph from dict")
-            log.error("rewrite failed, due to exception: %s, details:%s", ex, tb)
+            log.error("custom rnn rewrite failed, due to exception: %s, details:%s", ex, tb)
             return REWRITER_RESULT.FAIL
 
     def _parse_time_var(self, context):
         time_var = context.time_var
         log.debug("time var %s - enter input id (%s) shape: %s, output (%s) shape: %s", time_var.enter_name,
                   time_var.enter_input_id, self.g.get_shape(time_var.enter_input_id),
-                  time_var.switch_true_identity_output_id, self.g.get_shape(time_var.switch_true_identity_output_id))
+                  time_var.switch_true_identity_output.id, time_var.switch_true_identity_output.shape)
 
-    def _parse_output_ta(self, context):
-        for enter_name, loop_var in context.loop_variables.items():
-            if not loop_var.is_tensor_array:
-                continue
-
-            output_ta = TensorArrayProp()
-            output_ta.data_input_id = loop_var.next_iteration_input_id
-
-            output_ta.index_input_id = loop_var.ta_index_id
-            if loop_var.exit_output_id:
-                exit_consumers = self.g.find_output_consumers(loop_var.exit_output_id)
-                ta_gather_node = [n for n in exit_consumers if is_tensor_array_gather_op(n)][0]
-                output_ta.output_id = ta_gather_node.output[0]
-
-            context.output_tas.append(output_ta)
-            log.debug("output ta %s - data input (%s) shape: %s, output (%s) shape: %s", enter_name,
-                      output_ta.data_input_id, self.g.get_shape(output_ta.data_input_id),
-                      output_ta.output_id, self.g.get_shape(output_ta.output_id))
-
-    def _parse_input_ta(self, context):
-        matcher = GraphMatcher(self.rnn_input_pattern, allow_reorder=True)
-        match_results = list(matcher.match_ops(self.g.get_nodes()))
-        match_results = [r for r in match_results if r.get_op("ta_input_scatter").name.startswith(context.rnn_scope)]
-        for match in match_results:
-            ta_input_scatter = match.get_op("ta_input_scatter")
-            # the 3rd input of scatter is the value
-            input_ta = TensorArrayProp()
-
-            # dynamic_rnn specific approach.
-            input_ta.data_input_id = ta_input_scatter.input[2]
-
-            ta_read_node = match.get_op("ta_read")
-            input_ta.index_input_id = ta_read_node.input[1]
-            input_ta.output_id = match.get_op("ta_read").output[0]
-
-            input_shape = self.g.get_shape(input_ta.data_input_id)
-            output_shape = self.g.get_shape(input_ta.output_id)
-            if output_shape is None and input_shape is not None:
-                self.g.set_shape(input_ta.output_id, input_shape[1:])
-
-            context.input_tas.append(input_ta)
-
-            log.debug("input ta %s - data input (%s) shape: %s, output (%s) shape: %s", ta_read_node.name,
-                      input_ta.data_input_id, self.g.get_shape(input_ta.data_input_id),
-                      input_ta.output_id, self.g.get_shape(input_ta.output_id))
-
-    def _cut_off_connection_for_cell(self, context):
-        nodes_to_remove = []
-        all_vars = [context.time_var]
-        all_vars += [val for _, val in context.other_loop_vars.items()]
-        for val in all_vars:
-            # remove the node to cut off a starting node of the cell (e.g. loop body).
-            nodes_to_remove.append(self.g.get_node_by_output(val.switch_true_identity_output_id))
-
-            # connect NextIteration to an invalid node, to cut off a ending node of the cell.
-            next_iter_nodes = [n for n in self.g.get_nodes() if n.type == "NextIteration"]
-            self.g.replace_all_inputs(next_iter_nodes, val.next_iteration_input_id, INVLAID_INPUT_ID)
-
-        for input_ta in context.input_tas:
-            # remove the node to cut off connection between scan_input and the cell.
-            nodes_to_remove.append(self.g.get_node_by_output(input_ta.output_id))
-
-        for output_ta in context.output_tas:
-            # remove the node to cut off connection between scan_output and the cell.
-            ta_write_nodes = [n for n in self.g.get_nodes() if is_tensor_array_write_op(n)]
-            self.g.replace_all_inputs(ta_write_nodes, output_ta.data_input_id, INVLAID_INPUT_ID)
-
-        return nodes_to_remove
-
-    def _compose_cell_inputs_and_outputs(self, context):
-        log.debug("_compose_cell_inputs_and_outputs")
-
-        nodes_to_append = []
-        loop_state_inputs = []
-        loop_state_outputs = []
-        initial_state_and_scan_inputs = []
-
-        # change time shape to {1} since current Scan does not support
-        time_var, to_append = self._adapt_time_var_as_workaround(context.time_var)
-        nodes_to_append.extend(to_append)
-
-        log.debug("prepare cell state inputs")
-        vars_to_iterate = [time_var] + [val for _, val in context.other_loop_vars.items()]
-        for var in vars_to_iterate:
-            nodes = self._adapt_scan_sequence_input_or_output("input", var.enter_input_id, False)
-            var.enter_input_id = nodes[-1].output[0]
-            nodes_to_append.extend(nodes)
-
-            loop_state_inputs.append(var.switch_true_identity_output_id)
-            loop_state_outputs.append(var.next_iteration_input_id)
-            initial_state_and_scan_inputs.append(var.enter_input_id)
-
-        log.debug("prepare cell scan inputs")
-        loop_scan_inputs = []
-        for input_ta in context.input_tas:
-            nodes = self._adapt_scan_sequence_input_or_output("input_ta", input_ta.data_input_id, False)
-            input_ta.data_input_id = nodes[-1].output[0]
-            nodes_to_append.extend(nodes)
-
-            loop_scan_inputs.append(input_ta.output_id)
-            initial_state_and_scan_inputs.append(input_ta.data_input_id)
-
-        log.debug("prepare cell scan outputs")
-        loop_scan_outputs = []
-        for output_ta in context.output_tas:
-            loop_scan_outputs.append(output_ta.data_input_id)
-
-        scan_props = ScanProperties(initial_state_and_scan_inputs, loop_state_inputs, loop_state_outputs,
-                                    loop_scan_inputs, loop_scan_outputs)
-
-        return scan_props, nodes_to_append
-
-    def _create_scan_node(self, context, scan_props):
+    def _create_scan_node(self, context, scan_props, init_values):
         log.debug("create scan node")
+        # reuse original output connection id (e.g. Exit_XXX), so we don't need set shape.
+        loop_outputs_shapes = []
+        loop_outputs_dtypes = []
+        for tensor_value_info in scan_props.state_outputs_exits + scan_props.scan_outputs_exits:
+            if tensor_value_info.id:
+                loop_outputs_shapes.append([1] + self.g.get_shape(tensor_value_info.id))
+                loop_outputs_dtypes.append(self.g.get_dtype(tensor_value_info.id))
+            else:
+                loop_outputs_shapes.append(None)
+                loop_outputs_dtypes.append(None)
+
         # here we did not give the sequence_length, because
         # current batch size is 1, not original batch size
         # original seq_length will be used by the loop body of Scan op.
-        scan_node = self.g.make_node("Scan", [""] + scan_props.initial_state_and_scan_inputs,
-                                     attr={"num_scan_inputs": len(scan_props.loop_scan_inputs)},
-                                     output_count=len(scan_props.loop_state_outputs + scan_props.loop_scan_outputs),
-                                     skip_conversion=True)
-
-        # the first state var is time-iterator.
-        index = 0
-        time_input_shape = self.g.get_shape(scan_node.input[1])
-        time_input_dtype = self.g.get_dtype(scan_node.input[1])
-
-        log.debug("_create_scan_node - set scan state_output shape for %s[%s]:%s",
-                  scan_node.name, index, time_input_shape)
-        self.g.set_shape(scan_node.output[index], time_input_shape)
-        self.g.set_dtype(scan_node.output[index], time_input_dtype)
-        index += 1
-
-        # for other state vars
-        state_input_shape = self.g.get_shape(scan_node.input[2])
-        state_input_dtype = self.g.get_dtype(scan_node.input[2])
-        for i in range(len(scan_props.loop_state_outputs) - 1):
-            log.debug("_create_scan_node - set scan state_output shape for %s[%s]:%s",
-                      scan_node.name, index, state_input_shape)
-            self.g.set_shape(scan_node.output[index], state_input_shape)
-            self.g.set_dtype(scan_node.output[index], state_input_dtype)
-            index += 1
-
-        last_scan_input_shape = self.g.get_shape(scan_node.input[-1])
-        batch = last_scan_input_shape[0] # should be 1
-        time = last_scan_input_shape[1]
-        for i in range(len(scan_props.loop_scan_outputs)):
-            scan_out_dtype = self.g.get_dtype(scan_props.loop_scan_outputs[i])
-            output_shape = self.g.get_shape(scan_props.loop_scan_outputs[i])
-            scan_output_shape = [batch, time] + output_shape
-            log.debug("scan output [%s] has shape %s, batch:%s, time: %s, cell output shape: %s",
-                      scan_props.loop_scan_outputs[i], scan_output_shape, batch, time, output_shape)
-            log.debug("_create_scan_node - set scan scan_output shape for %s[%s]:%s",
-                      scan_node.name, index, scan_output_shape)
-            self.g.set_shape(scan_node.output[index], scan_output_shape)
-            self.g.set_dtype(scan_node.output[index], scan_out_dtype)
-            index += 1
+        scan_node = self.g.make_node("Scan", [""] + init_values, op_name_scope="custom_rnn_scan",
+                                     attr={"num_scan_inputs": len(scan_props.scan_inputs)},
+                                     output_count=len(scan_props.state_outputs + scan_props.scan_outputs),
+                                     shapes=loop_outputs_shapes, dtypes=loop_outputs_dtypes,
+                                     skip_conversion=False)
 
         return scan_node
-
-    def _extract_and_register_cell_graph_info(self, context, scan_props, scan_node):
-        log.debug("_extract_cell_graph_nodes")
-
-        sub_graph_inputs = scan_props.loop_state_inputs + scan_props.loop_scan_inputs
-        sub_graph_outputs = scan_props.loop_state_outputs + scan_props.loop_scan_outputs
-        body_graph_meta = SubGraphMetadata(self.g, sub_graph_inputs, sub_graph_outputs,
-                                           scan_props.initial_state_and_scan_inputs)
-
-        # according to input and output, find the body graph
-        nodes, enter_nodes = self.find_subgraph(body_graph_meta, self.g)
-        other_enter_input_ids = []
-        for enter_node in enter_nodes:
-            # connect Enter's output to Enter's input
-            self.g.replace_all_inputs(self.g.get_nodes(), enter_node.output[0], enter_node.input[0])
-
-            nodes = self.g._extract_sub_graph_nodes(self.g.get_node_by_output(enter_node.input[0]))
-
-            other_enter_input_ids.append(enter_node.input[0])
-
-        body_graph_meta.other_enter_input_ids = other_enter_input_ids
-
-        log.debug("add body graph meta data into store")
-        BodyGraphDict.add_body_graph_info(scan_node.name, body_graph_meta)
-        return nodes
 
     def _connect_scan_with_output(self, context, scan_node):
         log.debug("connect scan output with the graph")
 
-        index = 1 # ignore the 1st input (time-iterator)
+        index = 0
         nodes_to_append = []
-        for _, val in context.other_loop_vars.items():
-            var_output_id = val.exit_output_id
-            if var_output_id:
+        for out_tensor_value_info in context.loop_properties.state_outputs_exits:
+            if out_tensor_value_info.id:
                 nodes = self._adapt_scan_sequence_input_or_output("state_output_reshape",
                                                                   scan_node.output[index], True)
                 nodes_to_append.extend(nodes)
-                self.g.replace_all_inputs(self.g.get_nodes(), var_output_id, nodes[-1].output[0])
+                self.g.replace_all_inputs(self.g.get_nodes(), out_tensor_value_info.id, nodes[-1].output[0])
 
             index += 1
 
-        for output_ta in context.output_tas:
-            ta_final_output_id = output_ta.output_id
-            if ta_final_output_id:
+        for out_tensor_value_info in context.loop_properties.scan_outputs_exits:
+            if out_tensor_value_info.id:
                 nodes = self._adapt_scan_sequence_input_or_output("scan_output_reshape",
                                                                   scan_node.output[index], True)
                 nodes_to_append.extend(nodes)
-                self.g.replace_all_inputs(self.g.get_nodes(), ta_final_output_id, nodes[-1].output[0])
+                self.g.replace_all_inputs(self.g.get_nodes(), out_tensor_value_info.id, nodes[-1].output[0])
             index += 1
 
         return nodes_to_append
@@ -442,126 +256,3 @@ class CustomRnnRewriter(LoopRewriterBase):
         log.debug("create Reshape for scan output %s, with output shape %s",
                   reshape_node.output[0], new_shape)
         return nodes_to_add
-
-    # in theory, time var can be a scalar, but in current implementation of runtime, it could not be handled
-    # correctly, so we unsqueeze it to a list containing a single element.
-    def _adapt_time_var_as_workaround(self, var):
-        log.debug("_adapt_time_var_as_workaround")
-        nodes_to_append = []
-        # change time shape to {1} since current Scan does not support
-        time_init_node = self._create_unsqueeze_node("time_var_init", var.enter_input_id)
-        nodes_to_append.append(time_init_node)
-        var.enter_input_id = time_init_node.output[0]
-
-        time_output_node = self._create_unsqueeze_node("time_var_output", var.next_iteration_input_id)
-        nodes_to_append.append(time_output_node)
-        var.next_iteration_input_id = time_output_node.output[0]
-
-        time_input_node = self._create_squeeze_node("time_var_input", var.switch_true_identity_output_id)
-        nodes_to_append.append(time_input_node)
-        self.g.replace_all_inputs(self.g.get_nodes(), var.switch_true_identity_output_id, time_input_node.output[0])
-        self.g.set_shape(var.switch_true_identity_output_id, [1] + self.g.get_shape(var.switch_true_identity_output_id))
-
-        return var, nodes_to_append
-
-    def _create_unsqueeze_node(self, target_name, input_id):
-        input_shape = self.g.get_shape(input_id)
-        utils.make_sure(input_shape is not None, input_id + "'s shape is none")
-        output_shape = [1] + input_shape
-        unsqueeze_node = self.g.make_node("Unsqueeze", [input_id], attr={"axes": [0]},
-                                          shapes=[output_shape], dtypes=[self.g.get_dtype(input_id)],
-                                          op_name_scope=target_name)
-
-        return unsqueeze_node
-
-    def _create_squeeze_node(self, target_name, input_id):
-        input_shape = self.g.get_shape(input_id)
-        utils.make_sure(input_shape is not None, input_id + "'s shape is none")
-        output_shape = list(input_shape)[1:]
-        squeeze_node = self.g.make_node("Squeeze", [input_id], attr={"axes": [0]},
-                                        shapes=[output_shape], dtypes=[self.g.get_dtype(input_id)],
-                                        op_name_scope=target_name)
-
-        return squeeze_node
-    # end of time var workaround
-
-
-class CustomRnnLateRewriter(object):
-    def __init__(self, g):
-        self.g = g
-
-    def rewrite(self):
-        log.debug("enter custom rnn late rewriter")
-        nodes = self.g.get_nodes()
-        nodes_to_remove = []
-        for scan_node in nodes:
-            if scan_node.type != "Scan":
-                continue
-            log.debug("late write for scan node %s", scan_node.name)
-            num_scan_inputs = scan_node.get_attr("num_scan_inputs").i
-            if not BodyGraphDict.has_body_graph_info(scan_node.name):
-                continue
-
-            body_graph_meta = BodyGraphDict.pop_body_graph_info(scan_node.name)
-            onnx_nodes, _ = LoopRewriterBase.find_subgraph(body_graph_meta, self.g)
-
-            log.debug("start creating body graph for scan node %s ", scan_node.name)
-            const_nodes = [n for n in onnx_nodes if n.type in ("Const", "ConstV2")]
-            for n in const_nodes:
-                # when set nodes, Const should be removed, they need be replaced as initializers.
-                onnx_nodes.remove(n)
-
-            onnx_nodes = set(onnx_nodes)
-            nodes_to_remove.extend(onnx_nodes)
-
-            ops = []
-            for op in onnx_nodes:
-                onnx_op = op.op
-                ops.append(onnx_op)
-
-            body_g = Graph(ops, output_shapes=self.g._output_shapes, dtypes=self.g._dtypes)
-
-            log.debug("start preparing body graph inputs nodes")
-            temp_nodes = body_g.get_nodes()
-            i = 0
-            input_count = len(body_graph_meta.input_ids)
-            for input_name, init_input_id in zip(body_graph_meta.input_ids, body_graph_meta.initial_input_ids):
-                shape = body_g.get_shape(input_name)
-                dtype = body_g.get_dtype(input_name)
-                if shape is None:
-                    shape = self.g.get_shape(init_input_id)
-                    if i >= input_count - num_scan_inputs:
-                        loop_input_shape = list(shape)[2:]  # delete [1, time,]
-                    else:
-                        loop_input_shape = list(shape)
-                else:
-                    loop_input_shape = list(shape)
-
-                body_g.add_graph_input(input_name, dtype, loop_input_shape)
-                i += 1
-
-            log.debug("start preparing body graph outputs nodes")
-            new_output_names = []
-            for o in body_graph_meta.output_ids:
-                # insert identity node, since sometimes we need output same output_id as state_output
-                # and scan_out, but ONNX don't allow the same output_id appeared more than once as
-                # output node.
-                node = body_g.make_node("Identity", inputs=[o], shapes=[body_g.get_shape(o)],
-                                        dtypes=[body_g.get_dtype(o)])
-                new_output_names.append(node.output[0])
-                temp_nodes.append(node)
-
-            body_g.set_nodes(temp_nodes)
-            body_g.topological_sort(body_g.get_nodes())
-
-            log.debug("start make graph based on body graph nodes")
-            body_g.outputs = new_output_names
-            graph = body_g.make_graph("scan body graph", graph_name=scan_node.name + "_body_graph")
-            scan_node.set_attr("body", graph)
-
-        # remove nodes in body graph from g
-        for n in set(nodes_to_remove):
-            if n in nodes:
-                nodes.remove(n)
-
-        return nodes

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -63,10 +63,10 @@ class GRUUnitRewriter(UnitRewriterBase):
         return cell_node.name[:cell_node.name.rfind("/")]
 
     def get_weight_and_bias(self, match):
-        gate_kernel = get_weights_from_const_node(match.get_op("gate_kernel"))
-        gate_bias = get_weights_from_const_node(match.get_op("gate_bias"))
-        hidden_kernel = get_weights_from_const_node(match.get_op("hidden_kernel"))
-        hidden_bias = get_weights_from_const_node(match.get_op("hidden_bias"))
+        gate_kernel = get_weights_from_const_node(self.g, match.get_op("gate_kernel"))
+        gate_bias = get_weights_from_const_node(self.g, match.get_op("gate_bias"))
+        hidden_kernel = get_weights_from_const_node(self.g, match.get_op("hidden_kernel"))
+        hidden_bias = get_weights_from_const_node(self.g, match.get_op("hidden_bias"))
         if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
             log.debug("rnn weights check failed, skip")
             return None

--- a/tf2onnx/rewriter/grublock_rewriter.py
+++ b/tf2onnx/rewriter/grublock_rewriter.py
@@ -53,10 +53,10 @@ class GRUBlockUnitRewriter(GRUUnitRewriter):
         node = match.get_op("GRUBlockCell")
         # from tf, it can be known that, the inputs index and meaning of input data is:
         # 0-input, 1-state, 2-gate_kernel, 3-hidden_kernel, 4-gate_bias, 5-hidden_bias
-        gate_kernel = get_weights_from_const_node(node.inputs[2].inputs[0])
-        gate_bias = get_weights_from_const_node(node.inputs[4].inputs[0])
-        hidden_kernel = get_weights_from_const_node(node.inputs[3].inputs[0])
-        hidden_bias = get_weights_from_const_node(node.inputs[5].inputs[0])
+        gate_kernel = get_weights_from_const_node(self.g, node.inputs[2].inputs[0])
+        gate_bias = get_weights_from_const_node(self.g, node.inputs[4].inputs[0])
+        hidden_kernel = get_weights_from_const_node(self.g, node.inputs[3].inputs[0])
+        hidden_bias = get_weights_from_const_node(self.g, node.inputs[5].inputs[0])
         if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
             log.debug("rnn weights check failed, skip")
             return None

--- a/tf2onnx/rewriter/loop_rewriter.py
+++ b/tf2onnx/rewriter/loop_rewriter.py
@@ -1,0 +1,138 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+tf2onnx.rewriter.loop_rewriter - generic loop support
+"""
+
+from __future__ import division
+from __future__ import print_function
+import logging
+import sys
+import traceback
+from onnx import onnx_pb, TensorProto
+import numpy as np
+from tf2onnx.graph import Graph
+from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
+from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase, Context
+from tf2onnx.rewriter.rnn_utils import is_tensor_array_gather_op, is_tensor_array_write_op
+from tf2onnx.rewriter.rnn_utils import BodyGraphDict, REWRITER_RESULT, SubGraphMetadata
+from tf2onnx.tfonnx import utils
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("tf2onnx.rewriter.loop_rewriter")
+
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
+
+
+class LoopRewriter(LoopRewriterBase):
+    def __init__(self, g):
+        super(LoopRewriter, self).__init__(g)
+
+    def create_context(self):
+        return Context()
+
+    def run(self):
+        log.debug("enter loop rewriter")
+        return self.run_internal()
+
+    def need_rewrite(self, context):
+        return True
+
+    def rewrite(self, context):
+        log.debug("enter rewrite function")
+        loop_node = None
+        try:
+            loop_props = context.loop_properties
+            cell_g_info = context.cell_graph
+            cond_g_info = context.cond_graph
+
+            # todo(pengwa): we don't check the case where loop body won't be executed at all.
+
+            ## create Loop body graph with existing nodes
+
+            # replace condition graph's inputs to be cell graph's outputs, because we want condition graph
+            # to consumer cell graph outputs.
+            for loop_var in cond_g_info.dependent_vars:
+                self.g.replace_all_inputs(cond_g_info.nodes, loop_var.switch_true_identity_output.id,
+                                          loop_var.next_iteration_input.id)
+
+            body_nodes = set(cell_g_info.nodes + cond_g_info.nodes)
+            body_outputs = cond_g_info.outputs + cell_g_info.outputs
+            loop_body_g = LoopRewriterBase.construct_graph_from_nodes(self.g, body_nodes, body_outputs)
+
+            # create loop body graph inputs
+            loop_body_g.add_graph_input(utils.make_name("i"), TensorProto.INT64, ())
+            loop_body_g.add_graph_input(utils.make_name("cond"), TensorProto.BOOL, ())
+            for i, tensor_value_info in enumerate(loop_props.state_inputs):
+                input_name = tensor_value_info.id
+                if input_name is None:
+                    # if the variable is not used in the body graph, then we created a fake one,
+                    # the same type and shape as its corresponding output.
+                    out_tensor_value_info = loop_props.state_outputs[i]
+                    dtype = out_tensor_value_info.dtype
+                    shape = out_tensor_value_info.shape
+                    input_name = utils.make_name("unused_state_input_")
+                else:
+                    dtype = tensor_value_info.dtype
+                    shape = tensor_value_info.shape
+
+                loop_body_g.add_graph_input(input_name, dtype, shape)
+
+            body_nodes_to_append = []
+            for input_ta in loop_props.tensor_array_inputs:
+                # Loop does not have scan inputs, so we use Gather to get data for each iteration.
+                unsqueezed_index_node = loop_body_g.make_node("Unsqueeze", [input_ta.index_input_id], attr={"axes": [0]})
+                body_nodes_to_append.append(unsqueezed_index_node)
+                gather_node = loop_body_g.make_node("Gather", [input_ta.data_input_id, unsqueezed_index_node.output[0]])
+                body_nodes_to_append.append(gather_node)
+                data_node = loop_body_g.make_node("Squeeze", [gather_node.output[0]], attr={"axes": [0]})
+                body_nodes_to_append.append(data_node)
+
+                loop_body_g.replace_all_inputs(loop_body_g.get_nodes(), input_ta.consumer.id, data_node.output[0])
+
+            body_nodes = loop_body_g.get_nodes()
+            body_nodes.extend(body_nodes_to_append)
+            loop_body_g.set_nodes(body_nodes)
+
+
+            ## create Loop node
+            loop_node = self._create_loop_node(context, loop_props)
+            if not loop_node:
+                log.error("failed to create loop node during rewrite")
+                return REWRITER_RESULT.FAIL
+            loop_node.set_body_graph_as_attr("body", loop_body_g)
+
+            all_nodes = self.g.get_nodes()
+            all_nodes.append(loop_node)
+            self.g.set_nodes(all_nodes)
+
+            log.debug("rewrite successfully")
+            return REWRITER_RESULT.OK
+
+        except Exception as ex:
+            tb = traceback.format_exc()
+            log.error("loop rewrite failed, due to exception: %s, details:%s", ex, tb)
+            return REWRITER_RESULT.FAIL
+
+    def _create_loop_node(self, context, loop_props):
+        # reuse original output connection id (e.g. Exit_XXX), so we don't need set shape.
+        loop_outputs = []
+        for tensor_value_info in loop_props.state_outputs_exits + loop_props.scan_outputs_exits:
+            if tensor_value_info.id:
+                loop_outputs.append(tensor_value_info.id)
+            else:
+                loop_outputs.append(utils.make_name("unused_loop_output_"))
+
+        # trip count and cond are not used, giving them values just because bug
+        # (https://github.com/Microsoft/onnxruntime/issues/255) of onnxruntime.
+        trip_cnt = self.g.make_const(utils.make_name("trip_count"), np.array(sys.maxsize, dtype=np.int64))
+        cond = self.g.make_const(utils.make_name("cond"), np.array(True, dtype=np.bool))
+        loop_node = self.g.make_node("Loop", [trip_cnt.output[0]] + [cond.output[0]] +
+                                     loop_props.state_inputs_initial_values,  # ONNX Loop support state inputs only
+                                     outputs=loop_outputs, op_name_scope="generic_loop",
+                                     skip_conversion=False)
+
+        return loop_node

--- a/tf2onnx/rewriter/loop_rewriter_base.py
+++ b/tf2onnx/rewriter/loop_rewriter_base.py
@@ -10,39 +10,180 @@ from __future__ import print_function
 import copy
 import logging
 from collections import deque
+from tf2onnx import utils
+from tf2onnx.graph import Node, Graph, GraphUtil
+from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.rnn_utils import is_loopcond_op, is_tensor_array_op, is_tensor_array_write_op
-from tf2onnx.rewriter.rnn_utils import BodyGraphDict, REWRITER_RESULT
+from tf2onnx.rewriter.rnn_utils import is_tensor_array_gather_op, is_tensor_array_write_op
+from tf2onnx.rewriter.rnn_utils import BodyGraphDict, REWRITER_RESULT, SubGraphMetadata
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("tf2onnx.rewriter.loop_rewriter_base")
+INVALID_INPUT_ID = utils.make_name("invalid_input_id")
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
 
-class Context:
+class Context(object):
     def __init__(self):
-        self.need_keep_nodes = []
         self.while_context_scope = None
-        self.loop_variables = {}
+        self.loop_properties = LoopProperties()
+        self.loop_cond = None
+
+        self.cell_graph = None  # GraphInfo of cell graph
+        self.cond_graph = None  # GraphInfo of condition graph
 
 
-class LoopVariable:
+class GraphInfo(object):
+    def __init__(self, ops, inputs, outputs):
+        self.nodes = ops
+        self.inputs = inputs  # list of TensorValueInfo in order
+        self.outputs = outputs  # list of TensorValueInfo in order
+        self.dependent_vars = None
+
+
+class LoopProperties(object):
+    def __init__(self):
+        # use enter name as key, they are initial inputs.
+        # we don't use enter_input_id because it might be
+        # used as initial input for more than one Enter nodes.
+        self.state_variables = {}
+        self.scan_variables = {}
+
+        self.tensor_array_inputs = []  # list of type InputTensorArray
+
+    def add_variable(self, var):
+        utils.make_sure(var.enter_name not in self.scan_variables,
+                        "variable %s already exists as scan variable.", var.enter_name)
+        utils.make_sure(var.enter_name not in self.state_variables,
+                        "variable %s already exists as state variable.", var.enter_name)
+        if not var.is_tensor_array:
+            self.state_variables[var.enter_name] = var
+        else:
+            self.scan_variables[var.enter_name] = var
+
+    @property
+    def all_variables(self):
+        items = self.state_variables.copy()
+        items.update(self.scan_variables)
+        return items
+
+    # state inputs and outputs are in pairs, even though some outputs are not depending on corresponding input, 
+    # we leave the input id be None.
+    @property
+    def state_inputs(self):
+        return [v.switch_true_identity_output for v in self.state_variables.values()]
+
+    @property
+    def state_inputs_initial_values(self):
+        return [v.enter_input_id for v in self.state_variables.values()]
+
+    @property
+    def state_outputs(self):
+        return [v.next_iteration_input for v in self.state_variables.values()]
+
+    @property
+    def state_outputs_exits(self):
+        return [v.exit_output for v in self.state_variables.values()]
+
+    # scan output (e.g. tensor array) won't be used by next iteration calculation
+    @property
+    def scan_outputs(self):
+        return [v.next_iteration_input for v in self.scan_variables.values()]
+
+    @property
+    def scan_outputs_exits(self):
+        return [v.exit_output for v in self.scan_variables.values()]
+
+    # treat input tensor array as scan inputs
+    def add_scan_input(self, input_tensor_array):
+        self.tensor_array_inputs.append(input_tensor_array)
+
+    # usually it is called TensorArrayReadV3
+    @property
+    def scan_inputs(self):
+        return [i.consumer for i in self.tensor_array_inputs]
+
+    @property
+    def scan_inputs_initial_values(self):
+        return [i.data_input_id for i in self.tensor_array_inputs]
+
+class LoopVariable(object):
+    """In TensorFlow loop, all loop variables will be listed as iteration body graph's inputs, and outputs.
+       Loop (state variable 1, state variable 2) {
+           # do the calculation
+           # updated state variable 1 not necessarily only depends on state variable 1, it might depends
+           # on 0, 1, or 2 state variables. 
+           # So if it depends on 0 state variable, then switch_true_identity_output_id is None. For this case,
+           # during conversion, a fake input for ONNX Loop body graph is created, but not consumed by any node.
+           return (updated) state variable 1, (updated) state variable 2, scan variable 1, scan variable 2 
+       }
+
+       Here we take the perspective of body graph's outputs:
+           1. start from the iteration body graph's output (e.g. next_iteration_input_id)
+           2. find body graph generating it (those node between NextIteration and Switch)
+           3. find the variable initial value (e.g. enter_input_id)
+           4. check whether it is a tensor array
+           5. the body graph output might go to next iteration as corresponding input
+              (e.g. switch_true_identity_output_id).
+    """
     def __init__(self, enter_name, enter_input_id, next_iteration_input_id,
-                 switch_true_identity_output_id, exit_output_id, is_tensor_array):
+                 switch_true_identity_output_id, exit_output_id, is_tensor_array, ta_index_id, g):
         self.enter_name = enter_name
         self.enter_input_id = enter_input_id
-        self.next_iteration_input_id = next_iteration_input_id
-        self.switch_true_identity_output_id = switch_true_identity_output_id
-        self.exit_output_id = exit_output_id
 
+        # the output of iteration body graph for this variable
+        # should not be None
+        utils.make_sure(next_iteration_input_id, "next_iteration_input_id should not be None")
+        self.next_iteration_input = TensorValueInfo(next_iteration_input_id, g)
+
+        # the starting point of iteration body graph,
+        # might be None when this variable value (either initial value or last iteration output value)
+        # is not consumed iteration body graph nodes.
+        self.switch_true_identity_output= TensorValueInfo(switch_true_identity_output_id, g)
+
+        # the switch_false branch is ended with Exit, which is a boundary for the loop,
+        # might be None when no consumers for the variable output.
+        self.exit_output = TensorValueInfo(exit_output_id, g)
+
+        # only applicable for tensor array variable
         self.is_tensor_array = is_tensor_array
-        self.ta_index_id = None
+        # todo: need check ta's index variable is a scalar starting from 1, and increase by 1 each iteration. 
+        # then we can be sure this is equivalent to scan output behavior.
+        self.ta_index_id = ta_index_id
 
 
-class LoopRewriterBase:
+class InputTensorArray(object):
+    def __init__(self, data_input_id, index_input_id, consumer_id, g):
+        self.index_input_id = index_input_id
+        self.data_input_id = data_input_id
+
+        # tensor array is unstacked before being used in loop, consumer_id is the node
+        # (in the iteration body graph) consuming one of the element of tensor array.
+        self.consumer = TensorValueInfo(consumer_id, g)
+
+
+class TensorValueInfo(object):
+    def __init__(self, tensor_id, g):
+        self.id = tensor_id
+        if self.id:
+            self.dtype = g.get_dtype(tensor_id)
+            self.shape = g.get_shape(tensor_id)
+
+
+class LoopRewriterBase(object):
     def __init__(self, g):
         self.g = g
-        self.keep_nodes_global = []
+        self.ta_read_input_pattern = \
+            OpTypePattern("TensorArrayReadV3", name="ta_read", inputs=[
+                OpTypePattern("Enter", name="ta_enter", inputs=[
+                    OpTypePattern("TensorArrayV3")
+                ]),
+                OpTypePattern("Identity", name="ta_index"),
+                OpTypePattern("Enter", name="ta_scatter_enter", inputs=[
+                    OpTypePattern("TensorArrayScatterV3", name="ta_input_scatter")
+                ]),
+            ])
 
     def create_context(self):
         return Context()
@@ -55,28 +196,47 @@ class LoopRewriterBase:
 
     def run_internal(self):
         log.debug("enter loop rewriter")
-        for n in self.g.get_nodes():
-            if is_loopcond_op(n):
-                log.debug("======================")
-                log.debug("found LoopCond op named %s", n.name)
-                context = self.create_context()
-                self._parse_loop_variables(n, context)
-                if self.need_rewrite(context):
-                    _result = self.rewrite(context)
-                    if _result == REWRITER_RESULT.OK:
-                        log.debug("rewrite successfully")
-                    elif _result == REWRITER_RESULT.SKIP:
-                        log.debug("rewrite skipped for LoopCond called %s", n.name)
-                        continue
-                    elif _result == REWRITER_RESULT.FAIL:
-                        raise ValueError("rewrite failed, so just fast fail it")
-        all_output_name = copy.deepcopy(self.g.outputs)
-        if all_output_name:
-            all_output_name.extend(BodyGraphDict.get_body_graph_output_names())
-            self.g.delete_unused_nodes(all_output_name)
+        for op in self.g.get_nodes():
+            if not is_loopcond_op(op):
+                continue
+
+            log.debug("======================\n handling loop cond node called %s", op.name)
+            context = self.create_context()
+            context.loop_cond = op
+
+            self._check_in_read_only_mode(context)
+
+            if self.need_rewrite(context):
+                # cut off connection between cell/cond graphs and useless nodes like Merge, NextIteration.
+                to_remove = self._cut_off_connection_for_cell(context)
+                all_nodes = self.g.get_nodes()
+                for n in set(to_remove):
+                    if n in all_nodes:
+                        all_nodes.remove(n)
+                self.g.set_nodes(all_nodes)
+
+                context.cell_graph = self._crop_loop_body_sub_graph(context)
+                context.cond_graph = self._crop_loop_condition_sub_graph(context)
+
+                _result = self.rewrite(context)
+                if _result == REWRITER_RESULT.OK:
+                    log.debug("rewrite successfully")
+                elif _result == REWRITER_RESULT.SKIP:
+                    log.debug("rewrite skipped for LoopCond called %s", n.name)
+                    continue
+                elif _result == REWRITER_RESULT.FAIL:
+                    raise ValueError("rewrite failed, so just fast fail it")
+
+        # clean the graph based on output names.
+        self.g.delete_unused_nodes(self.g.outputs)
         return self.g.get_nodes()
 
-    def _parse_loop_variables(self, loop_cond_op, context):
+    def _check_in_read_only_mode(self, context):
+        self._parse_loop_variables(context)
+        self._parse_input_ta(context)
+
+    def _parse_loop_variables(self, context):
+        loop_cond_op = context.loop_cond
         parts = loop_cond_op.name.split('/')
         context.while_context_scope = '/'.join(parts[0:-1]) + "/"
         log.debug("found while loop scope %s", context.while_context_scope)
@@ -87,10 +247,95 @@ class LoopRewriterBase:
                 raise ValueError("LoopCond's output node should be followed with a Switch node")
 
             loop_var = self._get_loop_var_from_switch(s)
-            if loop_var.enter_name in context.loop_variables:
-                raise ValueError("duplicated enter name registered")
+            context.loop_properties.add_variable(loop_var)
 
-            context.loop_variables[loop_var.enter_name] = loop_var
+    def _parse_input_ta(self, context):
+        loop_body_graph_inputs = [v.switch_true_identity_output.id for v in context.loop_properties.all_variables.values()
+                                  if v.switch_true_identity_output.id]
+        matcher = GraphMatcher(self.ta_read_input_pattern, allow_reorder=False)
+        match_results = matcher.match_ops(self.g.get_nodes())
+        match_results = [r for r in match_results if r.get_op("ta_index").output[0] in loop_body_graph_inputs]
+        for match in match_results:
+            ta_input_scatter = match.get_op("ta_input_scatter")
+            # the 3rd input of scatter is the value
+            data_input_id = ta_input_scatter.input[2]
+            ta_read_node = match.get_op("ta_read")
+
+            # todo: need check ta's index variable is a scalar starting from 1, and increase by 1 each iteration. 
+            # then we can be sure this is equivalent to scan input behavior.
+            index_input_id = ta_read_node.input[1]
+            unstacked_ta_consumer = match.get_op("ta_read").output[0]
+            ta = InputTensorArray(data_input_id, index_input_id, unstacked_ta_consumer, self.g)
+            context.loop_properties.add_scan_input(ta)
+
+    def _crop_loop_body_sub_graph(self, context):
+        # according to input and output, find the body graph
+        loop_props = context.loop_properties
+        inputs = loop_props.state_inputs + loop_props.scan_inputs
+        input_ids = [input_tensor_value_info.id for input_tensor_value_info in inputs]
+
+        outputs = loop_props.state_outputs + loop_props.scan_outputs
+        output_ids = [out_tensor_value_info.id for out_tensor_value_info in outputs]
+        ops, enter_nodes, _ = self.find_subgraph(set(input_ids), set(output_ids), self.g, merge_as_end=False)
+
+        other_enter_input_ids = []
+        for enter_node in enter_nodes:
+            # connect Enter's output to Enter's input
+            self.g.replace_all_inputs(ops, enter_node.output[0], enter_node.input[0])
+            other_enter_input_ids.append(enter_node.input[0])
+
+        return GraphInfo(ops, inputs, outputs)
+
+    def _crop_loop_condition_sub_graph(self, context):
+        input_ids = []
+        output_ids = [context.loop_cond.input[0]]
+        outputs = [TensorValueInfo(o, self.g) for o in output_ids]
+        ops, enter_nodes, merge_nodes = self.find_subgraph(set(input_ids), set(output_ids), self.g, merge_as_end=True)
+
+        other_enter_input_ids = []
+        for enter_node in enter_nodes:
+            # connect Enter's output to Enter's input
+            self.g.replace_all_inputs(ops, enter_node.output[0], enter_node.input[0])
+            other_enter_input_ids.append(enter_node.input[0])
+
+        dependent_vars = []
+        for merge_node in merge_nodes:
+            enter_node = [n for n in merge_node.inputs if n.type == "Enter"][0]
+            loop_var = context.loop_properties.all_variables[enter_node.name]
+
+            # cut off connection between condition graph and Merge node.
+            non_switch_consumers = [n for n in self.g.find_output_consumers(merge_node.output[0]) if n.type != "Switch"]
+            self.g.replace_all_inputs(non_switch_consumers, merge_node.output[0], loop_var.switch_true_identity_output.id)
+            dependent_vars.append(loop_var)
+
+        # cut off connection between condition graph and LoopCond node.
+        self.g.replace_all_inputs([context.loop_cond], context.loop_cond.output[0], INVALID_INPUT_ID)
+
+        graph_info = GraphInfo(ops, [], outputs)
+        graph_info.dependent_vars = dependent_vars
+        return graph_info
+
+    def _cut_off_connection_for_cell(self, context):
+        nodes_to_remove = []
+        for val in context.loop_properties.all_variables.values():
+            if val.switch_true_identity_output.id:
+                # remove the node to cut off a starting node of the cell (e.g. loop body).
+                nodes_to_remove.append(self.g.get_node_by_output(val.switch_true_identity_output.id))
+
+            if val.is_tensor_array:
+                # connect NextIteration to an invalid node, to cut off an ending node of the cell.
+                ta_write_nodes = [n for n in self.g.get_nodes() if is_tensor_array_write_op(n)]
+                self.g.replace_all_inputs(ta_write_nodes, val.next_iteration_input.id, INVALID_INPUT_ID)
+            else:
+                # connect NextIteration to an invalid node, to cut off an ending node of the cell.
+                next_iter_nodes = [n for n in self.g.get_nodes() if n.type == "NextIteration"]
+                self.g.replace_all_inputs(next_iter_nodes, val.next_iteration_input.id, INVALID_INPUT_ID)
+
+        for scan_input in context.loop_properties.scan_inputs:
+            # remove the node to cut off connection between scan_input and the cell.
+            nodes_to_remove.append(self.g.get_node_by_output(scan_input))
+
+        return nodes_to_remove
 
     def _get_loop_var_from_switch(self, switch_node):
         if switch_node.type != 'Switch':
@@ -105,12 +350,15 @@ class LoopRewriterBase:
 
         # find the output_true consumers
         switch_consumers = self.g.find_output_consumers(switch_node.output[1])
-        if len(switch_consumers) != 1:
-            raise ValueError("switch has non-1 consumers")
-
-        if switch_consumers[0].type != "Identity":
-            raise ValueError("switch has consumer that is not Identity")
-        identity_node = switch_consumers[0]
+        switch_true_consumer_cnt = len(switch_consumers)
+        if switch_true_consumer_cnt == 0:
+            switch_true_identity_output = None
+        elif switch_true_consumer_cnt == 1:
+            if switch_consumers[0].type != "Identity":
+                raise ValueError("switch has consumer that is not Identity")
+            switch_true_identity_output = switch_consumers[0].output[0]
+        else:
+            raise ValueError("switch_true " + switch_node.name + " has unexpected count of consumers:", [n.name for n in switch_consumers])
 
         target_node_input_id = None
         enter_node = [n for n in merge_node.inputs if n.type == 'Enter'][0]
@@ -130,125 +378,108 @@ class LoopRewriterBase:
                 raise ValueError("switch false branch is followed by non-Exit")
             exit_output_id = exit_node.output[0]
         elif false_consumer_count == 0:
+            # sometime, the variable output won't be used in the new iteration as input.
             exit_output_id = None
         else:
             raise ValueError("unexpected number of switch false consumers")
 
         is_ta = False
+        ta_index_id = None
         if is_tensor_array_op(self.g.get_node_by_output(target_node_input_id)):
             is_ta = True
 
+            ta_write_node = self.g.get_node_by_output(last_iteration_output_id)
+            utils.make_sure(is_tensor_array_write_op(ta_write_node), "ta var nextiteration is not following ta write op")
+            last_iteration_output_id = ta_write_node.input[2]
+            ta_index_id = ta_write_node.input[1]
+
+            # here we parse patterns generated by 
+            # ta.write(), then ta.stack(), because this is the most frequent usage pattern.
+            if exit_output_id:
+                exit_consumers = self.g.find_output_consumers(exit_output_id)
+                ta_gather_node = [n for n in exit_consumers if is_tensor_array_gather_op(n)][0]
+
+                # update exit output id, treat the gather output as ta's output
+                exit_output_id = ta_gather_node.output[0]
+
         loop_var = LoopVariable(enter_node.name, target_node_input_id, last_iteration_output_id,
-                                identity_node.output[0], exit_output_id, is_ta)
-        loop_var = self._tune_shape_for_loop_var(loop_var)
-        loop_var = self._tune_shape_for_loop_ta_var(loop_var)
-        return loop_var
-
-    def _tune_shape_for_loop_ta_var(self, loop_var):
-        if loop_var.is_tensor_array:
-            ta_write_node = self.g.get_node_by_output(loop_var.next_iteration_input_id)
-            if not is_tensor_array_write_op(ta_write_node):
-                raise ValueError("ta var nextiteration is not following ta write op")
-
-            loop_var.next_iteration_input_id = ta_write_node.input[2]
-            loop_var.ta_index_id = ta_write_node.input[1]
-
-            ta_output_shape = None
-            next_iteration_shape = self.g.get_shape(loop_var.next_iteration_input_id)
-            if next_iteration_shape is None:
-                enter_node = ta_write_node.inputs[0]
-                ta_node_output = enter_node.input[0]
-                ta_element_shape = self.g.get_shape(ta_node_output)
-                ta_output_shape = ta_element_shape
-                log.debug("loop var [%s, %s] output shapes are inferred from TA element shape", loop_var.enter_name,
-                          loop_var.enter_input_id)
-            else:
-                log.debug("loop var [%s, %s] output shapes are inferred from cell output %s", loop_var.enter_name,
-                          loop_var.enter_input_id, loop_var.next_iteration_input_id)
-                ta_output_shape = next_iteration_shape
-
-            self.g.set_shape(loop_var.next_iteration_input_id, ta_output_shape)
-            self.g.set_shape(loop_var.switch_true_identity_output_id, ta_output_shape)
-            self.g.set_shape(loop_var.exit_output_id, ta_output_shape)
-
-        return loop_var
-
-    def _tune_shape_for_loop_var(self, loop_var):
-        if loop_var.is_tensor_array:
-            return loop_var
-        log.debug("_tune_shape_for_loop_var for loop var [%s, %s, %s]", loop_var.enter_name,
-                  loop_var.enter_input_id, loop_var.next_iteration_input_id)
-        var_output_shape = self.g.get_shape(loop_var.enter_input_id)
-        if var_output_shape is None:
-            var_output_shape = self.g.get_shape(loop_var.next_iteration_input_id)
-
-        self.g.set_shape(loop_var.next_iteration_input_id, var_output_shape)
-        self.g.set_shape(loop_var.switch_true_identity_output_id, var_output_shape)
-        self.g.set_shape(loop_var.exit_output_id, var_output_shape)
-        log.debug("_tune_shape_for_loop_var new shape is %s", var_output_shape)
+                                switch_true_identity_output, exit_output_id, is_ta, ta_index_id, self.g)
 
         return loop_var
 
     @staticmethod
-    def find_subgraph(graph_meta, g):
-        input_ids = graph_meta.input_ids
-        if graph_meta.other_enter_input_ids:
-            input_ids += graph_meta.other_enter_input_ids
-
-        input_ids = set(input_ids)
-        output_ids = set(graph_meta.output_ids)
+    def find_subgraph(input_ids, output_ids, g, merge_as_end=False):
         log.debug("input ids %s ", input_ids)
         log.debug("output ids %s ", output_ids)
-        nodes = []
-        q = deque()
-        output_nodes = [g.get_node_by_output(output_id) for output_id in output_ids]
-        handled_nodes = []
-        q.extend(output_nodes)
-        nodes.extend(output_nodes)
+
         enter_nodes = set()
-        while q:
-            n = q.popleft()
-            if not n:
-                continue
-            if n in handled_nodes:
-                continue
+        merge_nodes = set()
 
-            handled_nodes.append(n)
+        def find_input_boundary(node):
+            if node.type == "Enter":
+                enter_nodes.add(node)
+                log.debug("terminate the input search at %s", node.name)
+                return False
+            elif merge_as_end is True and node.type == "Merge":
+                merge_nodes.add(node)
+                log.debug("terminate the input search at %s", node.name)
+                return False
+            elif node.is_const():
+                log.debug("terminate search at const node %s", node.name)
+                return False
 
-            n_inputs = set(n.input)
-            for i in n_inputs:
-                input_node = g.get_node_by_output(i)
-                if i in input_ids:
-                    log.debug("terminate the input search at %s", i)
-                elif not input_node:
-                    log.error("input node does not exist, node name is: [%s] ", i)
-                    raise ValueError("failed to get input")
-                elif input_node.is_const() or input_node.is_graph_input():
-                    pass
-                elif input_node.type == "Enter":
-                    enter_nodes.add(input_node)
-                    log.debug("terminate the input search at %s", i)
-                else:
-                    log.debug("add node %s into sub graph %s", input_node.name, n.name)
-                    if input_node not in nodes:
-                        nodes.append(input_node)
-                    q.append(input_node)
+            for o in node.output:
+                if o in input_ids:
+                    return False
+            return True
 
-            implicit_inputs = n.get_implicit_inputs(require_input_in_cur_graph=True)
-            n_inputs = set(implicit_inputs)
-            for i in n_inputs:
-                input_node = g.get_node_by_output(i)
-                if i in input_ids:
-                    log.debug("terminate the input search at %s", i)
-                elif not input_node:
-                    log.debug("implicit input is initializer or input in main graph, node name is: [%s] ", i)
-                elif input_node.type == "Enter":
-                    enter_nodes.add(input_node)
-                    log.debug("terminate the input search at %s", i)
-                else:
-                    log.debug("add node %s into sub graph %s", input_node.name, n.name)
-                    if input_node not in nodes:
-                        nodes.append(input_node)
-                    q.append(input_node)
+        nodes = g.extract_sub_graph_nodes(output_ids, input_checker=find_input_boundary)
 
-        return nodes, enter_nodes
+        return nodes, enter_nodes, merge_nodes
+
+    @staticmethod
+    def construct_graph_from_nodes(parent_g, nodes, outputs):
+        log.debug("construct_graph_from_nodes")
+
+        g = Graph([], output_shapes={}, dtypes={}, target=parent_g._target, opset=parent_g._opset,
+                  extra_opset=parent_g._extra_opset, output_names=[])
+        g.parent_graph = parent_g
+        nodes = set(nodes)
+        all_inputs_and_outputs = set()
+        ops = []
+        for op in nodes:
+            all_inputs_and_outputs |= set(op.input)
+            all_inputs_and_outputs |= set(op.get_implicit_inputs(False))  # we assume original graph won't have nested graphs
+            all_inputs_and_outputs |= set(op.output)
+
+            new_node = g.make_node(op.type, op.input, outputs=op.output, attr=op.attr, name=op.name,
+                                   skip_conversion=op._skip_conversion)
+            body_graphs = op.graph.contained_graphs.pop(op.name, None)
+            if body_graphs:
+                new_node.set_body_graph_as_attr(op.name, body_graphs)
+            ops.append(new_node)
+
+        for i in all_inputs_and_outputs:
+            if i not in g._output_shapes:
+                g._output_shapes[i] = parent_g._output_shapes[i]
+            if i not in g._dtypes:
+                g._dtypes[i] = parent_g._dtypes[i]
+
+        g.set_nodes(ops)
+
+        # handle cell graph: insert identity node, since sometimes we need output same output_id 
+        # as state_output and scan_out, but ONNX don't allow the same output_id to appear more
+        # than once as output node.
+        cell_body_nodes = []
+        new_output_names = []
+        for out_tensor_value_info in outputs:
+            node = g.make_node("Identity", inputs=[out_tensor_value_info.id], op_name_scope="sub_graph_ending_node",
+                                shapes=[out_tensor_value_info.shape], dtypes=[out_tensor_value_info.dtype])
+            new_output_names.append(node.output[0])
+            cell_body_nodes.append(node)
+
+        cell_nodes = g.get_nodes()
+        cell_nodes.extend(cell_body_nodes)
+        g.set_nodes(cell_nodes)
+        g.outputs = new_output_names
+        return g

--- a/tf2onnx/rewriter/loop_rewriter_base.py
+++ b/tf2onnx/rewriter/loop_rewriter_base.py
@@ -226,8 +226,9 @@ class LoopRewriterBase(object):
                 elif _result == REWRITER_RESULT.FAIL:
                     raise ValueError("rewrite failed, so just fast fail it")
 
-        # clean the graph based on output names.
-        self.g.delete_unused_nodes(self.g.outputs)
+        if self.g.outputs:
+            # clean the graph based on output names.
+            self.g.delete_unused_nodes(self.g.outputs)
         return self.g.get_nodes()
 
     def _check_in_read_only_mode(self, context):

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -51,7 +51,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
     def get_weight_and_bias(self, match):
         # if one of them is not match, just return
         w_e = match.get_op("cell_kernel")
-        w = get_weights_from_const_node(w_e)
+        w = get_weights_from_const_node(self.g, w_e)
         if not w:
             return None
 
@@ -63,17 +63,17 @@ class LSTMUnitRewriter(UnitRewriterBase):
             return None
 
         b_e = match.get_op("cell_bias")
-        b = get_weights_from_const_node(b_e)
+        b = get_weights_from_const_node(self.g, b_e)
         if not b or b.value.shape[0] != w.value.shape[1]:
             log.warning("cell_kernel and cell_bias's dimensions does not match, skip")
             return None
 
         ft_bias = match.get_op("ft_bias")
-        ft = get_weights_from_const_node(ft_bias)
+        ft = get_weights_from_const_node(self.g, ft_bias)
         if not ft:
             return None
 
-        if not (len(ft.value) == 1 and b_e.dtype == ft_bias.dtype):
+        if not (len(ft.value) == 1 and self.g.get_dtype(b_e.output[0]) == self.g.get_dtype(ft_bias.output[0])):
             return None
 
         return RnnWeights(w, b, ft)

--- a/tf2onnx/rewriter/random_uniform.py
+++ b/tf2onnx/rewriter/random_uniform.py
@@ -64,7 +64,7 @@ def rewrite_random_uniform_fold_const(g, ops):
 
 
 def create_onnx_random_uniform_op(g, tmax, tmin, ru_op, output):
-    dtype = output.dtype
+    dtype = g.get_dtype(output.output[0])
     op_name = utils.make_name("RandomUniform")
     if ru_op.inputs[0].type == "Shape":
         shape_node = ru_op.inputs[0]

--- a/tf2onnx/rewriter/rnn.py
+++ b/tf2onnx/rewriter/rnn.py
@@ -15,7 +15,8 @@ from tf2onnx.rewriter.bilstm_rewriter import rewrite_bidirectional_lstms
 from tf2onnx.rewriter.lstm_rewriter import LSTMUnitRewriter
 from tf2onnx.rewriter.grublock_rewriter import GRUUnitRewriter, GRUBlockUnitRewriter
 from tf2onnx.rewriter.bigru_rewriter import rewrite_bidirectional_grus
-from tf2onnx.rewriter.custom_rnn_rewriter import CustomRnnRewriter, CustomRnnLateRewriter
+from tf2onnx.rewriter.custom_rnn_rewriter import CustomRnnRewriter
+from tf2onnx.rewriter.loop_rewriter import LoopRewriter
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
@@ -50,6 +51,5 @@ def rewrite_custom_rnn_cell(g, ops):
     return  CustomRnnRewriter(g).run()
 
 
-def rewrite_custom_rnn_body_graph(g, ops):
-    g.update_proto()
-    return CustomRnnLateRewriter(g).rewrite()
+def rewrite_generic_loop(g, ops):
+    return LoopRewriter(g).run()

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -177,51 +177,6 @@ class RNNUnitType(Enum):
     GRUBlockCell = 2
 
 
-# describe the body graph's input and output node
-class SubGraphMetadata(object):
-    def __init__(self, g, input_ids, output_ids, initial_input_ids):
-        self.g = g
-        self.input_ids = input_ids
-        self.output_ids = output_ids
-
-        self.initial_input_ids = initial_input_ids
-
-        # sub-graph boundary
-        self.other_enter_input_ids = []
-
-
-class BodyGraphDict():
-    BODY_GRAPH_DICT = {}
-
-    def __init__(self, g):
-        self.g = g
-
-    @staticmethod
-    def add_body_graph_info(body_owner_name, body_graph):
-        if body_owner_name not in BodyGraphDict.BODY_GRAPH_DICT:
-            BodyGraphDict.BODY_GRAPH_DICT[body_owner_name] = body_graph
-        else:
-            raise ValueError("body_owner_name " + body_owner_name + " already exists as a key")
-
-    @staticmethod
-    def pop_body_graph_info(body_owner_name):
-        val = BodyGraphDict.BODY_GRAPH_DICT[body_owner_name]
-        del BodyGraphDict.BODY_GRAPH_DICT[body_owner_name]
-        return val
-
-    @staticmethod
-    def has_body_graph_info(body_owner_name):
-        return body_owner_name in BodyGraphDict.BODY_GRAPH_DICT
-
-    @staticmethod
-    def get_body_graph_output_names():
-        output_names = []
-        for k in BodyGraphDict.BODY_GRAPH_DICT:
-            _output_names = BodyGraphDict.BODY_GRAPH_DICT[k].output_ids
-            output_names.extend(_output_names)
-        return set(output_names)
-
-
 rnn_cell_patterns = {
     RNNUnitType.LSTMCell: lstmcell_pattern,
     RNNUnitType.GRUCell: grucell_pattern,

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -233,7 +233,7 @@ def get_pattern(cell_type_name):
     return rnn_cell_patterns[cell_type_name]
 
 
-def get_weights_from_const_node(node):
+def get_weights_from_const_node(g, node):
     temp = node
     val = None
     dtype = None
@@ -243,7 +243,7 @@ def get_weights_from_const_node(node):
 
     if temp and temp.type == 'Const':
         val = temp.get_tensor_value()
-        dtype = utils.ONNX_TO_NUMPY_DTYPE[temp.dtype]
+        dtype = utils.ONNX_TO_NUMPY_DTYPE[g.get_dtype(temp.output[0])]
         log.debug("found weights %s", temp.name)
     else:
         log.debug("weight node seems not to be Const, skip, node name is %s", temp.name)

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -61,7 +61,6 @@ class UnitRewriterBase(object):
                 self.run_single_match(match)
 
             self.g.delete_unused_nodes(self.g.outputs)
-            self.g.update_proto()
             self.print_step("finish handling")
 
         return self.g.get_nodes()
@@ -420,7 +419,7 @@ class UnitRewriterBase(object):
             return None
 
         fill_val = node.inputs[1].get_tensor_value()[0]
-        fill_val_dtype = utils.ONNX_TO_NUMPY_DTYPE[node.inputs[1].dtype]
+        fill_val_dtype = utils.ONNX_TO_NUMPY_DTYPE[self.g.get_dtype(node.input[1])]
 
         # this must be int64, since Concat's input data type must be consistent.
         num_direction_node = self.g.make_const(utils.make_name("Const"), np.array([1], dtype=np.float32))

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -124,7 +124,7 @@ def infer_shape_for_node(g, node):
         axis = axis_node.get_tensor_value()[0]
         keep_dims = node.get_attr_int("keep_dims")
         shape = node.input_shape_at(0)
-        if axis < 0 :
+        if axis < 0:
             axis += len(shape)
 
         new_shape = shape[:axis]
@@ -231,7 +231,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
         return False
 
     if node.type == "TensorArrayReadV3":
-        # Read an element from the TensorArray into output value. 
+        # Read an element from the TensorArray into output value.
         flow_in_node = node.inputs[2]
         if flow_in_node.type != "Enter":
             return False

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -31,7 +31,6 @@ from tf2onnx.rewriter.rnn import rewrite_generic_loop
 from tf2onnx.rewriter.rnn import rewrite_single_direction_gru
 from tf2onnx.rewriter.rnn import rewrite_single_direction_grublock
 from tf2onnx.rewriter.rnn import rewrite_single_direction_lstm, rewrite_bi_direction_lstm
-from tf2onnx.rewriter.rnn_utils import is_tensor_array_op
 from tf2onnx.shape_inference import infer_shape_for_graph, set_shape_from_inputs_broadcast
 from tf2onnx.utils import port_name
 
@@ -331,8 +330,8 @@ def reshape_op(ctx, node, name, args):
 def reshape_op5(ctx, node, name, args):
     dtype = ctx.get_dtype(node.output[0])
     need_casting = dtype in [onnx_pb.TensorProto.INT32,
-                                  onnx_pb.TensorProto.INT16,
-                                  onnx_pb.TensorProto.INT64]
+                             onnx_pb.TensorProto.INT16,
+                             onnx_pb.TensorProto.INT64]
     # onnx wants reshape.input[1] to have the value be int64 which is not the case for tensorflow.
     nodes = _convert_shapenode_to_int64(ctx, node, 1)
     if ctx.opset >= 8 or not need_casting:
@@ -1494,8 +1493,7 @@ def reverse_op8(ctx, node, name, args):
     input_dtype = ctx.get_dtype(node.input[0])
     input_shape = ctx.get_shape(node.input[0])
 
-    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset,
-              extra_opset=ctx._extra_opset, output_names=[])
+    g = ctx.create_new_graph_with_same_config()
     g.set_nodes([g.make_node('Identity', ['X'], outputs=['Y'])])
     g.add_graph_input('X', input_dtype, input_shape[2:])
     g.add_graph_output('Y', input_dtype, input_shape[2:])

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -26,7 +26,8 @@ from tf2onnx.graph import Node, Graph
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.rewriter.random_uniform import rewrite_random_uniform, rewrite_random_uniform_fold_const
 from tf2onnx.rewriter.rnn import rewrite_bi_direction_gru
-from tf2onnx.rewriter.rnn import rewrite_custom_rnn_cell, rewrite_custom_rnn_body_graph
+from tf2onnx.rewriter.rnn import rewrite_custom_rnn_cell
+from tf2onnx.rewriter.rnn import rewrite_generic_loop
 from tf2onnx.rewriter.rnn import rewrite_single_direction_gru
 from tf2onnx.rewriter.rnn import rewrite_single_direction_grublock
 from tf2onnx.rewriter.rnn import rewrite_single_direction_lstm, rewrite_bi_direction_lstm
@@ -63,7 +64,7 @@ def tflist_to_onnx(node_list, shape_override):
     ignored_attr = ["unknown_rank", "_class", "Tshape", "use_cudnn_on_gpu", "Index", "Tpaddings",
                     "TI", "Tparams", "Tindices", "Tlen", "Tdim", "dynamic_size", "Tmultiples",
                     "output_dtype", "Tblock_shape", "Tcrops", "index_type", "Taxis", "U", "maxval",
-                    "Tout", "Tlabels", "Tindex"]
+                    "Tout", "Tlabels", "Tindex", "element_shape"]
     # some stats
     op_cnt = collections.Counter()
     attr_cnt = collections.Counter()
@@ -117,17 +118,6 @@ def tflist_to_onnx(node_list, shape_override):
                 attr["to"] = utils.map_tf_dtype(utils.get_tf_node_attr(node, "DstT"))
             elif a == "SrcT":
                 continue
-            elif a == "element_shape":
-                if is_tensor_array_op(node):
-                    # this is for getting output shape for tensor array
-                    shape = node.get_attr("element_shape")
-                    dims = [d.size for d in shape.dim]
-                    output_name = node.outputs[0].name
-                    # override tf's ta output shape, which is [2], not reflecting
-                    # the shape stored in it at all.
-                    output_shapes[output_name] = dims
-                else:
-                    continue
             elif a in ignored_attr:
                 continue
             else:
@@ -291,7 +281,7 @@ def reduce_op(ctx, node, name, args):
 
 def placeholder_op(ctx, node, name, args):
     input_name = node.output[0]
-    ctx.add_graph_input(input_name, node.dtype, ctx.get_shape(input_name))
+    ctx.add_graph_input(input_name, ctx.get_dtype(input_name), ctx.get_shape(input_name))
     return None
 
 
@@ -339,7 +329,8 @@ def reshape_op(ctx, node, name, args):
 
 
 def reshape_op5(ctx, node, name, args):
-    need_casting = node.dtype in [onnx_pb.TensorProto.INT32,
+    dtype = ctx.get_dtype(node.output[0])
+    need_casting = dtype in [onnx_pb.TensorProto.INT32,
                                   onnx_pb.TensorProto.INT16,
                                   onnx_pb.TensorProto.INT64]
     # onnx wants reshape.input[1] to have the value be int64 which is not the case for tensorflow.
@@ -358,8 +349,8 @@ def reshape_op5(ctx, node, name, args):
     if len(next_nodes) != 1 or next_nodes[0].type != "Cast":
         op_name = utils.make_name(node.name)
         output_cast = ctx.insert_new_node_on_output("Cast", node.output[0], name=op_name)
-        output_cast.set_attr("to", node.dtype)
-        ctx.set_dtype(output_cast.output[0], node.dtype)
+        output_cast.set_attr("to", dtype)
+        ctx.set_dtype(output_cast.output[0], dtype)
         ctx.copy_shape(node.output[0], output_cast.output[0])
         nodes.append(output_cast)
     return [input_cast] + nodes
@@ -370,7 +361,6 @@ def less_op7(ctx, node, name, args):
     nodes = [node]
     input1_dtype = ctx.get_dtype(node.input[0])
     input2_dtype = ctx.get_dtype(node.input[1])
-    utils.make_sure(input1_dtype == input2_dtype, "less inputs not having same dtype")
     target_dtype = onnx_pb.TensorProto.FLOAT
     need_case_1 = input1_dtype != target_dtype
     if need_case_1:
@@ -769,10 +759,10 @@ def sign_op(ctx, node, name, args):
     """Sign op."""
     # T sign = Sign(T Input)
     nodes = []
-    node_dtype = node.dtype
+    node_dtype = ctx.get_dtype(node.output[0])
     utils.make_sure(node_dtype, "Dtype of {} is None".format(node.name))
     if node_dtype in [onnx_pb.TensorProto.COMPLEX64, onnx_pb.TensorProto.COMPLEX128]:
-        raise ValueError("dtype " + node.dtype + " is not supported in onnx for now")
+        raise ValueError("dtype " + node_dtype + " is not supported in onnx for now")
     input_tensor_type = utils.ONNX_TO_NUMPY_DTYPE[node_dtype]
     zero_name = utils.make_name("{}_zero".format(node.name))
     ctx.make_const(zero_name, np.array(0, dtype=input_tensor_type))
@@ -841,7 +831,7 @@ def transpose_op(ctx, node, name, args):
 def _wrap_concat_with_cast(ctx, node):
     """wrap concat in casts for opset < 8 since it only supports."""
     supported_types = [onnx_pb.TensorProto.FLOAT, onnx_pb.TensorProto.FLOAT16]
-    dtype = node.dtype
+    dtype = ctx.get_dtype(node.output[0])
     need_casting = dtype not in supported_types
     nodes = []
     if need_casting:
@@ -859,7 +849,6 @@ def _wrap_concat_with_cast(ctx, node):
             op_name = utils.make_name(node.name)
             output_cast = ctx.insert_new_node_on_output("Cast", output_name, name=op_name)
             output_cast.set_attr("to", dtype)
-            output_cast.dtype = dtype
             ctx.set_dtype(output_cast.output[0], dtype)
             ctx.copy_shape(output_name, output_cast.output[0])
             nodes.append(output_cast)
@@ -1345,7 +1334,7 @@ def fused_batchnorm_op7(ctx, node, name, args):
     scale_shape = ctx.get_shape(node.input[1])
     mean_shape = ctx.get_shape(node.input[3])
     var_shape = ctx.get_shape(node.input[4])
-    val_type = utils.ONNX_TO_NUMPY_DTYPE[node.inputs[1].dtype]
+    val_type = utils.ONNX_TO_NUMPY_DTYPE[ctx.get_dtype(node.input[1])]
 
     if mean_shape != scale_shape:
         new_mean_value = np.array(np.resize(node.inputs[3].get_tensor_value(), scale_shape), dtype=val_type)
@@ -1369,10 +1358,11 @@ def matmul_op(ctx, node, name, args):
     attrs_val = [node.get_attr(attr) for attr in attrs]
     attrs_val = [0 if val is None else val.i for val in attrs_val]
 
+    dtype = ctx.get_dtype(node.output[0])
     if any(attrs_val[2:]):
         # conjugation operation on complex data not supported in onnx for now, so if it's complex than raise exception
-        if node.dtype not in [onnx_pb.TensorProto.FLOAT, onnx_pb.TensorProto.FLOAT16, onnx_pb.TensorProto.DOUBLE]:
-            raise ValueError("dtype " + node.dtype + " is not supported in onnx matmul for now")
+        if dtype not in [onnx_pb.TensorProto.FLOAT, onnx_pb.TensorProto.FLOAT16, onnx_pb.TensorProto.DOUBLE]:
+            raise ValueError("dtype " + dtype + " is not supported in onnx matmul for now")
 
     transpose_a = (attrs_val[0] + attrs_val[2] + attrs_val[4]) % 2
     transpose_b = (attrs_val[1] + attrs_val[3] + attrs_val[5]) % 2
@@ -1504,27 +1494,13 @@ def reverse_op8(ctx, node, name, args):
     input_dtype = ctx.get_dtype(node.input[0])
     input_shape = ctx.get_shape(node.input[0])
 
-    # create one input (ValueInfoProto)
-    x = utils.make_onnx_inputs_outputs('X', input_dtype, input_shape[2:])
+    g = Graph([], output_shapes={}, dtypes={}, target=ctx._target, opset=ctx._opset,
+              extra_opset=ctx._extra_opset, output_names=[])
+    g.set_nodes([g.make_node('Identity', ['X'], outputs=['Y'])])
+    g.add_graph_input('X', input_dtype, input_shape[2:])
+    g.add_graph_output('Y', input_dtype, input_shape[2:])
 
-    # create one output (ValueInfoProto)
-    y = utils.make_onnx_inputs_outputs('Y', input_dtype, input_shape[2:])
-
-    # create a node (NodeProto)
-    node_def = helper.make_node(
-        'Identity',  # node name
-        ['X'],  # inputs
-        ['Y'],  # outputs
-    )
-
-    # create the graph (GraphProto)
-    graph_def = helper.make_graph(
-        [node_def],
-        'reverse_scan-body-graph',
-        [x],
-        [y],
-    )
-    node.set_attr("body", graph_def)
+    node.set_body_graph_as_attr("body", g)
     node.set_attr("directions", [1])  # reverse the scan input
 
     seq_len_dtype = ctx.get_dtype(node.input[1])
@@ -1824,6 +1800,12 @@ _OPSET_7 = {
     "Tan": (direct_op, []),
     "Tile": (tile_op7, []),
     "TruncateDiv": (broadcast_op7, ["Div"]),
+
+    # workaround created ONNX node in pre-rewriters to make sure those ops
+    # is handled especially on their contained subgraphs.
+    "If": (direct_op, []),
+    "Loop": (direct_op, []),
+    "Scan": (direct_op, []),
 }
 
 _OPSET_8 = {
@@ -1888,7 +1870,7 @@ def rewrite_random_normal(g, ops):
     for match in match_results:
         output = match.get_op('output')
         mean = output.inputs[1].get_tensor_value()[0]
-        dtype = output.dtype
+        dtype = g.get_dtype(output.output[0])
         op_name = utils.make_name("RandomNormal")
         out_name = port_name(op_name)
 
@@ -2412,8 +2394,8 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
                  rewrite_random_normal, rewrite_dropout,
                  rewrite_single_direction_lstm, rewrite_bi_direction_lstm,
                  rewrite_single_direction_gru, rewrite_single_direction_grublock,
-                 rewrite_bi_direction_gru, rewrite_custom_rnn_cell,
-                 rewrite_logical_compare_with_equal
+                 rewrite_bi_direction_gru, rewrite_logical_compare_with_equal,
+                 rewrite_custom_rnn_cell, rewrite_generic_loop,
                  ]
 
     if custom_rewriter is not None:
@@ -2433,6 +2415,8 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
         else:
             raise ex
 
+    # some nodes may already copied into inner Graph, so remove them from main Graph.
+    g.delete_unused_nodes(output_names)
     topological_sort(g, continue_on_error)
 
     if custom_op_handlers is None:
@@ -2440,7 +2424,7 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
     mapped_op, unmapped_op = tensorflow_onnx_mapping(g, continue_on_error, custom_op_handlers)
 
     # post-processing rewriters
-    late_rewriters = [rewrite_custom_rnn_body_graph]
+    late_rewriters = []
     if TARGET_RS5 in target:
         late_rewriters.append(rewrite_incomplete_type_support_rs5)
     if TARGET_RS6 in target:


### PR DESCRIPTION
Changes include:

1. **Enable nested graph node searching**. 
 1.1 get_implicit_inputs is refactored to get sub graph based on Graph's containedgraphs instead of searching attributes of type GraphProto. 
 1.2 The problem: node output dtype/shape should also be supported for recursive search because inner graph will have reference to outer scope node, so we have some places allowing retrieving shape/dtype with output id including port. Another thing we need consider is that: we sometime want to set a shape with output id (like topk_k:1), so we may hold a Graph instance g, but what if topk_k:1 does not exist in existing Graph._dtypes or _output_shapes? With current implementation, we cannot figure out where(e.g. which Graph) to store the newly inserted output id's dtyep/shape info. 
       The proposal: we need put dtype/shape in Node instead of Graph. Then, if we want to get/set a dtype with an output id, firstly get the node (recursively), then get/set the dtype. In this PR, I did this. BUT we still need a change to move the storage into Node. 

2. **Loop parsing and conversion** 
   2.1 Refactor custom_rnn_rewriter, put some logic into its base class LoopRewriterBase. 
   2.2 LoopRewriter is implemented inheriting LoopRewriterBase

3. **Remove useless code**:
   Originally the process we handle custom rnn conversion is: 1). parse loop 2). check is rnn 3). find subgraph boundary node (ids), put it into a global dict indexed with Scan node's name. 4). op mapping 5). check all Scan node, find  its' subgraphs inputs/outputs, get all related nodes, create a Graph and set it into Scan's attribute. 
   So we have rewrite_custom_rnn_cell at the beginning , and also have a rewrite_custom_rnn_body_graph, which is in the later rewriter.

   Now, when we do rewriting in the beginning, we organize nodes in recursive mode, and op mapping is done recursively as well, we don't have extra need in later rewriter except the rs6 target flag.

4. TF graph shape inference for TensorArray ops.
    It is observed in internel models, some output don't have shape returned calling TF API, so enriching the TA ops shape inferencing (which is very simple) help us get there easily. The reason I did not check it in seperately: I found enabling this in a single change will make some testing failed. 


**About testing:**

- python tests\backend.py --opset 7/8
- python tests\lstm.py
- python tests\gru(block).py
- python tests\test_loops.py
- python tests\test_graph.py
- python tests\test_optimizer.py
- python tests\test_custom_rnn.py --opset 8
- python tests\run_pretrained_models.py --backend onnxruntime  --config tests\run_pretrained_models.yaml  --fold_const --onnx-file ".\tmp" --opset 8
- python tests\run_pretrained_models.py --backend onnxruntime --config tests\internal-rnn.yaml   --fold_const --onnx-file ".\tmp" --opset 8 --target rs6   **(13 RNN models we have converted are all successful)**
- python tests\run_pretrained_models.py --backend onnxruntime --config tests\internal-cnn.yaml   --fold_const --onnx-file ".\tmp" --opset 8 --target rs6  **(5 of 6 total CNN model are successful, the other 1 is an known issue)**
- python -m tf2onnx.convert --input tests\internal\cnns\classical\resnet_v2_152_inf_graph.pb --inputs input:0 --outputs resnet_v2_152/predictions/Reshape_1:0 --output res152.onnx --verbose --fold_const