### PR TITLE
shape inference support LogicalOr, relax shape check for cond rewriter

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -16,7 +16,6 @@ from onnx import TensorProto
 from onnx import helper
 
 import tensorflow as tf
-import tf2onnx
 from tf2onnx import utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.graph import GraphUtil

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -17,7 +17,7 @@ from onnx import helper
 
 import tensorflow as tf
 import tf2onnx
-import tf2onnx.utils
+from tf2onnx import utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.graph import GraphUtil
 from common import unittest_main
@@ -50,14 +50,13 @@ def onnx_pretty(g, args=None):
 
 
 class Tf2OnnxInternalTests(unittest.TestCase):
-
     def setUp(self):
         """Setup test."""
         # suppress log info of tensorflow so that result of test can be seen much easier
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
         tf.logging.set_verbosity(tf.logging.WARN)
 
-        tf2onnx.utils.INTERNAL_NAME = 1
+        utils.INTERNAL_NAME = 1
         arg = namedtuple("Arg", "input inputs outputs verbose")
         self._args0 = arg(input="test", inputs=[], outputs=["output:0"], verbose=False)
         self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"], verbose=False)
@@ -142,8 +141,8 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         for match in match_results:
             input_node = match.get_op('input')
             output_node = match.get_op('output')
-            op_name = tf2onnx.utils.make_name("ReplacedOp")
-            out_name = tf2onnx.utils.port_name(op_name)
+            op_name = utils.make_name("ReplacedOp")
+            out_name = utils.port_name(op_name)
             new_node = g.make_node("Sub", inputs=input_node.input, outputs=[out_name], name=op_name)
             ops = g.replace_subgraph(ops, match, [], [output_node], [], [new_node])
         g.topological_sort(ops)
@@ -183,9 +182,25 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         arg = "input/V-1_2:0,input/X:0[1,2,3],Y:1[4,5],Z:3,A:1,B"
         expected_inputs = ['input/V-1_2:0', 'input/X:0', 'Y:1', 'Z:3', 'A:1', 'B']
         expected_shape = {'Y:1': [4, 5], 'input/X:0': [1, 2, 3]}
-        inputs, shape_override = tf2onnx.utils.split_nodename_and_shape(arg)
+        inputs, shape_override = utils.split_nodename_and_shape(arg)
         self.assertEqual(expected_inputs, inputs)
         self.assertEqual(expected_shape, shape_override)
+
+    def test_shape_utils(self):
+        self.assertEqual(utils.merge_shapes(None, None), None)
+        self.assertEqual(utils.merge_shapes([], None), [])
+        self.assertEqual(utils.merge_shapes(None, [1, 2, 3]), [1, 2, 3])
+        self.assertEqual(utils.merge_shapes([1, 3], [None, 3]), [1, 3])
+        self.assertEqual(utils.merge_shapes([1, None, 3], (-1, 2, "unk")), [1, 2, 3])
+
+        self.assertTrue(utils.are_shapes_compatible(None, []))
+        self.assertTrue(utils.are_shapes_compatible([1, None, 3], (-1, 2, "unk")))
+        self.assertFalse(utils.are_shapes_compatible([1, 2, 3], (2, 3)))
+        self.assertFalse(utils.are_shapes_compatible([1, 2, 3], (4, 5, 6)))
+
+        self.assertTrue(utils.are_shapes_equal(None, None))
+        self.assertFalse(utils.are_shapes_equal(None, []))
+        self.assertTrue(utils.are_shapes_equal([1, 2, 3], (1, 2, 3)))
 
 
 if __name__ == '__main__':

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -36,10 +36,12 @@ broadcast_ops = [
     "GreaterEqual",
     "Less",
     "LogicalAnd",
+    "LogicalOr",
     "Mul",
     "RealDiv",
     "Sub"
 ]
+
 
 def infer_shape_for_graph(g):
     no_shape_updated = True
@@ -135,7 +137,7 @@ def infer_shape_for_node(g, node):
             axis += len(s1)
         new_shape = s1[:axis] + [val]
         if axis < len(s1) - 1:
-            new_shape += s1[axis+1:]
+            new_shape += s1[axis + 1:]
 
         g.set_shape(node.output[0], new_shape)
         log.debug("set ConcatV2 node [%s] with new shape %s", node.output[0], new_shape)
@@ -148,7 +150,7 @@ def infer_shape_for_node(g, node):
         shape_indices = g.get_shape(node.input[1])
         axis = node.input[2].get_tensor_value()
 
-        shape = shape_params[:axis] + shape_indices + shape_indices[axis+1:]
+        shape = shape_params[:axis] + shape_indices + shape_indices[axis + 1:]
         g.set_shape(node.output[0], shape)
         return True
 

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -362,7 +362,7 @@ def save_protobuf(path, message, as_text=False):
 
 
 def is_list_or_tuple(obj):
-    return type(obj) in [list, tuple]
+    return isinstance(obj, (list, tuple))
 
 
 def is_unknown_dimension(dim):
@@ -405,11 +405,12 @@ def are_shapes_compatible(src, dest):
     try:
         merge_shapes(src, dest)
         return True
-    except Exception:
+    except:  # pylint: disable=bare-except
         return False
 
 
 def are_shapes_equal(src, dest):
+    """ Check whether 2 shapes are equal. """
     if src is None:
         return dest is None
     if dest is None:


### PR DESCRIPTION
fix several issues found in real model conversion.

- shape inference support LogicalOr
- relax cond_rewriter shape check
it is possible that shapes for true and false branches are **compatible but not exactly the same**, which is still valid.
- add shape utilities to simplify shape operations.
