### PR TITLE
fix numpy dll missing issue with anaconda python on windows

### DIFF
--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -70,6 +70,8 @@ jobs:
 #        versionSpec: '$(CI_PYTHON_VERSION)'
 #        architecture: 'x64'
 
+# TODO: Conda Environment task is deprecating, move to raw python after issue above is fixed.
+# https://github.com/Microsoft/azure-pipelines-tasks/pull/9573
     - task: CondaEnvironment@1
       inputs:
         createCustomEnvironment: 'true'

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -77,6 +77,7 @@ jobs:
         createCustomEnvironment: 'true'
         environmentName: 'tf2onnx'
         packageSpecs: 'python=$(CI_PYTHON_VERSION)'
+        updateConda: 'false'
 
     - ${{ if eq(parameters.run_setup, 'True') }}:
       - template: 'setup.yml'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -8,3 +8,17 @@ steps:
     python setup.py install
     pip freeze --all
   displayName: 'Setup Environment'
+
+# TODO: remove later
+# Anaconda python 3.6.8 h9f7ef89_1 changed dll lookup logic, numpy failes to load dll on Windows
+# https://github.com/numpy/numpy/issues/12957
+# https://github.com/ContinuumIO/anaconda-issues/issues/10629
+# Add numpy lib path manually here
+- bash: |
+    site_dir=$(python -c "import site; print(site.getsitepackages()[1])")
+    echo "##vso[task.prependpath]$site_dir\numpy\.libs"
+  displayName: 'Fix numpy path'
+  condition: and(succeeded(), in(variables['Agent.OS'], 'Windows_NT'))
+
+- bash: env
+  displayName: 'Display Environment Variables'


### PR DESCRIPTION
unit test and pretrained model test with matrix are failing recently.
the root cause is:
anaconda updates its python package with dll lookup logic changed.
it causes numpy fails to find required dll on Windows.

more information here:
https://github.com/numpy/numpy/issues/12957
https://github.com/ContinuumIO/anaconda-issues/issues/10629

as a workaround, add numpy lib directory to path explicitly to resolve this issue.

eventually, we should use raw python instead of anaconda.
the reason that anaconda is used currently is: shared python so is missing for azure pipeline hosted agent, which causes onnxruntime failure. 
