### PR TITLE
fix CI failure, refine test code

### DIFF
--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -5,7 +5,6 @@ jobs:
   parameters:
     platforms: ['linux', 'windows', 'mac']
     tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
-    onnx_versions: ['1.3']
     onnx_opsets: ['8', '7']
     onnx_backends:
       onnxruntime: ['0.2.1']

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -5,6 +5,14 @@ steps:
     set -ex
     pip install pytest pytest-cov pytest-runner graphviz requests pyyaml pillow pandas
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME)
+
+    # TF 1.10 requires numpy <=1.14.5 and >=1.13.3, but onnxruntime 0.2.1 does not work with numpy <= 1.14.5
+    # Upgrade numpy only within constraints from other packages if any.
+    if [[ $CI_TF_VERSION == 1.10* ]] && [[ $CI_ONNX_BACKEND == "onnxruntime" ]] ;
+    then
+        pip install $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME) numpy --no-deps -U
+    fi
+
     python setup.py install
     pip freeze --all
   displayName: 'Setup Environment'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -5,7 +5,6 @@ jobs:
   parameters:
     platforms: ['linux', 'windows', 'mac']
     tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
-    onnx_versions: ['1.3']
     onnx_opsets: ['8', '7']
     onnx_backends:
       onnxruntime: ['0.2.1']

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,4 @@
 test=pytest
 
 [tool:pytest]
