### PR TITLE
tf2onnx converted model cannot go to onnx-experimental.py because of naming conflicting

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -92,10 +92,10 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] ' \
                    'n1 [op_type=Abs] n7 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] ' \
-                   'n4 [op_type=Add] n5 [op_type=Abs] graph_outputs_Identity__3 [op_type=Identity] ' \
+                   'n4 [op_type=Add] n5 [op_type=Abs] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
                    'n6 [op_type=Identity] input -> n1 n1:0 -> n7 n7:0 -> n2 n1:0 -> n3 ' \
-                   'n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 raw_output___2:0 -> graph_outputs_Identity__3 ' \
-                   'raw_output___2:0 -> n6 }'
+                   'n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 ' \
+                   'n5_raw_output___2:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_insert_node2(self):
@@ -107,9 +107,9 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n7 [op_type=Abs] ' \
                    'n3 [op_type=Abs] n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
-                   'graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
+                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
                    'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 ' \
-                   'n4:0 -> n5 raw_output___2:0 -> graph_outputs_Identity__3 raw_output___2:0 -> n6 }'
+                   'n4:0 -> n5 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 n5_raw_output___2:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_remove_input(self):
@@ -122,9 +122,9 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n3 [op_type=Abs] ' \
                    'n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
-                   'graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
+                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
                    'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> n4 n4:0 -> n5 ' \
-                   'raw_output___2:0 -> graph_outputs_Identity__3 raw_output___2:0 -> n6 }'
+                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 n5_raw_output___2:0 -> n6 }'
         self.assertEqual(expected, result)
 
     def test_rewrite_subgraph(self):
@@ -150,9 +150,9 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] ' \
                    'n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__5 [op_type=Sub] ' \
-                   'graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
+                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
                    'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__5 ' \
-                   'n3:0 -> ReplacedOp__5 ReplacedOp__5:0 -> graph_outputs_Identity__3 ' \
+                   'n3:0 -> ReplacedOp__5 ReplacedOp__5:0 -> n5_graph_outputs_Identity__3 ' \
                    'ReplacedOp__5:0 -> n6 }'
         self.assertEqual(expected, result)
 

--- a/tools/onnx-experiments.py
+++ b/tools/onnx-experiments.py
@@ -81,7 +81,7 @@ def rewrite_constant_fold(g, ops):
                     log.info("folding node type=%s, name=%s", op.type, op.name)
                     if op.type == "Cast":
                         dst = op.get_attr_int("to")
-                        np_type = dst
+                        np_type = tf2onnx.utils.map_onnx_to_numpy_type(dst)
                         val = np.cast[np_type](*inputs)
                     elif op.type == "Transpose":
                         perm = op.get_attr("perm").ints
@@ -113,8 +113,9 @@ def rewrite_constant_fold(g, ops):
                     if consumers:
                         for consumer in consumers:
                             g.replace_input(consumer, old_output_name, new_output_name)
-                    for node in op.inputs:
-                        g.remove_node(node.name)
+                    for i, node in zip(op.input, op.inputs):
+                        if len(g.find_output_consumers(i)) == 1:
+                            g.remove_node(node.name)
                     keep_looking = True
                 except Exception as ex:  # pylint: disable=broad-except
                     tb = traceback.format_exc()


### PR DESCRIPTION
tf2onnx converted model cannot go to onnx-experimental.py because of naming conflicting