### PR TITLE
run_pretrained_model delete TMPPATH after test

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 
 import argparse
 import os
+import shutil
 import sys
 import tarfile
 import tempfile
@@ -438,6 +439,9 @@ def main():
         except Exception as ex:
             ret = None
             print(ex)
+        finally:
+            if os.path.exists(TMPPATH) and not args.debug:
+                shutil.rmtree(TMPPATH)
         if not ret:
             failed += 1
 


### PR DESCRIPTION
TMPPATH causes out of disk often on internal agent, delete it after test.