-addopts=--cov=tf2onnx --ignore=tests/test_custom_rnncell.py --ignore=tests/test_const_fold.py --ignore=tests/test_loops.py
-#testpaths=tests/test_*.py
+addopts=--cov=tf2onnx

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,206 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+""" test common utilities."""
+
+import argparse
+import os
+import sys
+import tempfile
+import unittest
+
+from distutils.version import LooseVersion
+from tf2onnx.tfonnx import DEFAULT_TARGET, POSSIBLE_TARGETS
+
+__all__ = ["TestConfig", "get_test_config", "unittest_main",
+           "check_tf_min_version", "check_opset_min_version", "check_target", "skip_onnxruntime_backend",
+           "skip_caffe2_backend", "check_onnxruntime_incompatibility"]
+
+
+# pylint: disable=missing-docstring
+
+class TestConfig(object):
+    def __init__(self):
+        self.platform = sys.platform
+        self.tf_version = self._get_tf_version()
+        self.opset = int(os.environ.get("TF2ONNX_TEST_OPSET", 7))
+        self.target = os.environ.get("TF2ONNX_TEST_TARGET", ",".join(DEFAULT_TARGET)).split(',')
+        self.backend = os.environ.get("TF2ONNX_TEST_BACKEND", "onnxruntime")
+        self.backend_version = self._get_backend_version()
+        self.is_debug_mode = False
+        self.temp_path = tempfile.mkdtemp()
+
+    @property
+    def is_mac(self):
+        return self.platform == "darwin"
+
+    @property
+    def is_onnxruntime_backend(self):
+        return self.backend == "onnxruntime"
+
+    @property
+    def is_caffe2_backend(self):
+        return self.backend == "caffe2"
+
+    def _get_tf_version(self):
+        import tensorflow as tf
+        return LooseVersion(tf.__version__)
+
+    def _get_backend_version(self):
+        version = None
+        if self.backend == "onnxruntime":
+            import onnxruntime as ort
+            version = ort.__version__
+        elif self.backend == "caffe2":
+            # TODO: get caffe2 version
+            pass
+
+        if version:
+            version = LooseVersion(version)
+        return version
+
+    def __str__(self):
+        return "\n\t".join(["TestConfig:",
+                            "platform={}".format(self.platform),
+                            "tf_version={}".format(self.tf_version),
+                            "opset={}".format(self.opset),
+                            "target={}".format(self.target),
+                            "backend={}".format(self.backend),
+                            "backend_version={}".format(self.backend_version),
+                            "is_debug_mode={}".format(self.is_debug_mode)])
+
+    @staticmethod
+    def load():
+        config = TestConfig()
+        # if not launched by pytest, parse console arguments to override config
+        if "pytest" not in sys.argv[0]:
+            parser = argparse.ArgumentParser()
+            parser.add_argument('--backend', default=config.backend,
+                                choices=["caffe2", "onnxmsrtnext", "onnxruntime"],
+                                help="backend to test against")
+            parser.add_argument('--opset', type=int, default=config.opset, help="opset to test against")
+            parser.add_argument("--target", default=",".join(config.target), choices=POSSIBLE_TARGETS,
+                                help="target platform")
+            parser.add_argument("--debug", help="output debugging information", action="store_true")
+            parser.add_argument('unittest_args', nargs='*')
+
+            args = parser.parse_args()
+            config.backend = args.backend
+            config.opset = args.opset
+            config.target = args.target.split(',')
+            config.is_debug_mode = args.debug
+
+            # Now set the sys.argv to the unittest_args (leaving sys.argv[0] alone)
+            sys.argv[1:] = args.unittest_args
+
+        return config
+
+
+# need to load config BEFORE main is executed when launched from script
+# otherwise, it will be too late for test filters to take effect
+_config = TestConfig.load()
+
+
+def get_test_config():
+    global _config
+    return _config
+
+
+def unittest_main():
+    print(get_test_config())
+    unittest.main()
+
+
+def _append_message(reason, message):
+    if message:
+        reason = reason + ": " + message
+    return reason
+
+
+def check_tf_min_version(min_required_version, message=""):
+    """ Skip if tf_version < min_required_version """
+    config = get_test_config()
+    reason = _append_message("conversion requires tf >= {}".format(min_required_version), message)
+    return unittest.skipIf(config.tf_version < LooseVersion(min_required_version), reason)
+
+
+def skip_tf_versions(excluded_versions, message=""):
+    """ Skip if tf_version SEMANTICALLY matches any of excluded_versions. """
+    config = get_test_config()
+    condition = False
+    reason = _append_message("conversion excludes tf {}".format(excluded_versions), message)
+
+    current_tokens = str(config.tf_version).split('.')
+    for excluded_version in excluded_versions:
+        exclude_tokens = excluded_version.split('.')
+        # assume len(exclude_tokens) <= len(current_tokens)
+        for i, exclude in enumerate(exclude_tokens):
+            if not current_tokens[i] == exclude:
+                break
+        condition = True
+
+    return unittest.skipIf(condition, reason)
+
+
+def check_opset_min_version(min_required_version, message=""):
+    """ Skip if opset < min_required_version """
+    config = get_test_config()
+    reason = _append_message("conversion requires opset >= {}".format(min_required_version), message)
+    return unittest.skipIf(config.opset < min_required_version, reason)
+
+
+def check_target(required_target, message=""):
+    """ Skip if required_target is NOT specified """
+    config = get_test_config()
+    reason = _append_message("conversion requires target {} specified".format(required_target), message)
+    return unittest.skipIf(required_target not in config.target, reason)
+
+
+def skip_onnxruntime_backend(message=""):
+    """ Skip if backend is onnxruntime """
+    config = get_test_config()
+    reason = _append_message("not supported by onnxruntime", message)
+    return unittest.skipIf(config.is_onnxruntime_backend, reason)
+
+
+def skip_caffe2_backend(message=""):
+    """ Skip if backend is caffe2 """
+    config = get_test_config()
+    reason = _append_message("not supported by caffe2", message)
+    return unittest.skipIf(config.is_caffe2_backend, reason)
+
+
+def check_onnxruntime_incompatibility(op):
+    """ Skip if backend is onnxruntime AND op is NOT supported in current opset """
+    config = get_test_config()
+
+    if not config.is_onnxruntime_backend:
+        return unittest.skipIf(False, None)
+
+    support_since = {
+        "Abs": 6,  # Abs-1
+        "Add": 7,  # Add-1, Add-6
+        "AveragePool": 7,  # AveragePool-1
+        "Div": 7,  # Div-1, Div-6
+        "Elu": 6,  # Elu-1
+        "Exp": 6,  # Exp-1
+        "Greater": 7,  # Greater-1
+        "Less": 7,  # Less-1
+        "Log": 6,  # Log-1
+        "Max": 6,  # Max-1
+        "Min": 6,  # Min-1
+        "Mul": 7,  # Mul-1, Mul-6
+        "Neg": 6,  # Neg-1
+        "Pow": 7,  # Pow-1
+        "Reciprocal": 6,  # Reciprocal-1
+        "Relu": 6,  # Relu-1
+        "Sqrt": 6,  # Sqrt-1
+        "Sub": 7,  # Sub-1, Sub-6
+        "Tanh": 6,  # Tanh-1
+    }
+
+    if op not in support_since or config.opset >= support_since[op]:
+        return unittest.skipIf(False, None)
+
+    reason = "{} is not supported by onnxruntime before opset {}".format(op, support_since[op])
+    return unittest.skipIf(True, reason)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+""" print pytest config."""
+
+from common import get_test_config
+
+
+def pytest_configure():
+    print(get_test_config())

