### PR TITLE
support more dtype for Equal

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -197,6 +197,7 @@ def check_onnxruntime_incompatibility(op):
         "AveragePool": 7,  # AveragePool-1
         "Div": 7,  # Div-1, Div-6
         "Elu": 6,  # Elu-1
+        "Equal": 7,  # Equal-1
         "Exp": 6,  # Exp-1
         "Greater": 7,  # Greater-1
         "Less": 7,  # Less-1

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -672,6 +672,26 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(mi, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
 
+    @check_onnxruntime_incompatibility("Equal")
+    def test_equal(self):
+        x_val1 = np.array([4, 2, 4, 1], dtype=np.int32).reshape((2, 2))
+        x_val2 = np.array([2, 4, 4, 1], dtype=np.int32).reshape((2, 2))
+        x1 = tf.placeholder(tf.int32, [2, 2], name=_TFINPUT)
+        x2 = tf.placeholder(tf.int32, [2, 2], name=_TFINPUT1)
+        mi = tf.equal(x1, x2)
+        _ = tf.identity(mi, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
+
+        tf.reset_default_graph()
+        x_val1 = np.array([4, 2, 4, 1], dtype=np.float32).reshape((2, 2))
+        x_val2 = np.array([2, 4, 4, 1], dtype=np.float32).reshape((2, 2))
+        x1 = tf.placeholder(tf.float32, [2, 2], name=_TFINPUT)
+        x2 = tf.placeholder(tf.float32, [2, 2], name=_TFINPUT1)
+        mi = tf.equal(x1, x2)
+        _ = tf.identity(mi, name=_TFOUTPUT)
+        self._run_test_case([_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
+
+
     def test_sequeeze_no_axis_specified(self):
         x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2, 1))
         x = tf.placeholder(tf.float32, [2, 2, 1], name=_TFINPUT)


### PR DESCRIPTION
1. Support more dtypes for Equal ops and add some unit tests.
2. Move ops used to compare two tensors into [logical_compare.py](tf2onnx/function/logical_compare.py).