### PR TITLE
optimize upsample's conversion logic

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -150,6 +150,8 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
             if check_shape:
                 self.assertEqual(expected_val.shape, actual_val.shape)
 
+        return g
+
     def save_onnx_model(self, model_proto, feed_dict, postfix=""):
         target_path = utils.save_onnx_model(self.test_data_directory, self._testMethodName + postfix, feed_dict,
                                             model_proto, include_test_data=self.config.is_debug_mode,

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import sys
 import unittest
+from collections import defaultdict
 
 from distutils.version import LooseVersion
 from tf2onnx import utils
@@ -15,7 +16,7 @@ from tf2onnx.tfonnx import DEFAULT_TARGET, POSSIBLE_TARGETS
 __all__ = ["TestConfig", "get_test_config", "unittest_main",
            "check_tf_min_version", "skip_tf_versions",
            "check_opset_min_version", "check_target", "skip_onnxruntime_backend", "skip_caffe2_backend",
-           "check_onnxruntime_incompatibility"]
+           "check_onnxruntime_incompatibility", "validate_const_node", "group_nodes_by_type"]
 
 
 # pylint: disable=missing-docstring
@@ -209,3 +210,17 @@ def check_onnxruntime_incompatibility(op):
 
     reason = "{} is not supported by onnxruntime before opset {}".format(op, support_since[op])
     return unittest.skipIf(True, reason)
+
+
+def validate_const_node(node, expected_val):
+    if node.is_const():
+        node_val = node.get_tensor_value()
+        return node_val == expected_val
+    return False
+
+
+def group_nodes_by_type(graph):
+    res = defaultdict(list)
+    for node in graph.get_nodes():
+        res[node.type].append(node)
+    return res

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -1060,7 +1060,6 @@ def upsample_op9(ctx, node, name, args):
     # first create "scales" info for onnx upsample
     # if shape of input and output known then  "scale" is calculated statically and set as a const node
     shape = ctx.get_shape(node.input[0])
-    added_nodes = []
     if shape and shape[2] != -1 and shape[1] != -1 and node.inputs[1].is_const():
         target_shape = node.inputs[1].get_tensor_value()
         n, h, w, c = shape
@@ -1069,7 +1068,6 @@ def upsample_op9(ctx, node, name, args):
         # the reason not storing data at raw field is because of the bug: https://github.com/onnx/onnx/issues/1852
         scale_val = np.array([1.0, 1.0, float(nh) / h, float(nw) / w]).astype(np.float32)
         scales = ctx.make_const(utils.make_name("scales"), scale_val, raw=False)
-        added_nodes.append(scales)
     else:
         ori_shape = ctx.make_node("Shape", [node.input[0]])
         ori_shape_hw = ctx.make_node("Slice", ori_shape.output, {"axes": [0], "starts": [1], "ends": [3]})
@@ -1083,9 +1081,6 @@ def upsample_op9(ctx, node, name, args):
         const_one_array = ctx.make_const(utils.make_name("one"), np.array([1.0, 1.0]).astype(np.float32))
         # scales is nchw
         scales = ctx.make_node("Concat", [const_one_array.output[0], scales_hw.output[0]], {"axis": 0})
-        added_nodes.extend([ori_shape, ori_shape_hw, ori_shape_hw_float, target_hw_float,
-                            scales_hw, const_one_array, scales])
-
     # because onnxruntime only supports to scale the last two dims so transpose is inserted
     input_nchw = ctx.make_node("Transpose", [node.input[0]], {"perm": [0, 3, 1, 2]})
     upsample = ctx.make_node("Upsample", [input_nchw.output[0], scales.output[0]], attr={"mode": args[0]})


### PR DESCRIPTION
input shape info is known only when input's shape is fixed. Under this
case the scale can be a const instead of a subgraph to compute it when
running the model.

the reason why I change the way to create initializers is because sometime we want to put data at related field of proto object such as float_data instead of raw_data(such as onnx sometimes will only access float_data when dtype of proto obj is specified)

import a mechanism to check the generated onnx graph is expected.