### PR TITLE
refine onnx node attributes check

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -218,6 +218,36 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         self.assertEqual(n.data_format, "NHWC")
         self.assertTrue(n.is_nhwc())
 
+    def test_node_attr_onnx(self):
+        n1 = helper.make_node("Conv", ["X", "W"], ["Y"], name="n1", my_attr="my_attr")
+        graph_proto = helper.make_graph(
+            nodes=[n1],
+            name="test",
+            inputs=[helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 2]),
+                    helper.make_tensor_value_info("W", TensorProto.FLOAT, [2, 2])],
+            outputs=[helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 2])],
+            initializer=[]
+        )
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
+        n1 = g.get_node_by_name("n1")
+        self.assertTrue("my_attr" in n1.attr)
+        self.assertTrue("my_attr" not in n1.attr_onnx)
+
+        n1 = helper.make_node("Conv", ["X", "W"], ["Y"], name="n1", domain="my_domain", my_attr="my_attr")
+        print(n1)
+        graph_proto = helper.make_graph(
+            nodes=[n1],
+            name="test",
+            inputs=[helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 2]),
+                    helper.make_tensor_value_info("W", TensorProto.FLOAT, [2, 2])],
+            outputs=[helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 2])],
+            initializer=[]
+        )
+        g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
+        n1 = g.get_node_by_name("n1")
+        self.assertTrue("my_attr" in n1.attr)
+        self.assertTrue("my_attr" in n1.attr_onnx)
+
 
 if __name__ == '__main__':
     unittest_main()

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -234,7 +234,6 @@ class Tf2OnnxInternalTests(unittest.TestCase):
         self.assertTrue("my_attr" not in n1.attr_onnx)
 
         n1 = helper.make_node("Conv", ["X", "W"], ["Y"], name="n1", domain="my_domain", my_attr="my_attr")
-        print(n1)
         graph_proto = helper.make_graph(
             nodes=[n1],
             name="test",

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import onnx
 from onnx import helper
 import tensorflow as tf
 

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -80,7 +80,7 @@ def main():
 
     opset = utils.find_opset(args.opset)
     print("using tensorflow={}, onnx={}, opset={}, tfonnx={}/{}".format(
-        tf.__version__, onnx.__version__, opset,
+        tf.__version__, utils.get_onnx_version(), opset,
         tf2onnx.__version__, tf2onnx.version.git_version[:6]))
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -377,6 +377,7 @@ class Graph(object):
             self.remove_node(n.name)
 
             new_outputs = [o if o != output else new_output_name for output in n.output]
+            # domain should be passed to new node
             new_node = self.make_node(n.type, n.input, outputs=new_outputs, attr=n.attr, name=n.name,
                                       skip_conversion=n._skip_conversion, dtypes=n_dtypes, shapes=n_shapes,
                                       domain=n.domain)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 
 import collections
 import copy
+import logging
 import sys
 import traceback
 import six
@@ -21,6 +22,9 @@ from tf2onnx import utils, __version__
 from tf2onnx.utils import port_name, find_opset
 from tf2onnx.optimizer import IdentityOptimizer, TransposeOptimizer
 from tf2onnx.schemas import get_schema
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("graph")
 
 
 # todo(pengwa): remove protected-access later
@@ -83,12 +87,15 @@ class Node(object):
 
     @property
     def attr_onnx(self):
+        schema = get_schema(self.type, self.graph.opset, self.domain)
+        if schema is None and not (self.is_const() or self.is_graph_input()):
+            log.warning("Node %s uses non-stardard onnx op <%s, %s>, skip attribute check", self.name, self.domain,
+                        self.type)
+
         onnx_attrs = {}
         for a in self._attr.values():
-            schema = get_schema(self.type, self.graph.opset)
-            if schema:
-                if schema.has_attribute(a.name):
-                    onnx_attrs[a.name] = a
+            if schema is None or schema.has_attribute(a.name):
+                onnx_attrs[a.name] = a
         return onnx_attrs
 
     @property
@@ -1054,7 +1061,7 @@ class GraphUtil(object):
         try:
             opts = [TransposeOptimizer(graph, output_names=graph.outputs, debug=debug),
                     IdentityOptimizer(graph, output_names=graph.outputs, debug=debug)
-                   ]
+                    ]
             for opt in opts:
                 opt.optimize()
             model_proto = graph.make_model(doc_string, optimize=optimize)
