### PR TITLE
[ignore me] add onnxruntime nightly test pipeline

### DIFF
--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -15,13 +15,13 @@ jobs:
       steps:
       - template: 'unit_test.yml'
 
-# Pre-trained model test
-- template: 'templates/job_generator.yml'
-  parameters:
-    tf_versions: ['1.12']
-    onnx_opsets: ['9', '8', '7']
-    onnx_backends:
-      onnxruntime: []
-    job:
-      steps:
-      - template: 'pretrained_model_test.yml'
+## Pre-trained model test
+#- template: 'templates/job_generator.yml'
+#  parameters:
+#    tf_versions: ['1.12']
+#    onnx_opsets: ['9', '8', '7']
+#    onnx_backends:
+#      onnxruntime: []
+#    job:
+#      steps:
+#      - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -1,0 +1,27 @@
+# Test against latest onnxruntime nightly package
+
+# TODO: change package name when nightly build is ready
+
+# Unit test
+jobs:
+- template: 'templates/job_generator.yml'
+  parameters:
+    tf_versions: ['1.12']
+    onnx_opsets: ['9', '8', '7']
+    onnx_backends:
+      onnxruntime: []
+    job:
+      steps:
+      - template: 'unit_test.yml'
+
+# Pre-trained model test
+jobs:
+- template: 'templates/job_generator.yml'
+  parameters:
+    tf_versions: ['1.12']
+    onnx_opsets: ['9', '8', '7']
+    onnx_backends:
+      onnxruntime: []
+    job:
+      steps:
+      - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -2,8 +2,9 @@
 
 # TODO: change package name when nightly build is ready
 
-# Unit test
 jobs:
+
+# Unit test
 - template: 'templates/job_generator.yml'
   parameters:
     tf_versions: ['1.12']
@@ -15,7 +16,6 @@ jobs:
       - template: 'unit_test.yml'
 
 # Pre-trained model test
-jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     tf_versions: ['1.12']

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -13,6 +13,12 @@ steps:
         pip install $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME) numpy --no-deps -U
     fi
 
+    # HACK: before onnxruntime nightly package is ready, install onnxruntime from pypi test
+    if [[ $CI_ONNXRUNTIME_FROM_PYPI_TEST == "true" ]] ;
+    then
+      pip install --index-url https://test.pypi.org/simple/ onnxruntime --force-reinstall
+    fi
+
     python setup.py install
     pip freeze --all
   displayName: 'Setup Environment'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -18,7 +18,7 @@ steps:
   displayName: 'Setup Environment'
 
 # TODO: remove later
-# Anaconda python 3.6.8 h9f7ef89_1 changed dll lookup logic, numpy failes to load dll on Windows
+# Anaconda python 3.6.8 h9f7ef89_1 changed dll lookup logic, numpy fails to load dll on Windows
 # https://github.com/numpy/numpy/issues/12957
 # https://github.com/ContinuumIO/anaconda-issues/issues/10629
 # Add numpy lib path manually here


### PR DESCRIPTION
add onnxruntime nightly test pipeline to test against latest onnxruntime nightly package.
currently, there is NO nightly package yet.
as a workaround for now, install onnxruntime package from pypi test.
after nightly package is ready, will install nightly package from pypi instead.