--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -12,6 +12,8 @@ import numpy as np
 import tensorflow as tf
 
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 # pylint: disable=abstract-method,arguments-differ
@@ -25,7 +27,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
-        res = tf.cond(x[0] < y[0], lambda: x+y, lambda: x-y, name="test_cond")
+        res = tf.cond(x[0] < y[0], lambda: x + y, lambda: x - y, name="test_cond")
         _ = tf.identity(res, name="output")
 
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
@@ -40,11 +42,13 @@ class CondTests(Tf2OnnxBackendTestBase):
         x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         true_const = tf.constant(True, name="true_const", dtype=tf.bool)
+
         def cond_graph():
             with tf.name_scope("cond_graph", "cond_graph", [x, y]):
                 b = tf.constant(np.array([2, 1, 3], dtype=np.float32), name="b", dtype=tf.float32)
                 return b
-        res = tf.cond(true_const, lambda: x+y, cond_graph, name="test_cond")
+
+        res = tf.cond(true_const, lambda: x + y, cond_graph, name="test_cond")
         _ = tf.identity(res, name="output")
 
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
@@ -52,17 +56,19 @@ class CondTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port)
 
-    @unittest.skip("a very special case that true and false branch of tf.cond only \
-    contain a const node, which depends on Switch per control inputs")
+    @unittest.skip("a very special case that true and false branch of tf.cond only "
+                   "contain a const node, which depends on Switch per control inputs")
     def test_cond_with_only_const(self):
         x_val = np.array([1, 2, 3], dtype=np.float32)
         y_val = np.array([4, 5, 6], dtype=np.float32)
         x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
+
         def cond_graph():
             with tf.name_scope("cond_graph", "cond_graph", [x, y]):
                 b = tf.constant(10, name="b", dtype=tf.float32)
                 return b
+
         res = tf.cond(x[0] < y[0], cond_graph, cond_graph, name="test_cond")
         _ = tf.identity(res, name="output")
 
@@ -78,7 +84,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
-        res = tf.cond(x[0] < y[0], lambda: [x, x+y], lambda: [x, x-y], name="test")
+        res = tf.cond(x[0] < y[0], lambda: [x, x + y], lambda: [x, x - y], name="test")
         _ = tf.identity(res, name="output")
 
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
@@ -108,12 +114,16 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
+
         def cond_graph():
             def cond_graph1():
                 def cond_graph2():
                     return tf.cond(x[0] < y[0], lambda: x + y, lambda: tf.square(y))
+
                 return tf.cond(tf.reduce_any(x < y), cond_graph2, cond_graph2)
+
             return tf.cond(x[0] > y[0], cond_graph1, cond_graph1)
+
         res = tf.cond(x[0] < y[0], cond_graph, cond_graph, name="test_cond")
         _ = tf.identity(res, name="output")
 
@@ -128,6 +138,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y_val = np.array([4, 5, 6], dtype=np.float32)
         x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
+
         def cond_graph():
             b = tf.constant(np.array([0], dtype=np.int32), dtype=tf.int32)
             z = tf.gather_nd(x, b)
@@ -136,6 +147,7 @@ class CondTests(Tf2OnnxBackendTestBase):
             b = lambda i: tf.add(y, 1)
             r = tf.while_loop(c, b, [y])
             return tf.cond(x[0] > y[0], lambda: z, lambda: r)
