### PR TITLE
node get/set data_format via attribute internally

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -18,7 +18,7 @@ from onnx import helper
 import tensorflow as tf
 from tf2onnx import utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
-from tf2onnx.graph import GraphUtil
+from tf2onnx.graph import Node, GraphUtil
 from common import unittest_main
 
 
@@ -202,6 +202,21 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         self.assertTrue(utils.are_shapes_equal(None, None))
         self.assertFalse(utils.are_shapes_equal(None, []))
         self.assertTrue(utils.are_shapes_equal([1, 2, 3], (1, 2, 3)))
+
+    def test_data_format(self):
+        n1 = helper.make_node("Conv", ["X", "W"], ["Y"], name="n1", data_format="NHWC")
+        graph_proto = helper.make_graph(
+            nodes=[n1],
+            name="test",
+            inputs=[helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 2]),
+                    helper.make_tensor_value_info("W", TensorProto.FLOAT, [2, 2])],
+            outputs=[helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 2])],
+            initializer=[]
+        )
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
+        n = g.get_node_by_name("n1")
+        self.assertEqual(n.data_format, "NHWC")
+        self.assertTrue(n.is_nhwc())
 
 
 if __name__ == '__main__':

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -18,7 +18,7 @@ from onnx import helper
 import tensorflow as tf
 from tf2onnx import utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
-from tf2onnx.graph import Node, GraphUtil
+from tf2onnx.graph import GraphUtil
 from common import unittest_main
 
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -46,10 +46,6 @@ class Node(object):
         # dict to original attributes
         for a in node.attribute:
             self._attr[a.name] = a
-
-        self.data_format = self.get_attr("data_format")
-        if self.data_format:
-            self.data_format = self.data_format.s.decode("utf-8")
         self._skip_conversion = skip_conversion
 
     @property
@@ -123,6 +119,16 @@ class Node(object):
         """Set Op type."""
         self._op.domain = val
 
+    @property
+    def data_format(self):
+        """Return data_format."""
+        return self.get_attr_str("data_format")
+
+    @data_format.setter
+    def data_format(self, val):
+        """Set data_format."""
+        self.set_attr("data_format", val)
+
     def is_nhwc(self):
         """Return True if node is in NCHW format."""
         return self.data_format == "NHWC"
@@ -141,16 +147,21 @@ class Node(object):
         return "<onnx op type='%s' name=%s>" % (self.type, self._op.name)
 
     def get_attr(self, name, default=None):
-        """Get attribute map."""
+        """Get raw attribute value."""
         attr = self.attr.get(name, default)
         return attr
 
     def get_attr_int(self, name):
-        """Get attribute map."""
-        attr = self.attr.get(name)
+        """Get attribute value as int."""
+        attr = self.get_attr(name)
         utils.make_sure(attr is not None, "attribute %s is None", name)
         attr = attr.i
         return attr
+
+    def get_attr_str(self, name, encoding="utf-8"):
+        """Get attribute value as string."""
+        attr = self.get_attr(name)
+        return attr.s.decode(encoding) if attr else None
 
     def set_attr(self, name, value):
         self.attr[name] = helper.make_attribute(name, value)


### PR DESCRIPTION
fix bug found in real model

currently, ```node.data_format``` field is set in node constructor only.

when we create a new node from an existing node, e.g. in ```construct_graph_from_nodes```, existing node's attributes are passed into ```g.make_node```.

while in ```make_node```, ```data_format``` is treated like ```onnx_attrs``` if it is a ```AttributeProto```, so it calls ```node.set_attr_onnx``` directly, so the ```data_format``` field remains None in new node. it will cause problem for logic later that depends on ```data_format```

always get/set data_format via attribute to fix this issue.