### PR TITLE
enhance tf shape inference for LessEqual and Max

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -153,7 +153,7 @@ class Test(object):
 
     def to_onnx(self, tf_graph, opset=None, shape_override=None, input_names=None):
         """Convert graph to tensorflow."""
-        return process_tf_graph(tf_graph, continue_on_error=True, verbose=True, opset=opset,
+        return process_tf_graph(tf_graph, continue_on_error=False, verbose=True, opset=opset,
                                 target=Test.target, shape_override=shape_override,
                                 input_names=input_names, output_names=self.output_names)
 
@@ -186,7 +186,6 @@ class Test(object):
         """Run test against msrt-next backend."""
         import onnxruntime as rt
         model_path = utils.save_onnx_model(TEMP_DIR, name, inputs, model_proto, include_test_data=True)
-        utils.save_onnx_model(TEMP_DIR, name, inputs, model_proto, include_test_data=False, as_text=True)
         print("\t\t" + model_path)
         m = rt.InferenceSession(model_path)
         results = m.run(self.output_names, inputs)

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -35,6 +35,7 @@ broadcast_ops = [
     "Greater",
     "GreaterEqual",
     "Less",
+    "LessEqual",
     "LogicalAnd",
     "LogicalOr",
     "Mul",
@@ -154,7 +155,7 @@ def infer_shape_for_node(g, node):
         g.set_shape(node.output[0], shape)
         return True
 
-    if node.type in ["All", "Any", "Min"]:
+    if node.type in ["All", "Any", "Max", "Min"]:
         axis_node = node.inputs[1]
         axis = axis_node.get_tensor_value()
         if not isinstance(axis, list):


### PR DESCRIPTION
- enhance tf shape inference for LessEqual and Max
this is a fix for https://github.com/onnx/tensorflow-onnx/pull/389, which causes failure on a real model after GreaterEqual rewriter is removed.
- set continue_on_error to false for run pretrained model
reduce test time and make the log clean

