### PR TITLE
ArgMax/ArgMin support int32

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -93,7 +93,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
 
     def run_test_case(self, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-07, atol=0.,
                       convert_var_to_const=True, constant_fold=True, check_value=True, check_shape=False,
-                      check_dtype=False, process_args=None, onnx_feed_dict=None):
+                      check_dtype=True, process_args=None, onnx_feed_dict=None):
         # optional - passed to process_tf_graph
         if process_args is None:
             process_args = {}

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1029,12 +1029,25 @@ class BackendTests(Tf2OnnxBackendTestBase):
         # since results are random, compare the shapes only
         self._run_test_case([_OUTPUT], {}, check_value=False, check_shape=True)
 
-    @unittest.skip("")
+    @skip_caffe2_backend()
     def test_argminmax(self):
-        # TODO: fails on onnxmsrt caffe2
         x_val = np.array([0.5, 1.0, -0.5, -1.0], dtype=np.float32).reshape((2, 2))
-        x = tf.placeholder(tf.float32, x_val.shape, name=_TFINPUT)
+        x = tf.placeholder(x_val.dtype, x_val.shape, name=_TFINPUT)
         x_ = tf.argmin(x, axis=0)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+
+        x_val = np.array([1, 2, -2, -1], dtype=np.int32).reshape((2, 2))
+        x = tf.placeholder(x_val.dtype, x_val.shape, name=_TFINPUT)
+        x_ = tf.argmax(x)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val})
+        tf.reset_default_graph()
+
+        x_val = np.array([1, 2, -2, -1], dtype=np.int32).reshape((2, 2))
+        x = tf.placeholder(x_val.dtype, x_val.shape, name=_TFINPUT)
+        x_ = tf.argmax(x, output_type=x_val.dtype)
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val})
 


### PR DESCRIPTION
found in real model.
TF ArgMax/ArgMin may return int32 or int64, while ONNX ArgMax/ArgMin returns int64 only.
need to add cast when necessary.

enable dtype check in test by default by the way.