### PR TITLE
check specific op (lstm, gru) in converted graph

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -93,7 +93,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
 
     def run_test_case(self, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-07, atol=0.,
                       convert_var_to_const=True, constant_fold=True, check_value=True, check_shape=False,
-                      check_dtype=True, process_args=None, onnx_feed_dict=None):
+                      check_dtype=True, process_args=None, onnx_feed_dict=None, graph_validator=None):
         # optional - passed to process_tf_graph
         if process_args is None:
             process_args = {}
@@ -149,6 +149,9 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
                 self.assertEqual(expected_val.dtype, actual_val.dtype)
             if check_shape:
                 self.assertEqual(expected_val.shape, actual_val.shape)
+
+        if graph_validator:
+            self.assertTrue(graph_validator(g))
 
         return g
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -224,3 +224,15 @@ def group_nodes_by_type(graph):
     for node in graph.get_nodes():
         res[node.type].append(node)
     return res
+
+
+def check_op_count(graph, op_type, expected_count):
+    return len(group_nodes_by_type(graph)[op_type]) == expected_count
+
+
+def check_lstm_count(graph, expected_count):
+    return check_op_count(graph, "LSTM", expected_count)
+
+
+def check_gru_count(graph, expected_count):
+    return check_op_count(graph, "GRU", expected_count)

--- a/tests/test_gru.py
+++ b/tests/test_gru.py
@@ -16,7 +16,7 @@ from tensorflow.contrib import rnn
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main
+from common import unittest_main, check_gru_count
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
@@ -47,7 +47,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         input_names_with_port = ["input_1:0"]
         feed_dict = {"input_1:0": x_val}
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_multiple_dynamic_gru(self):
         units = 5
@@ -93,7 +94,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 2))
 
     def test_single_dynamic_gru_seq_length_is_const(self):
         units = 5
@@ -119,7 +121,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_seq_length_is_not_const(self):
         units = 5
@@ -148,7 +151,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
         input_names_with_port = ["input_1:0", "input_2:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_placeholder_input(self):
         units = 5
@@ -172,7 +176,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_ch_zero_state_initializer(self):
         units = 5
@@ -201,7 +206,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     @unittest.skip("FIXME: disable for now for accuracy problem")
     def test_single_dynamic_gru_random_weights(self):
@@ -229,7 +235,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     @unittest.skip("FIXME: disable for now for accuracy problem")
     def test_single_dynamic_gru_random_weights2(self):
@@ -256,7 +263,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_gru_output_consumed_only(self):
         units = 5
@@ -280,7 +288,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_gru_state_consumed_only(self):
         units = 5
@@ -304,7 +313,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru(self):
         units = 5
@@ -335,7 +345,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru_output_consumed_only(self):
         units = 5
@@ -365,7 +376,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru_state_consumed_only(self):
         units = 5
@@ -395,7 +407,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru(self):
         units = 5
@@ -423,7 +436,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru_and_output_consumed_only(self):
         units = 5
@@ -448,7 +462,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru_and_state_consumed_only(self):
         units = 5
@@ -473,7 +488,8 @@ class GRUTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
 
 if __name__ == '__main__':

--- a/tests/test_grublock.py
+++ b/tests/test_grublock.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 from tensorflow.contrib import rnn
 from tensorflow.python.ops import variable_scope
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main
+from common import unittest_main, check_gru_count
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
@@ -45,7 +45,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         input_names_with_port = ["input_1:0"]
         feed_dict = {"input_1:0": x_val}
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_multiple_dynamic_gru(self):
         units = 5
@@ -89,7 +90,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 2))
 
     def test_single_dynamic_gru_seq_length_is_const(self):
         units = 5
@@ -113,7 +115,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_seq_length_is_not_const(self):
         units = 5
@@ -140,7 +143,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
         input_names_with_port = ["input_1:0", "input_2:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_placeholder_input(self):
         units = 5
@@ -162,7 +166,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_single_dynamic_gru_ch_zero_state_initializer(self):
         units = 5
@@ -188,7 +193,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     @unittest.skip("FIXME: disable for now for accuracy problem")
     def test_single_dynamic_gru_random_weights(self):
@@ -213,7 +219,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     @unittest.skip("FIXME: disable for now for accuracy problem")
     def test_single_dynamic_gru_random_weights2(self):
@@ -238,7 +245,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_gru_output_consumed_only(self):
         units = 5
@@ -260,7 +268,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_gru_state_consumed_only(self):
         units = 5
@@ -282,7 +291,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru(self):
         units = 5
@@ -310,7 +320,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru_output_consumed_only(self):
         units = 5
@@ -337,7 +348,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bigru_state_consumed_only(self):
         units = 5
@@ -364,7 +376,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru(self):
         units = 5
@@ -390,7 +403,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0", "cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru_and_output_consumed_only(self):
         units = 5
@@ -415,7 +429,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["output:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-07)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-07,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
     def test_dynamic_bidirectional_but_one_gru_and_state_consumed_only(self):
         units = 5
@@ -440,7 +455,8 @@ class GRUBlockTests(Tf2OnnxBackendTestBase):
         feed_dict = {"input_1:0": x_val}
         input_names_with_port = ["input_1:0"]
         output_names_with_port = ["cell_state:0"]
-        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06)
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
 
 
 if __name__ == '__main__':

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -73,7 +73,7 @@ class LSTMUnitRewriter(UnitRewriterBase):
         if not ft:
             return None
 
-        if not (ft.value == 1 and self.g.get_dtype(b_e.output[0]) == self.g.get_dtype(ft_bias.output[0])):
+        if not (np.ndim(ft.value) == 0 and self.g.get_dtype(b_e.output[0]) == self.g.get_dtype(ft_bias.output[0])):
             return None
 
         return RnnWeights(w, b, ft)


### PR DESCRIPTION
In unittests, check if converted graph contains specific ops, such as LSTM, GRU.

Other changes:
1. add time major and forget bias unittests for LSTM.
2. remove the requirement for forget bias in lstm_rewriter.