### PR TITLE
remain Const/Placeholder as it is, util we make_graph at last

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1538,7 +1538,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         res = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=label, logits=logits)
         _ = tf.identity(res, name=_TFOUTPUT)
 
-        self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val})
+        self._run_test_case([_OUTPUT], {_INPUT: label_val, _INPUT1: logits_val}, rtol=1e-6)
 
     @unittest.skipIf(BACKEND in ["onnxruntime"], "onnxruntime Slice did not supported BOOL.")
     def test_matrix_band_part(self):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -115,7 +115,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             x_ = tf.abs(x)
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
-            self.assertEqual('digraph { Abs [op_type=Abs] output [op_type=Identity] input:0 -> Abs Abs:0 -> output }',
+            self.assertEqual('digraph { input [op_type=Placeholder shape="[2, 3]"]'\
+                             ' Abs [op_type=Abs] output [op_type=Identity] input:0 -> Abs Abs:0 -> output }',
                              onnx_to_graphviz(g))
 
     def test_randomuniform(self):
@@ -154,9 +155,11 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             actual = onnx_to_graphviz(g)
-            expected = 'digraph { Add [op_type=Add] Dropout__3 [op_type=Dropout] output1 [op_type=Identity] ' \
-                       'output2 [op_type=Identity] output [op_type=Identity] input1:0 -> Add input2:0 -> ' \
-                       'Add Add:0 -> Dropout__3 Dropout__3:0 -> output1 output1:0 -> output2 output2:0 -> output }'
+            expected = 'digraph { prob [op_type=Placeholder shape="[]"] input2 [op_type=Placeholder shape="[1, 3]"] ' \
+                       'input1 [op_type=Placeholder shape="[2, 3]"] Add [op_type=Add] Dropout__3 [op_type=Dropout] ' \
+                       'output1 [op_type=Identity] output2 [op_type=Identity] output [op_type=Identity] ' \
+                       'input1:0 -> Add input2:0 -> Add Add:0 -> Dropout__3 Dropout__3:0 -> output1 ' \
+                       'output1:0 -> output2 output2:0 -> output }'
             self.assertEqual(expected, actual)
 
     def test_add(self):
@@ -167,8 +170,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Add [op_type=Add] output [op_type=Identity] input1:0 -> Add input2:0 -> '
-                'Add Add:0 -> output }',
+                'digraph { input2 [op_type=Placeholder shape="[1, 3]"] input1 [op_type=Placeholder shape="[2, 3]"] '
+                'Add [op_type=Add] output [op_type=Identity] input1:0 -> Add input2:0 -> Add Add:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_squareddifference(self):
@@ -179,7 +182,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { SquaredDifference [op_type=Sub] SquaredDifference__2 [op_type=Mul] '
+                'digraph { input2 [op_type=Placeholder shape="[1, 3]"] input1 [op_type=Placeholder shape="[1, 3]"] '
+                'SquaredDifference [op_type=Sub] SquaredDifference__2 [op_type=Mul] '
                 'output [op_type=Identity] input1:0 -> SquaredDifference input2:0 -> SquaredDifference '
                 'SquaredDifference:0 -> SquaredDifference__2 SquaredDifference:0 -> SquaredDifference__2 '
                 'SquaredDifference__2:0 -> output }',
@@ -192,7 +196,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Sum [op_type=ReduceSum] output [op_type=Identity] input1:0 -> Sum Sum:0 -> output }',
+                'digraph { Const [op_type=Const] input1 [op_type=Placeholder shape="[2, 3]"] '
+                'Sum [op_type=ReduceSum] output [op_type=Identity] input1:0 -> Sum Sum:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_argminmax(self):
@@ -202,7 +207,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { ArgMin [op_type=ArgMin] output [op_type=Identity] input1:0 -> ArgMin ArgMin:0 -> output }',
+                'digraph { "ArgMin/dimension" [op_type=Const] input1 [op_type=Placeholder shape="[2, 3]"] ' \
+                'ArgMin [op_type=ArgMin] output [op_type=Identity] input1:0 -> ArgMin ArgMin:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_rsqrt(self):
@@ -212,8 +218,9 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Rsqrt [op_type=Sqrt] Rsqrt__2 [op_type=Reciprocal] output [op_type=Identity] '
-                'input1:0 -> Rsqrt Rsqrt:0 -> Rsqrt__2 Rsqrt__2:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[2, 3]"] Rsqrt [op_type=Sqrt] '
+                'Rsqrt__2 [op_type=Reciprocal] output [op_type=Identity] input1:0 -> Rsqrt '
+                'Rsqrt:0 -> Rsqrt__2 Rsqrt__2:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_relu6(self):
@@ -223,7 +230,9 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Relu6 [op_type=Max] Relu6__4 [op_type=Min] output [op_type=Identity] input1:0 -> Relu6 '
+                'digraph { Relu6__3 [op_type=Const] Relu6__2 [op_type=Const] '
+                'input1 [op_type=Placeholder shape="[2, 3]"] Relu6 [op_type=Max] '
+                'Relu6__4 [op_type=Min] output [op_type=Identity] input1:0 -> Relu6 '
                 'Relu6__2 -> Relu6 Relu6:0 -> Relu6__4 Relu6__3 -> Relu6__4 Relu6__4:0 -> output }',
                 onnx_to_graphviz(g))
 
