### PR TITLE
remove useless Identity node in nested graphs

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -266,7 +266,7 @@ class Test(object):
                 onnx_graph = self.to_onnx(sess.graph, opset=opset, shape_override=shape_override,
                                           input_names=inputs.keys())
                 model_proto = onnx_graph.make_model("converted from tf2onnx")
-                new_model_proto = GraphUtil.opt_transposes_with_graph(onnx_graph, "test", debug=debug)
+                new_model_proto = GraphUtil.optimize_graph(onnx_graph, "test", debug=debug)
                 if new_model_proto:
                     model_proto = new_model_proto
                 else:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 from onnx import helper, TensorProto
+from tf2onnx import utils
 from tf2onnx.graph import GraphUtil
 from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main
@@ -19,22 +20,23 @@ from common import unittest_main
 class OptimizerTests(Tf2OnnxBackendTestBase):
     """Run original model proto and modified model proto with onnxruntime, compare the results."""
 
-    def run_and_compare(self, output_names_with_port, onnx_feed_dict, origin_proto,
-                        remaining_transpose_num=None, debug=False, rtol=1e-07):
+    def run_and_compare(self, output_names_with_port, onnx_feed_dict, origin_proto, op_type,
+                        remaining_op_num, debug=False, rtol=1e-07):
+        utils.make_sure(op_type is not None, "op_type should be specified")
+        utils.make_sure(remaining_op_num is not None, "remaining_op_num should be specified")
+
         origin_model_path = self.save_onnx_model(origin_proto, onnx_feed_dict, postfix="_origin")
 
-        new_proto = GraphUtil.opt_transposes_with_model_proto(origin_proto)
+        new_proto = GraphUtil.optimize_graph_with_model_proto(origin_proto)
 
         self.assertTrue(new_proto, msg="model proto after optimizer should not be None")
 
         new_model_path = self.save_onnx_model(new_proto, onnx_feed_dict, postfix="_opt")
-
-        previous = GraphUtil.get_node_count_from_onnx_graph(origin_proto.graph)
         current = GraphUtil.get_node_count_from_onnx_graph(new_proto.graph)
 
-        self.assertTrue(current["Transpose"] < previous["Transpose"], msg="transpose ops count not changed")
-        if remaining_transpose_num is not None:
-            self.assertTrue(current["Transpose"] == remaining_transpose_num, msg="some transpose ops left unexpected")
+        self.assertTrue(current[op_type] == remaining_op_num,
+                        msg="Expect " + str(remaining_op_num) + " " + op_type + " ops left, but actually " +
+                        str(current[op_type]) + " left")
 
         if self.config.is_onnxruntime_backend:
             expected = self.run_onnxruntime(origin_model_path, onnx_feed_dict, output_names_with_port)
@@ -47,7 +49,14 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             self.assertEqual(expected_val.dtype, actual_val.dtype)
             self.assertEqual(expected_val.shape, actual_val.shape)
 
-    def test_relu(self):
+    # Tranpose Optimizer Tests Start
+
+    def run_transpose_compare(self, output_names_with_port, onnx_feed_dict, origin_proto,
+                              remaining_transpose_num=None, debug=False, rtol=1e-07):
+        self.run_and_compare(output_names_with_port, onnx_feed_dict, origin_proto, op_type="Transpose",
+                             remaining_op_num=remaining_transpose_num, debug=debug, rtol=rtol)
+
+    def test_transpose_relu(self):
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 2, 3, 1], name="trans_1")
         node2 = helper.make_node("Relu", ["Y"], ["Z"], name="relu")
         node3 = helper.make_node("Transpose", ["Z"], ["Z1"], perm=[0, 3, 1, 2], name="trans_2")
@@ -60,10 +69,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_and_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
-                             model_proto, remaining_transpose_num=0)
+        self.run_transpose_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=0)
 
-    def test_leaky_relu(self):
+    def test_transpose_leaky_relu(self):
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 2, 3, 1], name="trans_1")
         node2 = helper.make_node("LeakyRelu", ["Y"], ["Z"], alpha=0.02, name="relu")
         node3 = helper.make_node("Transpose", ["Z"], ["Z1"], perm=[0, 3, 1, 2], name="trans_2")
@@ -76,10 +85,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_and_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
-                             model_proto, remaining_transpose_num=0)
+        self.run_transpose_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=0)
 
-    def test_max(self):
+    def test_transpose_max(self):
         const_1_val = [2.0]
         const_1 = helper.make_tensor("const_1", TensorProto.FLOAT, (1,), const_1_val)
         const_1_node = helper.make_node("Constant", [], ["const_1"], value=const_1, name="const_1")
@@ -104,8 +113,8 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_and_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
-                             model_proto, remaining_transpose_num=0)
+        self.run_transpose_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=0)
 
     def test_transpose_merge(self):
         node0 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 2, 3, 1], name="trans")
