### PR TITLE
azure pipeline install pandas on setup

### DIFF
--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -3,7 +3,7 @@
 steps:
 - bash: |
     set -ex
-    pip install pytest pytest-cov pytest-runner graphviz requests pyyaml pillow
+    pip install pytest pytest-cov pytest-runner graphviz requests pyyaml pillow pandas
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME)
     python setup.py install
     pip freeze --all


### PR DESCRIPTION
azure pipeline is failing, the root cause is:
Keras-Applications and Keras-Preprocessing JUST released new versions on pypi.
now pandas is required by one of them, but is not added as a install_requires package.

install pandas explicitly to fix this issue.