@@ -251,10 +260,12 @@ class Tf2OnnxGraphTests(unittest.TestCase):
 
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Conv2D__2 [op_type=Transpose] kernel [op_type=Reshape] Conv2D__3 [op_type=Transpose] '
-                'Conv2D [op_type=Conv] Conv2D__4 [op_type=Transpose] output [op_type=Identity] '
-                'input1:0 -> Conv2D__2 k:0 -> kernel "kernel/shape":0 -> kernel kernel:0 -> Conv2D__3 '
-                'Conv2D__2:0 -> Conv2D Conv2D__3:0 -> Conv2D Conv2D:0 -> Conv2D__4 Conv2D__4:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[1, 4, 4, 1]"] Conv2D__2 [op_type=Transpose] '
+                '"kernel/shape" [op_type=Const] k [op_type=Const] kernel [op_type=Reshape] '
+                'Conv2D__3 [op_type=Transpose] Conv2D [op_type=Conv] Conv2D__4 [op_type=Transpose] '
+                'output [op_type=Identity] input1:0 -> Conv2D__2 k:0 -> kernel "kernel/shape":0 -> kernel '
+                'kernel:0 -> Conv2D__3 Conv2D__2:0 -> Conv2D Conv2D__3:0 -> Conv2D '
+                'Conv2D:0 -> Conv2D__4 Conv2D__4:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_squeeze(self):
@@ -264,8 +275,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Squeeze [op_type=Squeeze] output [op_type=Identity] input1:0 -> Squeeze '
-                'Squeeze:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[2, 3]"] Squeeze [op_type=Squeeze] '\
+                'output [op_type=Identity] input1:0 -> Squeeze Squeeze:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_cast(self):
@@ -275,7 +286,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Cast [op_type=Cast] output [op_type=Identity] input1:0 -> Cast Cast:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[2, 3]"] Cast [op_type=Cast] output [op_type=Identity] '\
+                'input1:0 -> Cast Cast:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_reshape(self):
@@ -285,7 +297,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
             self.assertEqual(
-                'digraph { Reshape [op_type=Reshape] output [op_type=Identity] input1:0 -> Reshape '
+                'digraph { "Reshape/shape" [op_type=Const] input1 [op_type=Placeholder shape="[2, 3]"] '
+                'Reshape [op_type=Reshape] output [op_type=Identity] input1:0 -> Reshape '
                 '"Reshape/shape":0 -> Reshape Reshape:0 -> output }',
                 onnx_to_graphviz(g))
 
