### PR TITLE
fix some bugs

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -15,6 +15,7 @@ import tarfile
 import time
 import traceback
 import zipfile
+import logging
 
 import PIL.Image
 import numpy as np
@@ -33,6 +34,9 @@ from tf2onnx.graph import GraphUtil
 from tf2onnx.tfonnx import process_tf_graph
 
 # pylint: disable=broad-except,logging-not-lazy,unused-argument,unnecessary-lambda
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("tf2onnx")
 
 TEMP_DIR = os.path.join(utils.get_temp_directory(), "run_pretrained")
 PERFITER = 1000
@@ -246,9 +250,10 @@ class Test(object):
             for k in inputs.keys():  # pylint: disable=consider-iterating-dictionary
                 t = sess.graph.get_tensor_by_name(k)
                 dtype = tf.as_dtype(t.dtype).name
-                if type != "float32":
-                    v = inputs[k]
-                    inputs[k] = v.astype(dtype)
+                v = inputs[k]
+                if dtype != v.dtype:
+                    log.warning("input dtype doesn't match tensorflow's")
+                    inputs[k] = np.array(v, dtype=dtype)
             if self.force_input_shape:
                 for k, v in inputs.items():
                     shape_override[k] = list(v.shape)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -596,6 +596,15 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(mi, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
 
+        tf.reset_default_graph()
+        x_val1 = np.array([4.0, 16.0, 4.0, 1.6], dtype=np.int32).reshape((2, 2))
+        x_val2 = np.array([4.0, 4.0, 4.0, 4.0], dtype=np.int32).reshape((2, 2))
+        x1 = tf.placeholder(tf.int32, x_val1.shape, name=_TFINPUT)
+        x2 = tf.placeholder(tf.int32, x_val2.shape, name=_TFINPUT1)
+        mi = tf.minimum(x1, x2)
+        _ = tf.identity(mi, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
+
     @skip_caffe2_backend("issue with broadcasting scalar")
     @check_onnxruntime_incompatibility("Sub")
     def test_min_broadcast(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -797,6 +797,35 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2, "input3:0": x_val3})
 
+    def test_concat_empty_const_input(self):
+        x_val1 = np.array([1, 2, 3], dtype=np.float32)
+        x_val2 = np.array([], dtype=np.float32)
+        x1 = tf.placeholder(tf.float32, x_val1.shape, name=_TFINPUT)
+        x2 = tf.constant(x_val2, dtype=tf.float32)
+        x_ = tf.concat([x1, x2], 0)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1})
+
+        tf.reset_default_graph()
+        x_val1 = np.array([[1, 2, 3]], dtype=np.float32)
+        x_val2 = np.array([[]], dtype=np.float32)
+        x1 = tf.placeholder(tf.float32, x_val1.shape, name=_TFINPUT)
+        x2 = tf.constant(x_val2, dtype=tf.float32)
+        x_ = tf.concat([x1, x2], 1)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1})
+
+        tf.reset_default_graph()
+        x_val1 = np.array([1, 2, 3], dtype=np.float32)
+        x_val2 = np.array([], dtype=np.float32)
+        x_val3 = np.array([13, 14, 15], dtype=np.float32)
+        x1 = tf.placeholder(tf.float32, x_val1.shape, name=_TFINPUT)
+        x2 = tf.constant(x_val2, dtype=tf.float32)
+        x3 = tf.placeholder(tf.float32, x_val3.shape, name=_TFINPUT1)
+        x_ = tf.concat([x1, x2, x3], 0)
+        _ = tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val3})
+
     @check_opset_min_version(6, "cast")
     def test_concat_int64(self):
         x_val1 = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -908,7 +908,7 @@ class Graph(object):
                 break
         return new_node
 
-    def insert_new_node_on_output(self, op_type, output_name, name=None, domain=None, **kwargs):
+    def insert_new_node_on_output(self, op_type, output_name, name, domain=None, **kwargs):
         """Create and insert a new node into the graph.
         Args:
             op_type: type for new operation

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -131,9 +131,9 @@ def tf_to_onnx_tensor(tensor, name=""):
         tensor_content: empty
         tensor_shape.dim: [0]
         DTYPE_val: 1
-    3. empty tensor, e.g., np.array([], dtype=DTYPE):
+    3. empty tensor, e.g., np.array([], dtype=DTYPE) and np.array([[]], dtype=DTYPE):
         tensor_content: empty
-        tensor_shape.dim: [0]
+        tensor_shape.dim: [0] and [1, 0]
         DTYPE_val: empty
     """
     new_type = TF_TO_ONNX_DTYPE[tensor.dtype]
