### PR TITLE
fix ci build errors in tf 1.13

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -124,11 +124,11 @@ def _append_message(reason, message):
     return reason
 
 
-def check_tf_max_version(max_required_version, message=""):
+def check_tf_max_version(max_accepted_version, message=""):
     """ Skip if tf_version > max_required_version """
     config = get_test_config()
-    reason = _append_message("conversion requires tf <= {}".format(max_required_version), message)
-    return unittest.skipIf(config.tf_version > LooseVersion(max_required_version), reason)
+    reason = _append_message("conversion requires tf <= {}".format(max_accepted_version), message)
+    return unittest.skipIf(config.tf_version > LooseVersion(max_accepted_version), reason)
 
 
 def check_tf_min_version(min_required_version, message=""):

--- a/tests/common.py
+++ b/tests/common.py
@@ -124,6 +124,13 @@ def _append_message(reason, message):
     return reason
 
 
+def check_tf_max_version(max_required_version, message=""):
+    """ Skip if tf_version > max_required_version """
+    config = get_test_config()
+    reason = _append_message("conversion requires tf <= {}".format(max_required_version), message)
+    return unittest.skipIf(config.tf_version > LooseVersion(max_required_version), reason)
+
+
 def check_tf_min_version(min_required_version, message=""):
     """ Skip if tf_version < min_required_version """
     config = get_test_config()

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -32,18 +32,11 @@ class RealDiv(common.BroadcastOp):
     pass
 
 
-@tf_op(["Abs", "Ceil", "Elu", "Exp", "Floor", "Log", "LogSoftmax", "Neg", "Relu", "Sigmoid", "Sqrt", "Tanh",
-        "Softplus", "Softsign", "Reciprocal"])
+@tf_op(["Abs", "Ceil", "Elu", "Exp", "Floor", "LeakyRelu", "Log", "LogSoftmax", "Neg", "Relu", "Sigmoid", "Sqrt",
+        "Tanh", "Softplus", "Softsign", "Reciprocal"])
 class DirectOp:
     @classmethod
     def version_4(cls, ctx, node, **kwargs):
-        pass
-
-
-@tf_op(["LeakyRelu"])
-class TrigOpSinceOpset6:
-    @classmethod
-    def version_6(cls, ctx, node, **kwargs):
         pass
 
 

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -40,6 +40,13 @@ class DirectOp:
         pass
 
 
+@tf_op(["LeakyRelu"])
+class TrigOpSinceOpset6:
+    @classmethod
+    def version_6(cls, ctx, node, **kwargs):
+        pass
+
+
 @tf_op(["Acos", "Asin", "Atan", "Cos", "Sin", "Tan"])
 class TrigOpSinceOpset7:
     @classmethod


### PR DESCRIPTION
Two main errors when upgraded to tf 1.13 are about `LeakyRelu` and `dropout`.

- add tf op `LeakyRelu` and modify corresponding backend test case `test_leaky_relu`
- add backend test case for `nn.dropout` with `rate` given (new feature in tf 1.13)  instead of `keep_prob`
- add `test_graph` test case for `nn.dropout` when tf version is 1.13 or newer
- add `check_tf_max_version` in `tests/common.py`