### PR TITLE
back out experimental op dynamicslice support

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -832,18 +832,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
-    @unittest.skipIf(*support_op_conversion_since(9, "slice"))
-    def test_slice_with_non_const(self):
-        x_val = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.float32)
-        t1 = np.array([0, 1], dtype=np.int32)
-        t2 = np.array([2, 2], dtype=np.int32)
-        x0 = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
-        t1_ = tf.placeholder(tf.int32, t1.shape, name=_TFINPUT1)
-        t2_ = tf.placeholder(tf.int32, t2.shape, name=_TFINPUT2)
-        x_ = tf.slice(x0, t1_, t2_)
-        _ = tf.identity(x_, name=_TFOUTPUT)
-        self._run_test_case([_OUTPUT], {_INPUT: x_val, _INPUT1: t1, _INPUT2: t2})
-
     def test_split(self):
         x_val = np.linspace(1.0, 5 * 30.0, 5 * 30).astype(np.float32).reshape(5, 30)
         x0 = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -915,18 +915,6 @@ def concatv2_op(ctx, node, name, args):
     return node
 
 
-def dynamic_slice_op(ctx, node, name, args):
-    # tf op, T output = Slice(T input, Index begin, Index size, @type Index)
-    # onnx op, T output = DynamicSlice(T input, Tind starts, Tind ends, (optional)Tind axes), ends are exclusive
-
-    starts = node.inputs[1]
-    size = node.inputs[2]
-    ends = ctx.make_node("Add", [starts.output[0], size.output[0]])
-    new_slice = ctx.make_node("DynamicSlice", [*node.input[0:2], ends.output[0]],
-                              name=node.name, outputs=node.output)
-    return [ends, new_slice]
-
-
 def slice_op(ctx, node, name, args):
     # T output = Slice(T input, Index begin, Index size, @type Index)
     # T output = Slice(T data, @INTS axes, @INTS ends, @INTS starts)
@@ -1928,7 +1916,6 @@ _OPSET_9 = {
     "Atanh": (direct_op, []),
     "ResizeBilinear": (upsample_op9, ["Upsample", "linear"]),
     "ResizeNearestNeighbor": (upsample_op9, ["Upsample", "nearest"]),
-    "Slice": (dynamic_slice_op, []),
 }
 
 _OPSETS = [


### PR DESCRIPTION
should not use experimental op, otherwise it's hard to get all converted models available for common runtimes. 