@@ -308,8 +321,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph, custom_rewriter=[rewrite_test])
             self.assertEqual(
-                'digraph { Add [op_type=Mul] output [op_type=Identity] input1:0 -> '
-                'Add input1:0 -> Add Add:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[2, 3]"] Add [op_type=Mul] '
+                'output [op_type=Identity] input1:0 -> Add input1:0 -> Add Add:0 -> output }',
                 onnx_to_graphviz(g))
 
     def test_custom_op(self):
@@ -333,7 +346,8 @@ class Tf2OnnxGraphTests(unittest.TestCase):
                                  custom_op_handlers={"Print": print_handler},
                                  extra_opset=helper.make_opsetid(_TENSORFLOW_DOMAIN, 1))
             self.assertEqual(
-                'digraph { Print [op_type=Identity] output [op_type=Identity] input1:0 -> Print Print:0 -> output }',
+                'digraph { input1 [op_type=Placeholder shape="[2, 3]"] Print [op_type=Identity] '
+                'output [op_type=Identity] input1:0 -> Print Print:0 -> output }',
                 onnx_to_graphviz(g))
 
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tf2onnx
 import tf2onnx.utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
-from tf2onnx.graph import Graph
+from tf2onnx.graph import Graph, GraphUtil
 
 # pylint: disable=missing-docstring
 
@@ -43,8 +43,8 @@ def onnx_to_graphviz(g):
 
 def onnx_pretty(g, args=None):
     """Onnx graph pretty print."""
-    model_proto = g.make_model("converted from {}".format(args.input))
-    return helper.printable_graph(model_proto.graph)
+    graph_proto = g.make_model("converted from {}".format(args.input))
+    return helper.printable_graph(graph_proto.graph)
 
 
 class Tf2OnnxInternalTests(unittest.TestCase):
@@ -73,60 +73,63 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         n5 = helper.make_node("Abs", ["n4:0"], ["n5:0"], name="n5")
         n6 = helper.make_node("Identity", ["n5:0"], ["n6:0"], name="n6")
 
-        model_proto = helper.make_graph(
+        graph_proto = helper.make_graph(
             nodes=[n1, n2, n3, n4, n5, n6],
             name="test",
             inputs=[helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 2])],
             outputs=[helper.make_tensor_value_info("n5:0", TensorProto.FLOAT, [2, 2])],
             initializer=[]
         )
-        return model_proto
+        return graph_proto
 
     def test_insert_node1(self):
-        model_proto = self.sample_net()
-        nodes = model_proto.node
-        g = Graph(nodes, output_shapes={}, dtypes={})
+        graph_proto = self.sample_net()
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         n2 = g.get_node_by_name("n2")
         n7 = g.insert_new_node_on_input(n2, "Abs", "n1:0", name="n7")
         ops = g.get_nodes()
         ops.append(n7)
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { n1 [op_type=Abs] n7 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] ' \
-                   'n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n7 n7:0 -> n2 n1:0 -> n3 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5:0 -> n6 }'
+        expected = 'digraph { Placeholder__4 [op_type=Placeholder] ' \
+                   'n1 [op_type=Abs] n7 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] ' \
+                   'n4 [op_type=Add] n5 [op_type=Abs] graph_outputs_Identity__3 [op_type=Identity] ' \
+                   'n6 [op_type=Identity] input -> n1 n1:0 -> n7 n7:0 -> n2 n1:0 -> n3 ' \
+                   'n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 raw_output___2:0 -> graph_outputs_Identity__3 ' \
+                   'raw_output___2:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_insert_node2(self):
-        model_proto = self.sample_net()
-        nodes = model_proto.node
-        g = Graph(nodes, output_shapes={}, dtypes={})
+        graph_proto = self.sample_net()
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         n7 = g.insert_new_node_on_output("Abs", "n1:0", name="n7")
         ops = g.get_nodes()
         ops.append(n7)
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { n1 [op_type=Abs] n7 [op_type=Abs] n3 [op_type=Abs] n2 [op_type=Abs] ' \
-                   'n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5:0 -> n6 }'
+        expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n7 [op_type=Abs] ' \
+                   'n3 [op_type=Abs] n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
+                   'graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
+                   'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 ' \
+                   'n4:0 -> n5 raw_output___2:0 -> graph_outputs_Identity__3 raw_output___2:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_remove_input(self):
-        model_proto = self.sample_net()
-        nodes = model_proto.node
-        g = Graph(nodes, output_shapes={}, dtypes={})
+        graph_proto = self.sample_net()
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         n4 = g.get_node_by_name("n4")
         g.remove_input(n4, n4.input[1])
         result = onnx_to_graphviz(g)
         expected = 'digraph { n1 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] n4 [op_type=Add] ' \