+
         res = x[2] * tf.cond(x[0] < y[0], lambda: x, cond_graph, name="test_cond")
         _ = tf.identity(res, name="output")
 
@@ -179,7 +191,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
-        res = tf.case([(tf.reduce_all(x < 1), lambda: x+y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
+        res = tf.case([(tf.reduce_all(x < 1), lambda: x + y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
                       default=lambda: x, name="test_case")
         _ = tf.identity(res, name="output")
 
@@ -195,7 +207,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
-        res = tf.case([(tf.reduce_all(x < 1), lambda: x+y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
+        res = tf.case([(tf.reduce_all(x < 1), lambda: x + y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
                       default=lambda: x, name="test_case", exclusive=True)
         _ = tf.identity(res, name="output")
 
@@ -211,7 +223,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
-        res = tf.case([(tf.reduce_all(x < 1), lambda: x+y), (tf.reduce_all(y > 0), lambda: tf.square(y))])
+        res = tf.case([(tf.reduce_all(x < 1), lambda: x + y), (tf.reduce_all(y > 0), lambda: tf.square(y))])
         _ = tf.identity(res, name="output")
 
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
@@ -227,7 +239,7 @@ class CondTests(Tf2OnnxBackendTestBase):
         x = x + 1
         y = y + 1
         res = tf.case(
-            [(tf.reduce_all(x < 1), lambda: [x+y, x-y]), (tf.reduce_all(y > 0), lambda: [tf.abs(x), tf.square(y)])],
+            [(tf.reduce_all(x < 1), lambda: [x + y, x - y]), (tf.reduce_all(y > 0), lambda: [tf.abs(x), tf.square(y)])],
             default=lambda: [x, y], name="test_case"
         )
         _ = tf.identity(res, name="output")
@@ -244,12 +256,14 @@ class CondTests(Tf2OnnxBackendTestBase):
         y = tf.placeholder(tf.float32, y_val.shape, name="input_2")
         x = x + 1
         y = y + 1
+
         def case_graph():
             return tf.case(
-                [(tf.reduce_all(x < 1), lambda: x+y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
+                [(tf.reduce_all(x < 1), lambda: x + y), (tf.reduce_all(y > 0), lambda: tf.square(y))],
                 default=lambda: x - y,
                 name="test_case"
             )
+
         res = tf.case([(x[0] > 0, case_graph), (x[0] < 0, case_graph)], default=lambda: x - y)
         _ = tf.identity(res, name="output")
 
@@ -260,4 +274,4 @@ class CondTests(Tf2OnnxBackendTestBase):
 
 
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(CondTests)
+    unittest_main()

--- a/tests/test_const_fold.py
+++ b/tests/test_const_fold.py
@@ -6,8 +6,12 @@
 from __future__ import division
 from __future__ import print_function
 
+import unittest
+
 import tensorflow as tf
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument
 
@@ -53,6 +57,7 @@ class ConstantFoldingTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name="output_0")
         self._run_test_case(["output_0:0"], {})
 
+    @unittest.skip("tensorflow op ListDiff is not supported")
     def test_bahdanau_attention_memory_layer_tensordot(self):
         rank = tf.constant(3, dtype=tf.int32, name='rank')
         start = tf.constant(0, dtype=tf.int32, name='start')
@@ -76,5 +81,6 @@ class ConstantFoldingTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(out, name="output_0")
         self._run_test_case(["output_0:0"], {})
 
+
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(ConstantFoldingTests)
+    unittest_main()

--- a/tests/test_custom_rnncell.py
+++ b/tests/test_custom_rnncell.py
@@ -13,12 +13,15 @@ import tensorflow as tf
 from tensorflow.contrib import rnn
 from tensorflow.python.ops import init_ops
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import check_tf_min_version, check_opset_min_version, unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 # pylint: disable=abstract-method,arguments-differ
 
-class CustomRnnCellTests(Tf2OnnxBackendTestBase):
 
+class CustomRnnCellTests(Tf2OnnxBackendTestBase):
+    @check_opset_min_version(8, "Scan")
     def test_single_dynamic_custom_rnn(self):
         size = 5  # size of each model layer.
         batch_size = 1
@@ -37,6 +40,7 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "final_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+    @check_opset_min_version(8, "Scan")
     def test_single_dynamic_custom_rnn_time_major(self):
         size = 5  # size of each model layer.
         batch_size = 1
@@ -55,6 +59,7 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "final_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+    @check_opset_min_version(8, "Scan")
     def test_single_dynamic_custom_rnn_with_seq_length(self):
         units = 5
         batch_size = 6
@@ -78,6 +83,7 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "cell_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
+    @check_opset_min_version(8, "Scan")
     def test_single_dynamic_custom_rnn_with_non_const_seq_length(self):
         units = 5
         batch_size = 6
@@ -104,6 +110,8 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "cell_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
+    @check_opset_min_version(8, "Scan")
+    @check_tf_min_version("1.8")
     def test_attention_wrapper_const_encoder(self):
         size = 5
         time_step = 3
@@ -143,6 +151,8 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "final_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+    @check_opset_min_version(8, "Scan")
+    @check_tf_min_version("1.8")
     def test_attention_wrapper_lstm_encoder(self):
         size = 5
         time_step = 3
@@ -188,6 +198,8 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output_0:0", "output:0", "final_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+    @check_opset_min_version(8, "Scan")
+    @check_tf_min_version("1.8")
     def test_attention_wrapper_lstm_encoder_input_has_none_dim(self):
         size = 5
         time_step = 3
@@ -234,6 +246,7 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
 
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+    @check_opset_min_version(8, "Scan")
     def test_multi_rnn_lstm(self, state_is_tuple=True):
         units = 5
         batch_size = 6
@@ -269,6 +282,8 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "cell_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
+    @check_opset_min_version(8, "Scan")
+    @check_tf_min_version("1.8")
     def test_bidrectional_attention_wrapper_lstm_encoder(self):
         size = 30
         time_step = 3
@@ -327,6 +342,7 @@ class CustomRnnCellTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output_0:0", "final_state:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.1)
 
+
 class GatedGRUCell(tf.nn.rnn_cell.RNNCell):
     def __init__(self, hidden_dim, reuse=None):
         super().__init__(self, _reuse=reuse)
@@ -366,5 +382,6 @@ class GatedGRUCell(tf.nn.rnn_cell.RNNCell):
         next_h = h1 * (1 - z) + state * z
         return next_h, next_h
 
+
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(CustomRnnCellTests)
+    unittest_main()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -20,6 +20,7 @@ from onnx import helper
 import tf2onnx
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.tfonnx import process_tf_graph
+from common import unittest_main
 
 _TENSORFLOW_DOMAIN = "ai.onnx.converters.tensorflow"
 
@@ -115,7 +116,7 @@ class Tf2OnnxGraphTests(unittest.TestCase):
             x_ = tf.abs(x)
             _ = tf.identity(x_, name="output")
             g = process_tf_graph(sess.graph)
-            self.assertEqual('digraph { input [op_type=Placeholder shape="[2, 3]"]'\
+            self.assertEqual('digraph { input [op_type=Placeholder shape="[2, 3]"]' \
                              ' Abs [op_type=Abs] output [op_type=Identity] input:0 -> Abs Abs:0 -> output }',
                              onnx_to_graphviz(g))
 
@@ -354,4 +355,4 @@ class Tf2OnnxGraphTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest_main()

--- a/tests/test_gru.py
+++ b/tests/test_gru.py
@@ -16,6 +16,9 @@ from tensorflow.contrib import rnn
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
+
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
 
@@ -301,7 +304,7 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001, atol=1e-07)
 
     def test_dynamic_bigru(self):
         units = 5
@@ -474,4 +477,4 @@ class GRUTests(Tf2OnnxBackendTestBase):
 
 
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(GRUTests)
+    unittest_main()

--- a/tests/test_grublock.py
+++ b/tests/test_grublock.py
@@ -15,6 +15,8 @@ import tensorflow as tf
 from tensorflow.contrib import rnn
 from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
@@ -413,7 +415,7 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-07)
 
     def test_dynamic_bidirectional_but_one_gru_and_state_consumed_only(self):
         units = 5
@@ -442,4 +444,4 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
 
 
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(GRUBlockTests)
+    unittest_main()

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -20,6 +20,8 @@ import tf2onnx
 import tf2onnx.utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.graph import GraphUtil
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring
 
@@ -187,4 +189,4 @@ class Tf2OnnxInternalTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest_main()

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -13,6 +13,8 @@ import numpy as np
 import tensorflow as tf
 
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
@@ -52,6 +54,7 @@ class LoopTests(Tf2OnnxBackendTestBase):
         # todo: we cannot support i >= 3 for now, because in this case, TensorArray by default will
         # leave 0 for in the first 3 index.
         c = lambda i, *_: tf.logical_and(tf.less(i, 10), i >= 0)
+
         def b(i, out_ta):
             new_i = tf.add(i, 1)
             out_ta_new = out_ta.write(i, i)
@@ -197,4 +200,4 @@ class LoopTests(Tf2OnnxBackendTestBase):
 
 
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(LoopTests)
+    unittest_main()

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -16,6 +16,8 @@ from tensorflow.contrib import rnn
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
@@ -130,7 +132,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         outputs, cell_state = tf.nn.dynamic_rnn(
             cell,
             x,
-            dtype=tf.float32) # by default zero initializer is used
+            dtype=tf.float32)  # by default zero initializer is used
 
         _ = tf.identity(outputs, name="output")
         _ = tf.identity(cell_state, name="cell_state")
@@ -226,7 +228,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001)
 
     @unittest.skip("FIXME: disable for now for accuracy problem")
     def test_single_dynamic_lstm_random_weights2(self, state_is_tuple=True):
@@ -254,7 +256,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.01)
 
     def test_multiple_dynamic_lstm_state_is_tuple(self):
         self.internal_test_multiple_dynamic_lstm_with_parameters(True)
@@ -333,7 +335,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001)
 
     def test_dynamic_lstm_output_consumed_only(self):
         units = 5
@@ -356,7 +358,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001, atol=1e-07)
 
     def test_dynamic_lstm_state_consumed_only(self):
         units = 5
@@ -379,7 +381,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001)
 
     def test_dynamic_bilstm_state_is_tuple(self):
         self.internal_test_dynamic_bilstm_with_parameters(True)
@@ -486,4 +488,4 @@ class LSTMTests(Tf2OnnxBackendTestBase):
 
 
 if __name__ == '__main__':
-    Tf2OnnxBackendTestBase.trigger(LSTMTests)
+    unittest_main()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -7,15 +7,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
 import numpy as np
 from onnx import helper, TensorProto
 from tf2onnx.graph import GraphUtil
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
-
 
 class OptimizerTests(Tf2OnnxBackendTestBase):
     """Run original model proto and modified model proto with onnxruntime, compare the results."""
@@ -34,7 +33,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
 
         self.assertTrue(current["Transpose"] < previous["Transpose"], msg="transpose ops count not changed")
 
-        if type(self).BACKEND == "onnxruntime":
+        if self.config.is_onnxruntime_backend:
             expected = self.run_onnxruntime(origin_model_path, onnx_feed_dict, output_names_with_port)
             actual = self.run_onnxruntime(new_model_path, onnx_feed_dict, output_names_with_port)
         else:
@@ -105,5 +104,6 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
                              model_proto)
 
+
 if __name__ == "__main__":
-    Tf2OnnxBackendTestBase.trigger(OptimizerTests)
+    unittest_main()


### PR DESCRIPTION
- fix ci build failure when use tf 1.10
tf 1.10 requires numpy <=1.14.5 (tf tests break due to numpy api change in 1.15, but tf functionality is ok), but onnxruntime 0.2.1 crashes with numpy <=1.14.5.
upgrade numpy to higher version for tf 1.10

- use latest onnx for all test matrix
1.4 currently.

- add test config, refine test filter, refactor test base
  - introduce test config, which allows overriding via env var and command line arguments.
  - when run from script, load test config before test filters decorators, so the test filters can take effect correctly. previously test filters does not work properly when run from script.
  - extract common test filters, which can be used within all test scripts, not just backend tests.
  - refactor test base, simplify main for test class 

- enable all test scripts for ci, fix/disable some tests.
