### PR TITLE
upgrade required min onnx version to 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,5 @@ setup(
     author='onnx@microsoft.com',
     author_email='onnx@microsoft.com',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.2.2', 'six']
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'six']
 )


### PR DESCRIPTION
currently, we need to get op schema from onnx python api to filter out attributes that not belong to onnx op.
onnx < 1.4 does not support opset9, which will cause issue when people try to use opset 9.
e.g. https://github.com/onnx/tensorflow-onnx/issues/391