-                   'n5 [op_type=Abs] n6 [op_type=Identity] input -> n1 n1:0 -> n2 n1:0 -> n3 n2:0 -> n4 ' \
-                   'n4:0 -> n5 n5:0 -> n6 }'
+                   'n5 [op_type=Abs] n6 [op_type=Identity] graph_outputs_Identity__3 ' \
+                   '[op_type=Identity] Placeholder__4 [op_type=Placeholder] input -> n1 ' \
+                   'n1:0 -> n2 n1:0 -> n3 n2:0 -> n4 n4:0 -> n5 raw_output___2:0 -> n6 ' \
+                   'raw_output___2:0 -> graph_outputs_Identity__3 }'
         self.assertEqual(expected, result)
 
     def test_rewrite_subgraph(self):
-        model_proto = self.sample_net()
-        nodes = model_proto.node
-        g = tf2onnx.graph.Graph(nodes, output_shapes={}, dtypes={})
+        graph_proto = self.sample_net()
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         pattern = \
             OpTypePattern('Abs', name='output', inputs=[
                 OpTypePattern('Add', name='input')
@@ -143,9 +146,12 @@ class Tf2OnnxInternalTests(unittest.TestCase):
             ops = g.replace_subgraph(ops, match, [], [output_node], [], [new_node])
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { n1 [op_type=Abs] n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__2 [op_type=Sub] ' \
-                   'n6 [op_type=Identity] input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__2 ' \
-                   'n3:0 -> ReplacedOp__2 ReplacedOp__2:0 -> n6 }'
+        expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] ' \
+                   'n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__5 [op_type=Sub] ' \
+                   'graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
+                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__5 ' \
+                   'n3:0 -> ReplacedOp__5 ReplacedOp__5:0 -> graph_outputs_Identity__3 ' \
+                   'ReplacedOp__5:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_match_flipped(self):
@@ -153,7 +159,7 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         n2 = helper.make_node("Add", ["i2", "i2"], ["n2:0"], name="n2")
         n3 = helper.make_node("Mul", ["n1:0", "n2:0"], ["n3:0"], name="n3")
 
-        model_proto = helper.make_graph(
+        graph_proto = helper.make_graph(
             nodes=[n1, n2, n3],
             name="test",
             inputs=[helper.make_tensor_value_info("i1", TensorProto.FLOAT, [2, 2]),
@@ -161,8 +167,7 @@ class Tf2OnnxInternalTests(unittest.TestCase):
             outputs=[helper.make_tensor_value_info("n2:0", TensorProto.FLOAT, [2, 2])],
             initializer=[]
         )
-        nodes = model_proto.node
-        g = tf2onnx.graph.Graph(nodes, output_shapes={}, dtypes={})
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         pattern = OpTypePattern('Mul', inputs=[
             OpTypePattern('Add'),
             OpTypePattern('Sub')

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tf2onnx
 import tf2onnx.utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
-from tf2onnx.graph import Graph, GraphUtil
+from tf2onnx.graph import GraphUtil
 
 # pylint: disable=missing-docstring
 

--- a/tf2onnx/function/gathernd.py
+++ b/tf2onnx/function/gathernd.py
@@ -23,6 +23,7 @@ def _make_gathernd_inner_loop(ctx, params, index, dtype):
     trip_node = ctx.make_node("Size", [index.output[0]])
     nodes.append(trip_node)
     cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
+    nodes.append(cond_const)
     trip_name = utils.make_name("i")
     cond_name = utils.make_name("cond")
     cond_out_name = utils.make_name("cond_out")
@@ -78,6 +79,7 @@ def make_gathernd(ctx, params, indices, output, scope_name, t_params):
     # for (int i=0; i<outter_shape; i++) inner_loop(params, flatten_indices[i])
     cond_const = ctx.make_const(utils.make_name("cond"), np.ones((), dtype=np.bool))
     dummy_const = ctx.make_const(utils.make_name("dummy"), np.ones((), dtype=np.int64))
+    nodes.extend([cond_const, dummy_const])
 
     # body graph creation
     g = ctx.create_new_graph_with_same_config()
@@ -143,6 +145,7 @@ def make_gathernd(ctx, params, indices, output, scope_name, t_params):
                                    outputs=[output])
     nodes.extend([indices_outter_shape,
                   inner_loop_shape,
+                  one_const,
                   inner_loop_shape_,
                   output_inner_shape,
                   output_shape_,

--- a/tf2onnx/function/range.py
+++ b/tf2onnx/function/range.py
@@ -21,7 +21,8 @@ def make_range_const(ctx, start, limit, delta, output, scope_name, dtype):
     delta = ctx.get_node_by_output(delta).get_tensor_value(as_list=False)
     val = np.arange(start, limit, delta, dtype=start.dtype)
     const_range = ctx.make_const(base_name, val)
-    return ctx.make_node("Identity", [const_range.output[0]], dtypes=[dtype], outputs=[output])
+    return [ctx.make_node("Identity", [const_range.output[0]], dtypes=[dtype], outputs=[output]),
+            const_range]
 
 
 def make_range_non_const(ctx, start, limit, delta, output, scope_name, dtype):
@@ -65,7 +66,7 @@ def make_range_non_const(ctx, start, limit, delta, output, scope_name, dtype):
     # cond
     # Use initializer here since Constant OP before opset 9 does not support bool type
     cond_name = "{}_cond".format(base_name)
-    ctx.make_const(cond_name, np.ones((), dtype=bool))
+    nodes.append(ctx.make_const(cond_name, np.ones((), dtype=bool)))
 
     # body
     g = ctx.create_new_graph_with_same_config()

--- a/tf2onnx/function/select.py
+++ b/tf2onnx/function/select.py
@@ -92,11 +92,11 @@ def select_op8(ctx, node, name, args):
 def create_loop_op(g, gather_input_ids, output_type, output_shape, trip_count_input_ids, rank):
     nodes = []
     cond_var_name = utils.make_name("cond_var")
-    g.make_const(cond_var_name, np.array(True, dtype=np.bool))
+    nodes.append(g.make_const(cond_var_name, np.array(True, dtype=np.bool)))
 
     # Loop requires at least a variable, add a useless fake variable.
     fake_val_name = utils.make_name("fake_var")
-    g.make_const(fake_val_name, np.array(0.0, dtype=np.float32))
+    nodes.append(g.make_const(fake_val_name, np.array(0.0, dtype=np.float32)))
 
     if rank < 1:
         raise ValueError("rank is < 1")
@@ -130,7 +130,6 @@ def get_inputs_for_current_iteration(g, input_id, iter_index):
 def create_loop_body_graph(parent_g, gather_input_ids, output_data_type, output_shape, trip_count_input_ids,
                            rank, loop_name):
     g = parent_g.create_new_graph_with_same_config()
-    nodes = []
     iter_name = utils.make_name("i")
     cond_name = utils.make_name("cond")
     fake_var_name = utils.make_name("fake_var")
@@ -138,7 +137,7 @@ def create_loop_body_graph(parent_g, gather_input_ids, output_data_type, output_
     g.add_graph_input(iter_name, TensorProto.INT64, (1,))  # iteration_num
     g.add_graph_input(cond_name, TensorProto.BOOL, ())  # condition
     g.add_graph_input(fake_var_name, TensorProto.FLOAT, ())  # loop-carried dependency
-
+    nodes = g.get_nodes()
     # get the i'th value of condition
     cond_input_id = gather_input_ids[0]
     new_nodes, cond_input_id_for_current_iter = get_inputs_for_current_iteration(g, cond_input_id, iter_name)

--- a/tf2onnx/function/sparse_softmax_cross_entropy_with_logits.py
+++ b/tf2onnx/function/sparse_softmax_cross_entropy_with_logits.py
@@ -42,7 +42,8 @@ def sparse_softmax_cross_entropy_with_logits_op(ctx, node, name, args):
     mul2 = ctx.make_node(op_type="Mul", inputs=[const_negative_one.output[0], reduce_sum.output[0]])
     res = ctx.make_node(op_type="Squeeze", inputs=[mul2.output[0]], outputs=[node.output[0]], attr={"axes": [1]})
 
-    return [onehot, log_softmax, mul1, reduce_sum, mul2, res]
+    return [const_eye, onehot, log_softmax, mul1, reduce_sum,
+            const_negative_one, mul2, res]
 
 
 def sparse_softmax_cross_entropy_with_logits_op_by_gathernd(ctx, node, name, args):
@@ -95,5 +96,6 @@ def sparse_softmax_cross_entropy_with_logits_op_by_gathernd(ctx, node, name, arg
                         inputs=[mul2.output[0]], outputs=[node.output[0]],
                         attr={"axes": [1]})
 
-    nodes.extend([indices_size, indices_unsqueeze, id_unsqueeze, indices_with_id, log_softmax, mul2, res])
+    nodes.extend([zero_const, one_const, indices_size, indices_unsqueeze, id_unsqueeze, indices_with_id,
+                  log_softmax, const_negative_one, mul2, res])
     return nodes

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1041,6 +1041,10 @@ class GraphUtil(object):
         for n in graph_proto.node:
             if n.op_type == "Constant":
                 n.op_type = "Const"
+
+            # some pytorch model had empty names - make one up
+            if not n.name:
+                n.name = utils.make_name("was_empty")
             nodes_to_append.append(n)
 
         output_names = []

--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -53,12 +53,15 @@ def process_bigru(g, bi_grus):
         # create node
         w_name = utils.make_name("W")
         w_node = g.make_const(w_name, W, skip_conversion=True)
+        all_nodes.append(w_node)
 
         r_name = utils.make_name("R")
         r_node = g.make_const(r_name, R, skip_conversion=True)
+        all_nodes.append(r_node)
 
         b_name = utils.make_name("B")
         b_node = g.make_const(b_name, B, skip_conversion=True)
+        all_nodes.append(b_node)
         gru_inputs = [gru_fw.input[0], w_node.output[0],
                       r_node.output[0], b_node.output[0]]
         if len(gru_fw.inputs) > 4:

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -212,6 +212,7 @@ class CustomRnnRewriter(LoopRewriterBase):
             if inferred_shape is not None and inferred_shape[1:].count(-1) <= 1:
                 new_shape_node = self.g.make_const(utils.make_name(target_name + "_target_shape"),
                                                    np.array(inferred_shape[1:], dtype=np.int64))
+                nodes_to_add.append(new_shape_node)
             else:
                 # otherwise, get the dim dynamically, e.g. remove the fake batch size (e.g.1)
                 # from [1, time, real-batch, ...]
@@ -233,10 +234,12 @@ class CustomRnnRewriter(LoopRewriterBase):
             if inferred_shape is not None and inferred_shape.count(-1) <= 1:
                 new_shape_node = self.g.make_const(utils.make_name(target_name + "_target_shape"),
                                                    np.array([1] + inferred_shape, dtype=np.int64))
+                nodes_to_add.append(new_shape_node)
             else:
                 # add a fake batch size : 1
                 fake_batch_size_node = self.g.make_const(utils.make_name(target_name + "_target_shape"),
                                                          np.array([1,], dtype=np.int64))
+                nodes_to_add.append(fake_batch_size_node)
                 new_shape_node = self.g.make_node("Concat",
                                                   [fake_batch_size_node.output[0], shape_node.output[0]],
                                                   attr={"axis": 0})

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -255,6 +255,8 @@ class GRUUnitRewriter(UnitRewriterBase):
         rnn_props.onnx_input_ids["R"] = r_node.output[0]
         rnn_props.onnx_input_ids["B"] = b_node.output[0]
 
+        return [w_node, r_node, b_node]
+
     def process_var_init_nodes(self, rnn_props):
         assert "state" in rnn_props.var_initializers.keys()
         found_node_id = rnn_props.var_initializers["state"]

--- a/tf2onnx/rewriter/loop_rewriter.py
+++ b/tf2onnx/rewriter/loop_rewriter.py
@@ -38,7 +38,7 @@ class LoopRewriter(LoopRewriterBase):
 
     def rewrite(self, context):
         log.debug("enter rewrite function")
-        loop_node = None
+        loop_nodes = None
         try:
             loop_props = context.loop_properties
             cell_g_info = context.cell_graph
@@ -97,14 +97,14 @@ class LoopRewriter(LoopRewriterBase):
 
 
             ## create Loop node
-            loop_node = self._create_loop_node(context, loop_props)
-            if not loop_node:
+            loop_nodes = self._create_loop_node(context, loop_props)
+            if not loop_nodes:
                 log.error("failed to create loop node during rewrite")
                 return REWRITER_RESULT.FAIL
-            loop_node.set_body_graph_as_attr("body", loop_body_g)
+            loop_nodes[0].set_body_graph_as_attr("body", loop_body_g)
 
             all_nodes = self.g.get_nodes()
-            all_nodes.append(loop_node)
+            all_nodes.extend(loop_nodes)
             self.g.set_nodes(all_nodes)
 
             log.debug("rewrite successfully")
@@ -133,4 +133,4 @@ class LoopRewriter(LoopRewriterBase):
                                      outputs=loop_outputs, op_name_scope="generic_loop",
                                      skip_conversion=False)
 
-        return loop_node
+        return [loop_node, trip_cnt, cond]

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -192,6 +192,8 @@ class LSTMUnitRewriter(UnitRewriterBase):
         rnn_props.onnx_input_ids["R"] = r_node.output[0]
         rnn_props.onnx_input_ids["B"] = b_node.output[0]
 
+        return [w_node, r_node, b_node]
+
     def process_var_init_nodes(self, rnn_props):
         init_h_id = None
         init_c_id = None

--- a/tf2onnx/rewriter/unit_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rewriter_base.py
@@ -122,7 +122,8 @@ class UnitRewriterBase(object):
             return REWRITER_RESULT.SKIP
 
         self.print_step("process the weights/bias/ft_bias, to fit onnx weights/bias requirements")
-        self.process_weights_and_bias(rnn_weights, rnn_props)
+        nodes = self.process_weights_and_bias(rnn_weights, rnn_props)
+        self.all_nodes.extend(nodes)
 
         _, batch_size_node = self.process_seq_length(rnn_props, seq_len_input_node)
         rnn_props.batch_size_node = batch_size_node
@@ -435,7 +436,8 @@ class UnitRewriterBase(object):
 
         const_node = self.g.make_const(utils.make_name("Const"), np.array([[[fill_val]]], dtype=fill_val_dtype))
         tile_node = self.g.make_node("Tile", [const_node.output[0], tile_shape_int64.output[0]])
-        self.all_nodes.extend([tile_shape, tile_shape_int64, tile_node])
+        self.all_nodes.extend([tile_shape, tile_shape_int64, tile_node,
+                               num_direction_node, h_node, const_node])
         return tile_node
 
     def _convert_timemajor_transpose(self, node):

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -193,6 +193,13 @@ def map_tf_dtype(dtype):
     return dtype
 
 
+def map_numpy_to_onnx_dtype(np_dtype):
+    for onnx_dtype, numpy_dtype in ONNX_TO_NUMPY_DTYPE.items():
+        if numpy_dtype == np_dtype:
+            return onnx_dtype
+    raise ValueError("unsupported dtype " + np_dtype + " for mapping")
+
+
 def node_name(name):
     """Get node name without io#."""
     pos = name.find(":")

--- a/tools/onnx-experiments.py
+++ b/tools/onnx-experiments.py
@@ -22,7 +22,7 @@ import onnx
 from onnx import numpy_helper
 
 import tf2onnx.utils
-from tf2onnx.graph import Graph
+from tf2onnx.graph import Graph, GraphUtil
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("onnx-experiments")
@@ -41,48 +41,7 @@ def load_graph(fname):
     with open(fname, "rb") as f:
         data = f.read()
         model_proto = onnx.ModelProto()
-        model_proto.ParseFromString(data)
-        onnx_nodes = model_proto.graph.node
-        output_names = []
-
-        # some pytorch model had empty names - make one up
-        for node in onnx_nodes:
-            if not node.name:
-                node.name = tf2onnx.utils.make_name("was_empty")
-
-        g = Graph(onnx_nodes, output_shapes={}, dtypes={}, output_names=output_names)
-        for i in model_proto.graph.initializer:
-            v = numpy_helper.to_array(i)
-            name = i.name
-            g.initializers[name] = i
-            dtype = i.data_type
-            g.set_dtype(name, dtype)
-            g.set_shape(name, v.shape)
-        for i in model_proto.graph.input:
-            name = i.name
-            if name in g.initializers:
-                # ignore if it is not a model input
-                continue
-            shape = [j.dim_value if hasattr(i.type.tensor_type, "dim_value") else -1
-                     for j in i.type.tensor_type.shape.dim]
-            dtype = i.type.tensor_type.elem_type
-            g.set_dtype(name, dtype)
-            g.set_shape(name, shape)
-            g.add_graph_input(name, dtype, shape)
-        for i in model_proto.graph.output:
-            name = i.name
-            shape = [j.dim_value if hasattr(i.type.tensor_type, "dim_value") else -1
-                     for j in i.type.tensor_type.shape.dim]
-            dtype = i.type.tensor_type.elem_type
-            g.set_dtype(name, dtype)
-            g.set_shape(name, shape)
-            output_names.append(name)
-
-        # TODO: this is a hack in case a output name does not follow tensorflow convention
-        for node in g.get_nodes():
-            for name in node.output:
-                g._nodes_by_name[name] = node  # pylint: disable=protected-access
-
+        g = GraphUtil.create_graph_from_onnx_model(model_proto)
     return g, model_proto.producer_name
 
 

--- a/tools/onnx-experiments.py
+++ b/tools/onnx-experiments.py
@@ -19,10 +19,9 @@ import traceback
 
 import numpy as np
 import onnx
-from onnx import numpy_helper
 
 import tf2onnx.utils
-from tf2onnx.graph import Graph, GraphUtil
+from tf2onnx.graph import GraphUtil
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("onnx-experiments")
@@ -38,10 +37,8 @@ def get_args():
 
 
 def load_graph(fname):
-    with open(fname, "rb") as f:
-        data = f.read()
-        model_proto = onnx.ModelProto()
-        g = GraphUtil.create_graph_from_onnx_model(model_proto)
+    model_proto = onnx.ModelProto()
+    g = GraphUtil.create_graph_from_onnx_model(model_proto)
     return g, model_proto.producer_name
 
 


### PR DESCRIPTION
In this change, Const and Placeholder nodes are not converted during op mapping, instead, we make them into inputs/initializers during make_graph. If we want to add new input, we actually add new Placeholder node.

as mentioned in https://github.com/onnx/tensorflow-onnx/issues/280:,this change would be helpful since:
1). we can avoid creating dummy nodes just for code convenience and need take care of deletion when calling set_nodes(). 
2). we don't need main initializer in the Graph object (they are represented as node in the Graph), initializer is created in make_graph() only. 