@@ -120,8 +129,8 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_and_compare(["OUT"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
-                             model_proto, remaining_transpose_num=1)
+        self.run_transpose_compare(["OUT"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=1)
 
     def test_transpose_with_shape(self):
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 2, 3, 1], name="trans")
@@ -135,9 +144,136 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_and_compare(["Z"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
-                             model_proto, remaining_transpose_num=0)
+        self.run_transpose_compare(["Z"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=0)
 
+    # Tranpose Optimizer Tests End
+
+    # Identity Optimizer Tests Start
+
+    def run_identity_compare(self, output_names_with_port, onnx_feed_dict, origin_proto,
+                             remaining_identity_num=None, debug=False, rtol=1e-07):
+        self.run_and_compare(output_names_with_port, onnx_feed_dict, origin_proto, op_type="Identity",
+                             remaining_op_num=remaining_identity_num, debug=debug, rtol=rtol)
+
+    def test_identity_non_graph_output(self):
+        node1 = helper.make_node("Add", ["X", "X"], ["Y"], name="add")
+        node2 = helper.make_node("Identity", ["Y"], ["Z"], name="identity")
+        node3 = helper.make_node("Shape", ["Z"], ["Z1"], name="shape")
+
+        graph = helper.make_graph(
+            [node1, node2, node3],
+            "identity-test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4, 5))],
+            [helper.make_tensor_value_info("Z1", TensorProto.INT64, [4])],
+        )
+
+        model_proto = helper.make_model(graph, producer_name="onnx-tests")
+        self.run_identity_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                  model_proto, remaining_identity_num=0)
+
+    def test_identity_unremovable_identity(self):
+        # should not remove!!
+        node1 = helper.make_node("Identity", ["X"], ["Y"], name="identity")
+
+        graph = helper.make_graph(
+            [node1],
+            "identity-test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4, 5))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3, 4, 5))],
+        )
+
+        model_proto = helper.make_model(graph, producer_name="onnx-tests")
+        self.run_identity_compare(["Y"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                  model_proto, remaining_identity_num=1)
+
+    def test_identity_output_as_multiple_graph_outputs(self):
+        # handle case like this, both Identity nodes are graph outputs,
+        #            Add
+        #           /   \
+        #    Identity   Identity
+        # We at most can remove one Identity for this case.
+        node1 = helper.make_node("Add", ["X", "X"], ["Y"], name="identity")
+        node2 = helper.make_node("Identity", ["Y"], ["Z1"], name="identity2")
+        node3 = helper.make_node("Identity", ["Y"], ["Z2"], name="identity3")
+        graph = helper.make_graph(
+            [node1, node2, node3],
+            "identity-test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4, 5))],
+            [helper.make_tensor_value_info("Z1", TensorProto.FLOAT, (2, 3, 4, 5)),
+             helper.make_tensor_value_info("Z2", TensorProto.FLOAT, (2, 3, 4, 5))],
+        )
+
+        model_proto = helper.make_model(graph, producer_name="onnx-tests")
+        self.run_identity_compare(["Z1", "Z2"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                  model_proto, remaining_identity_num=1)
+
+
+    def test_identity_in_subgraph_non_graph_output(self):
+        node1 = helper.make_node("Add", ["X", "X"], ["Y"], name="add")
+
+        iter_num_value = np.array(1, dtype=np.int64)
+        node2 = helper.make_node(
+            'Constant',
+            inputs=[],
+            outputs=['iterate_num_value'],
+            value=helper.make_tensor(
+                name='iterate_num_value',
+                data_type=TensorProto.INT64,
+                dims=iter_num_value.shape,
+                vals=iter_num_value.flatten().astype(np.int64),
+            ),
+        )
+
+        cond_value = np.array(True, dtype=np.bool)
+        node3 = helper.make_node(
+            'Constant',
+            inputs=[],
+            outputs=['cond_value'],
+            value=helper.make_tensor(
+                name='cond_value',
+                data_type=TensorProto.BOOL,
+                dims=iter_num_value.shape,
+                vals=cond_value.flatten().astype(np.bool),
+            ),
+        )
+
+        # sub graph
+        sub_node1 = helper.make_node("Add", ["loop_var_1", "loop_var_1"], ["SubY"], name="sub_add")
+        sub_node2 = helper.make_node("Identity", ["SubY"], ["SubIdentity1"], name="sub_identity_1")
+        sub_node3 = helper.make_node("Identity", ["SubIdentity1"], ["loop_var_out_1"], name="sub_identity_2")
+        sub_node4 = helper.make_node("Identity", ["loop_condition"], ["loop_cond_output"], name="sub_identity_3")
+        sub_graph = helper.make_graph(
+            [sub_node1, sub_node2, sub_node3, sub_node4],
+            "identity_subgraph-test",
+            [helper.make_tensor_value_info("loop_iter_num", TensorProto.INT64, (1,)),  # iteration_num
+             helper.make_tensor_value_info("loop_condition", TensorProto.BOOL, ()),  # condition
+             helper.make_tensor_value_info("loop_var_1", TensorProto.FLOAT, ()),  # loop-carried dependency
+             ],
+            [helper.make_tensor_value_info("loop_cond_output", TensorProto.BOOL, ()),
+             helper.make_tensor_value_info("loop_var_out_1", TensorProto.FLOAT, ())
+            ],
+        )
+        # sub graph ends
+
+        loop_node = helper.make_node("Loop", ["iterate_num_value", "cond_value", "Y"], ["loop_var_1_output"],
+                                     name="loop", body=sub_graph)
+
+        node4 = helper.make_node("Identity", ["loop_var_1_output"], ["Z"], name="identity")
+        node5 = helper.make_node("Shape", ["Z"], ["Z1"], name="shape")
+
+        graph = helper.make_graph(
+            [node1, node2, node3, loop_node, node4, node5],
+            "identity-test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4, 5))],
+            [helper.make_tensor_value_info("Z1", TensorProto.INT64, [4])],
+        )
+
+        model_proto = helper.make_model(graph, producer_name="onnx-tests")
+        self.run_identity_compare(["Z1"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
+                                  model_proto, remaining_identity_num=0)
+
+    # Tranpose Optimizer Tests End
 
 if __name__ == "__main__":
     unittest_main()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -208,7 +208,6 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_identity_compare(["Z1", "Z2"], {"X": np.random.randn(2, 3, 4, 5).astype(np.float32)},
                                   model_proto, remaining_identity_num=1)
 
-
     def test_identity_in_subgraph_non_graph_output(self):
         node1 = helper.make_node("Add", ["X", "X"], ["Y"], name="add")
 

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -126,8 +126,8 @@ def main():
 
     model_proto = g.make_model("converted from {}".format(args.input))
 
-    new_model_proto = GraphUtil.opt_transposes_with_graph(g, "converted from {}".format(model_path),
-                                                          optimize=not args.continue_on_error)
+    new_model_proto = GraphUtil.optimize_graph(g, "converted from {}".format(model_path),
+                                               optimize=not args.continue_on_error)
     if new_model_proto:
         model_proto = new_model_proto
     else:

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -19,8 +19,7 @@ import numpy as np
 from onnx import helper, numpy_helper, optimizer, shape_inference, OperatorSetIdProto, AttributeProto
 from tf2onnx import utils, __version__
 from tf2onnx.utils import port_name, find_opset
-from tf2onnx.optimizer.identity_optimizer import IdentityOptimizer
-from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
+from tf2onnx.optimizer import IdentityOptimizer, TransposeOptimizer
 from tf2onnx.schemas import get_schema
 
 

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -6,4 +6,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ["identity_optimizer", "transpose_optimizer"]
+from .identity_optimizer import IdentityOptimizer
+from .transpose_optimizer import TransposeOptimizer
+
+__all__ = [
+    "IdentityOptimizer",
+    "TransposeOptimizer",
+]

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -6,4 +6,4 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__all__ = ["transpose_optimizer"]
+__all__ = ["identity_optimizer", "transpose_optimizer"]

--- a/tf2onnx/optimizer/identity_optimizer.py
+++ b/tf2onnx/optimizer/identity_optimizer.py
@@ -73,6 +73,12 @@ class IdentityOptimizer(object):
     def _handle_graph_output_identity(self, graph, identity, graph_outputs):
         input_id = identity.input[0]
         input_node = identity.inputs[0]
+
+        if input_node.graph != graph:
+            # If input node is in parent graph, we don't handle it now
+            log.debug("input node in parent graph, skip")
+            return False
+
         if input_node.is_graph_input():
             # Identity between input and output should not be removed.
             log.debug("skip identity between input and output")


### PR DESCRIPTION
Identity node may comes for different reasons:

1. original model has Identity node. 
2. converters inserted Identity node for easier handling. For example, graph output should never be changed, so for each op mapping function, we MUST make sure we consider "what if the node is generating the graph output". This is kind of heavy. What we did currently is: for a given graph output, we insert an Identity node generating it before all ops mapping happens. And for node not being Identity, the mapping function just assume the node won't be the one generating the graph output directly. For Identity node, it is easy to make sure it does not change the graph output.
3. In subgraphs such as Loop's Scan, sometimes tensor A:0, might be used as two different sub-graph outputs, (image LSTM case, hidden state is passed to next iteration, and also returned in each iteration, so it will be used as two different outputs). So in those cases, we intentionally insert a Identity node for each output.

It is better to do a clean up after all nodes get mapped correctly, so I added a IdentityOptimizer and triggered it at the end.

IdentityOptimizer just like TransposeOptimizer, can be used along with GraphUtils/Graph/Node structures, and easily used by other tools. But there is a potential unstable problem on onnx shape inferencing. 