@@ -1080,7 +1087,7 @@ class GraphUtil(object):
 
             opts = [TransposeOptimizer(g, output_names=g.outputs, debug=debug),
                     IdentityOptimizer(g, output_names=g.outputs, debug=debug)
-                   ]
+                    ]
             for opt in opts:
                 opt.optimize()
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -87,6 +87,7 @@ class Node(object):
 
     @property
     def attr_onnx(self):
+        """Return onnx valid attributes"""
         schema = get_schema(self.type, self.graph.opset, self.domain)
         if schema is None and not (self.is_const() or self.is_graph_input()):
             log.warning("Node %s uses non-stardard onnx op <%s, %s>, skip attribute check", self.name, self.domain,

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -20,7 +20,7 @@ from tensorflow.python.framework import graph_util
 from tensorflow.tools.graph_transforms import TransformGraph
 
 import tf2onnx
-from tf2onnx import utils
+from tf2onnx import schemas, utils
 from tf2onnx.function import *  # pylint: disable=wildcard-import
 from tf2onnx.graph import Graph
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
@@ -1461,6 +1461,7 @@ def reverse_op8(ctx, node, name, args):
     node.input[0] = node.input[1]
     node.input[1] = tmp
 
+
 def reverse_op9(ctx, node, name, args):
     # T output = ReverseSequence(T input, int32|int64 seq_lengths, @int seq_dim, @int batch_dim)
     # we cannot easily construct reverse_sequence equivalence in opset 9, so we will not support it
@@ -1648,6 +1649,7 @@ def logical_compare_op(ctx, node, name, args):
                 inp_cast = ctx.insert_new_node_on_input(node, "Cast", inp, to=target_dtype)
                 ctx.copy_shape(inp, inp_cast.output[0])
                 ctx.set_dtype(inp_cast.output[0], target_dtype)
+
 
 def logical_compareeq_op(ctx, node, name, args):
     logical_compare_op(ctx, node, name, [])
@@ -2400,6 +2402,11 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
         Return:
             onnx graph
     """
+    if opset > schemas.get_max_supported_opset_version():
+        log.warning("currently installed onnx package %s is too low to support opset %s, "
+                    "please upgrade onnx package to avoid potential conversion issue.",
+                    utils.get_onnx_version(), opset)
+
     if shape_override is None:
         shape_override = {}
     if inputs_as_nchw is None:

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -18,6 +18,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.core.framework import types_pb2, tensor_pb2
 from google.protobuf import text_format
+import onnx
 from onnx import helper, onnx_pb, defs, numpy_helper
 
 #
@@ -74,12 +75,14 @@ ONNX_DTYPE_NAMES = {
     onnx_pb.TensorProto.BOOL: "bool"
 }
 
+
 class TensorValueInfo(object):
     def __init__(self, tensor_id, g):
         self.id = tensor_id
         if self.id:
             self.dtype = g.get_dtype(tensor_id)
             self.shape = g.get_shape(tensor_id)
+
 
 ONNX_UNKNOWN_DIMENSION = -1
 
@@ -409,3 +412,7 @@ def are_shapes_equal(src, dest):
 def create_vague_shape_like(shape):
     make_sure(len(shape) >= 0, "rank should be >= 0")
     return [-1 for i in enumerate(shape)]
+
+
+def get_onnx_version():
+    return onnx.__version__


### PR DESCRIPTION
- check whether currently installed onnx package version supports opset version specified
- skip onnx node attributes check for unknown op
- support domain argument when create node
- when user creates node with op in non onnx domain, make sure domain is kept when dealing with graph output node