@@ -141,8 +141,8 @@ def tf_to_onnx_tensor(tensor, name=""):
     dims = [d.size for d in tdim]
     is_raw, data = get_tf_tensor_data(tensor)
     # empty tensor
-    if dims == [0] and not is_raw and data is None:
-        np_data = np.array([], dtype=map_onnx_to_numpy_type(new_type))
+    if not is_raw and data is None:
+        np_data = np.array([], dtype=map_onnx_to_numpy_type(new_type)).reshape(dims)
         return numpy_helper.from_array(np_data, name=name)
     make_sure(data, "tensor data isn't expected to be None or empty")
     # scalar tensor

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -120,21 +120,39 @@ def split_nodename_and_shape(name):
 
 
 def tf_to_onnx_tensor(tensor, name=""):
-    """Convert tensorflow tensor to onnx tensor."""
+    """
+    Convert tensorflow tensor to onnx tensor.
+    Here deal with three types of tensor:
+    1. normal tensor, e.g., np.array([1,2,3], dtype=DTYPE):
+        tensor_content: raw data of [1,2,3]
+        tensor_shape.dim: [3]
+        DTYPE_val: empty
+    2. scalar tensor, e.g., np.array(1, dtype=DTYPE):
+        tensor_content: empty
+        tensor_shape.dim: [0]
+        DTYPE_val: 1
+    3. empty tensor, e.g., np.array([], dtype=DTYPE):
+        tensor_content: empty
+        tensor_shape.dim: [0]
+        DTYPE_val: empty
+    """
     new_type = TF_TO_ONNX_DTYPE[tensor.dtype]
     tdim = tensor.tensor_shape.dim
     dims = [d.size for d in tdim]
-    # FIXME: something is fishy here
-    if dims == [0]:
-        dims = [1]
     is_raw, data = get_tf_tensor_data(tensor)
+    # empty tensor
+    if dims == [0] and not is_raw and data is None:
+        np_data = np.array([], dtype=map_onnx_to_numpy_type(new_type))
+        return numpy_helper.from_array(np_data, name=name)
+    make_sure(data, "tensor data isn't expected to be None or empty")
+    # scalar tensor
+    if dims == [0] and not is_raw and len(data) == 1:
+        return helper.make_tensor(name, new_type, [], data, False)
     if not is_raw and len(data) == 1 and np.prod(dims) > 1:
         batch_data = np.zeros(dims, dtype=map_onnx_to_numpy_type(new_type))
         batch_data.fill(data[0])
-        onnx_tensor = numpy_helper.from_array(batch_data, name=name)
-    else:
-        onnx_tensor = helper.make_tensor(name, new_type, dims, data, is_raw)
-    return onnx_tensor
+        return numpy_helper.from_array(batch_data, name=name)
+    return helper.make_tensor(name, new_type, dims, data, is_raw)
 
 
 def get_tf_tensor_data(tensor):
@@ -154,16 +172,15 @@ def get_tf_tensor_data(tensor):
         data = tensor.int64_val
     elif tensor.bool_val:
         data = tensor.bool_val
-    elif tensor.dtype == tf.int32:
-        data = [0]
-    elif tensor.dtype == tf.int64:
-        data = [0]
-    elif tensor.dtype == tf.float32:
-        data = [0.]
-    elif tensor.dtype == tf.float16:
-        data = [0]
     elif tensor.string_val:
         data = tensor.string_val
+    elif tensor.dtype in [
+            tf.int32,
+            tf.int64,
+            tf.float32,
+            tf.float16
+    ]:
+        data = None
     else:
         raise ValueError('tensor data not supported')
     return [is_raw, data]


### PR DESCRIPTION
1. correct input dtype when run pretrained model.
2. support more dtype for Maximum and Minimum and add unittests.
3. any empty input of concat op will lead to seg fault on onnxruntime. here I workaround it by remove concat op when its input is empty.
4. fix bugs when parsing tensor value of const op. 