### PR TITLE
refine logging infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ optional arguments:
   --tests TESTS      tests to run
   --backend BACKEND  backend to use
   --config           yaml config file
-  --verbose          verbose output
+  --verbose          verbose output, option is additive
   --opset OPSET      target opset to use
   --perf csv-file    capture performance numbers or tensorflow and onnx runtime
   --debug            dump generated graph with shape info
@@ -199,7 +199,7 @@ tf2onnx.tfonnx.process_tf_graph(tf_graph,
         Args:
             tf_graph: tensorflow graph
             continue_on_error: if an op can't be processed (aka there is no mapping), continue
-            verbose: print summary stats
+            verbose: print summary stats (deprecated)
             target: list of workarounds applied to help certain platforms
             opset: the opset to be used (int, default is latest)
             custom_op_handlers: dictionary of custom ops handlers

--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -31,7 +31,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
         utils.INTERNAL_NAME = 1
         np.random.seed(1)  # Make it reproducible.
 
-        self.log = logging.getLogger("tf2onnx.unitest." + str(type(self)))
+        self.logger = logging.getLogger(self.__class__.__name__)
         if not self.config.is_debug_mode:
             # suppress log info of tensorflow so that result of test can be seen much easier
             os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -121,7 +121,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
                 os.makedirs(self.test_data_directory)
             model_path = os.path.join(self.test_data_directory, self._testMethodName + "_original.pb")
             utils.save_protobuf(model_path, sess.graph_def)
-            self.log.debug("created file %s", model_path)
+            self.logger.debug("created file %s", model_path)
 
         graph_def = tf_optimize(input_names_with_port, output_names_with_port,
                                 sess.graph_def, constant_fold)
@@ -129,7 +129,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
         if self.config.is_debug_mode:
             model_path = os.path.join(self.test_data_directory, self._testMethodName + "_after_tf_optimize.pb")
             utils.save_protobuf(model_path, graph_def)
-            self.log.debug("created file  %s", model_path)
+            self.logger.debug("created file  %s", model_path)
 
         tf.reset_default_graph()
         tf.import_graph_def(graph_def, name='')
@@ -158,5 +158,5 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
                                             model_proto, include_test_data=self.config.is_debug_mode,
                                             as_text=self.config.is_debug_mode)
 
-        self.log.debug("create model file: %s", target_path)
+        self.logger.debug("create model file: %s", target_path)
         return target_path

--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -30,12 +30,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
         # reset name generation on every test
         utils.INTERNAL_NAME = 1
         np.random.seed(1)  # Make it reproducible.
-
         self.logger = logging.getLogger(self.__class__.__name__)
-        if not self.config.is_debug_mode:
-            # suppress log info of tensorflow so that result of test can be seen much easier
-            os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-            tf.logging.set_verbosity(tf.logging.WARN)
 
     def tearDown(self):
         if not self.config.is_debug_mode:

--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -26,20 +26,16 @@ from tf2onnx import optimizer
 class Tf2OnnxBackendTestBase(unittest.TestCase):
     def setUp(self):
         self.config = get_test_config()
-        self.maxDiff = None
         tf.reset_default_graph()
         # reset name generation on every test
         utils.INTERNAL_NAME = 1
         np.random.seed(1)  # Make it reproducible.
 
         self.log = logging.getLogger("tf2onnx.unitest." + str(type(self)))
-        if self.config.is_debug_mode:
-            self.log.setLevel(logging.DEBUG)
-        else:
+        if not self.config.is_debug_mode:
             # suppress log info of tensorflow so that result of test can be seen much easier
             os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
             tf.logging.set_verbosity(tf.logging.WARN)
-            self.log.setLevel(logging.INFO)
 
     def tearDown(self):
         if not self.config.is_debug_mode:

--- a/tests/common.py
+++ b/tests/common.py
@@ -116,7 +116,7 @@ def get_test_config():
 
 def unittest_main():
     config = get_test_config()
-    logging.basicConfig(level=logging.WARNING)
+    logging.basicConfig(level=logging.WARNING, format=constants.LOG_FORMAT)
     with utils.set_log_level(logging.getLogger(), logging.INFO) as logger:
         logger.info(config)
     unittest.main()

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,6 +4,7 @@
 """ test common utilities."""
 
 import argparse
+import logging
 import os
 import sys
 import unittest
@@ -114,7 +115,10 @@ def get_test_config():
 
 
 def unittest_main():
-    print(get_test_config())
+    config = get_test_config()
+    logging.basicConfig(level=logging.WARNING)
+    with utils.set_log_level(logging.getLogger(), logging.INFO) as logger:
+        logger.info(config)
     unittest.main()
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -95,7 +95,7 @@ class TestConfig(object):
             config.backend = args.backend
             config.opset = args.opset
             config.target = args.target.split(',')
-            config.log_level = logging.get_adjusted_level(args.verbose, config.log_level)
+            config.log_level = logging.get_verbosity_level(args.verbose, config.log_level)
             config.is_debug_mode = args.debug
             if args.temp_dir:
                 config.temp_dir = args.temp_dir

--- a/tests/common.py
+++ b/tests/common.py
@@ -31,7 +31,6 @@ class TestConfig(object):
         self.backend = os.environ.get("TF2ONNX_TEST_BACKEND", "onnxruntime")
         self.backend_version = self._get_backend_version()
         self.log_level = logging.WARNING
-        self.is_debug_mode = False
         self.temp_dir = utils.get_temp_directory()
 
     @property
@@ -45,6 +44,10 @@ class TestConfig(object):
     @property
     def is_caffe2_backend(self):
         return self.backend == "caffe2"
+
+    @property
+    def is_debug_mode(self):
+        return utils.is_debug_mode()
 
     def _get_tf_version(self):
         import tensorflow as tf
@@ -92,11 +95,13 @@ class TestConfig(object):
             parser.add_argument("unittest_args", nargs='*')
 
             args = parser.parse_args()
+            if args.debug:
+                utils.set_debug_mode(True)
+
             config.backend = args.backend
             config.opset = args.opset
             config.target = args.target.split(',')
             config.log_level = logging.get_verbosity_level(args.verbose, config.log_level)
-            config.is_debug_mode = args.debug
             if args.temp_dir:
                 config.temp_dir = args.temp_dir
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,11 @@
 
 import logging
 from common import get_test_config
-from tf2onnx import utils
+from tf2onnx import constants, utils
 
 
 def pytest_configure():
     config = get_test_config()
-    logging.basicConfig(level=logging.WARNING)
+    logging.basicConfig(level=logging.WARNING, format=constants.LOG_FORMAT)
     with utils.set_log_level(logging.getLogger(), logging.INFO) as logger:
         logger.info(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,13 @@
 
 """ print pytest config."""
 
+import logging
 from common import get_test_config
+from tf2onnx import utils
 
 
 def pytest_configure():
-    print(get_test_config())
+    config = get_test_config()
+    logging.basicConfig(level=logging.WARNING)
+    with utils.set_log_level(logging.getLogger(), logging.INFO) as logger:
+        logger.info(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,12 @@
 
 """ print pytest config."""
 
-import logging
 from common import get_test_config
-from tf2onnx import constants, utils
+from tf2onnx import logging
 
 
 def pytest_configure():
     config = get_test_config()
-    logging.basicConfig(level=logging.WARNING, format=constants.LOG_FORMAT)
-    with utils.set_log_level(logging.getLogger(), logging.INFO) as logger:
+    logging.basicConfig(level=config.log_level)
+    with logging.set_scope_level(logging.INFO) as logger:
         logger.info(config)

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -371,7 +371,7 @@ def tests_from_yaml(fname):
 
 def main():
     args = get_args()
-    logging.basicConfig(level=logging.get_adjusted_level(args.verbose))
+    logging.basicConfig(level=logging.get_verbosity_level(args.verbose))
 
     Test.cache_dir = args.cache
     Test.target = args.target

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -34,7 +34,7 @@ from tf2onnx.tfonnx import process_tf_graph
 # pylint: disable=broad-except,logging-not-lazy,unused-argument,unnecessary-lambda
 
 logging.basicConfig(level=logging.INFO, format=constants.LOG_FORMAT)
-log = logging.getLogger("tf2onnx")
+logger = logging.getLogger("run_pretrained")
 
 TEMP_DIR = os.path.join(utils.get_temp_directory(), "run_pretrained")
 PERFITER = 1000
@@ -255,7 +255,7 @@ class Test(object):
                 dtype = tf.as_dtype(t.dtype).name
                 v = inputs[k]
                 if dtype != v.dtype:
-                    log.warning("input dtype doesn't match tensorflow's")
+                    logger.warning("input dtype doesn't match tensorflow's")
                     inputs[k] = np.array(v, dtype=dtype)
             if self.force_input_shape:
                 for k, v in inputs.items():

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -28,14 +28,12 @@ import tensorflow.contrib.rnn  # pylint: disable=unused-import
 import yaml
 
 import tf2onnx
-from tf2onnx import loader
-from tf2onnx import utils
-from tf2onnx import optimizer
+from tf2onnx import constants, loader, optimizer, utils
 from tf2onnx.tfonnx import process_tf_graph
 
 # pylint: disable=broad-except,logging-not-lazy,unused-argument,unnecessary-lambda
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO, format=constants.LOG_FORMAT)
 log = logging.getLogger("tf2onnx")
 
 TEMP_DIR = os.path.join(utils.get_temp_directory(), "run_pretrained")

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -153,7 +153,7 @@ class Test(object):
 
     def to_onnx(self, tf_graph, opset=None, extra_opset=None, shape_override=None, input_names=None):
         """Convert graph to tensorflow."""
-        return process_tf_graph(tf_graph, continue_on_error=False, verbose=True, opset=opset,
+        return process_tf_graph(tf_graph, continue_on_error=False, opset=opset,
                                 extra_opset=extra_opset, target=Test.target, shape_override=shape_override,
                                 input_names=input_names, output_names=self.output_names)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -188,7 +188,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
                 mp = tf.nn.max_pool(x, ksize, strides, padding=padding)
                 _ = tf.identity(mp, name=_TFOUTPUT)
 
-                self.log.debug(str(p))
+                self.logger.debug(str(p))
                 self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
     @unittest.skipIf(get_test_config().is_onnxruntime_backend and get_test_config().backend_version == "0.2.1",
@@ -207,7 +207,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
                 mp = tf.nn.avg_pool(x, ksize, strides, padding=padding)
                 _ = tf.identity(mp, name=_TFOUTPUT)
 
-                self.log.debug(str(p))
+                self.logger.debug(str(p))
                 self._run_test_case([_OUTPUT], {_INPUT: x_val}, rtol=1e-06)
 
     def _conv_test(self, x_val, w, strides=None, padding="VALID", dilations=None, rtol=1e-07):
@@ -1125,7 +1125,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             paddings = tf.constant(pad)
             op = tf.pad(x, paddings, mode)
             _ = tf.identity(op, name=_TFOUTPUT)
-            self.log.debug(str(p))
+            self.logger.debug(str(p))
             self._run_test_case([_OUTPUT], {_INPUT: x_val})
 
     @skip_caffe2_backend()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -95,17 +95,15 @@ class Tf2OnnxGraphTests(Tf2OnnxBackendTestBase):
 
     def setUp(self):
         super().setUp()
-        arg = namedtuple("Arg", "input inputs outputs verbose continue_on_error")
-        self._args0 = arg(input="test", inputs=[], outputs=["output:0"],
-                          verbose=False, continue_on_error=False)
-        self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"],
-                          verbose=False, continue_on_error=False)
+        arg = namedtuple("Arg", "input inputs outputs continue_on_error")
+        self._args0 = arg(input="test", inputs=[], outputs=["output:0"], continue_on_error=False)
+        self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"], continue_on_error=False)
         self._args2 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output:0"],
-                          verbose=False, continue_on_error=False)
+                          continue_on_error=False)
         self._args3 = arg(input="test", inputs=["input1:0", "input2:0", "prob:0"], outputs=["output:0"],
-                          verbose=False, continue_on_error=False)
+                          continue_on_error=False)
         self._args4 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output1:0", "output2:0"],
-                          verbose=False, continue_on_error=False)
+                          continue_on_error=False)
 
     def test_abs(self):
         with tf.Session() as sess:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,7 +22,7 @@ from tf2onnx.tfonnx import process_tf_graph
 from tf2onnx.handler import tf_op
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import get_test_config, unittest_main, check_tf_min_version, check_tf_max_version
+from common import unittest_main, check_tf_min_version, check_tf_max_version
 
 
 # pylint: disable=missing-docstring,unused-argument,unused-variable

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,8 +7,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-import unittest
 from collections import namedtuple
 
 import numpy as np
@@ -17,13 +15,13 @@ import graphviz as gv
 import tensorflow as tf
 from onnx import helper
 
-import tf2onnx
 from tf2onnx import constants, utils
 from tf2onnx.graph import GraphUtil
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.tfonnx import process_tf_graph
 from tf2onnx.handler import tf_op
 
+from backend_test_base import Tf2OnnxBackendTestBase
 from common import get_test_config, unittest_main, check_tf_min_version, check_tf_max_version
 
 
@@ -91,21 +89,12 @@ def onnx_pretty(g, args=None):
     return helper.printable_graph(model_proto.graph)
 
 
-class Tf2OnnxGraphTests(unittest.TestCase):
+class Tf2OnnxGraphTests(Tf2OnnxBackendTestBase):
     """Test cases."""
     maxDiff = None
 
     def setUp(self):
-        """Setup test."""
-        # reset name generation on every test
-        # suppress log info of tensorflow so that result of test can be seen much easier
-        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-        tf.logging.set_verbosity(tf.logging.WARN)
-
-        self.config = get_test_config()
-
-        tf2onnx.utils.INTERNAL_NAME = 1
-        tf.reset_default_graph()
+        super().setUp()
         arg = namedtuple("Arg", "input inputs outputs verbose continue_on_error")
         self._args0 = arg(input="test", inputs=[], outputs=["output:0"],
                           verbose=False, continue_on_error=False)

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -7,8 +7,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-import unittest
 from collections import namedtuple
 
 import graphviz as gv
@@ -20,6 +18,8 @@ import tensorflow as tf
 from tf2onnx import utils
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
 from tf2onnx.graph import GraphUtil
+
+from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main
 
 
@@ -49,14 +49,9 @@ def onnx_pretty(g, args=None):
     return helper.printable_graph(graph_proto.graph)
 
 
-class Tf2OnnxInternalTests(unittest.TestCase):
+class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
     def setUp(self):
-        """Setup test."""
-        # suppress log info of tensorflow so that result of test can be seen much easier
-        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-        tf.logging.set_verbosity(tf.logging.WARN)
-
-        utils.INTERNAL_NAME = 1
+        super().setUp()
         arg = namedtuple("Arg", "input inputs outputs verbose")
         self._args0 = arg(input="test", inputs=[], outputs=["output:0"], verbose=False)
         self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"], verbose=False)

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -52,13 +52,12 @@ def onnx_pretty(g, args=None):
 class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
     def setUp(self):
         super().setUp()
-        arg = namedtuple("Arg", "input inputs outputs verbose")
-        self._args0 = arg(input="test", inputs=[], outputs=["output:0"], verbose=False)
-        self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"], verbose=False)
-        self._args2 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output:0"], verbose=False)
-        self._args3 = arg(input="test", inputs=["input1:0", "input2:0", "prob:0"], outputs=["output:0"], verbose=False)
-        self._args4 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output1:0", "output2:0"],
-                          verbose=False)
+        arg = namedtuple("Arg", "input inputs outputs")
+        self._args0 = arg(input="test", inputs=[], outputs=["output:0"])
+        self._args1 = arg(input="test", inputs=["input:0"], outputs=["output:0"])
+        self._args2 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output:0"])
+        self._args3 = arg(input="test", inputs=["input1:0", "input2:0", "prob:0"], outputs=["output:0"])
+        self._args4 = arg(input="test", inputs=["input1:0", "input2:0"], outputs=["output1:0", "output2:0"])
 
     @staticmethod
     def sample_net():

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -14,6 +14,7 @@ from tf2onnx.graph import GraphUtil
 from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main, group_nodes_by_type
 
+
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
 
 class OptimizerTests(Tf2OnnxBackendTestBase):
@@ -34,8 +35,8 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         current = GraphUtil.get_node_count_from_onnx_graph(new_proto.graph)
 
         self.assertTrue(current[op_type] == remaining_op_num,
-                        msg="Expect " + str(remaining_op_num) + " " + op_type + " ops left, but actually " +
-                        str(current[op_type]) + " left")
+                        msg="Expect " + str(remaining_op_num) + " " + op_type + " ops left, but actually " + str(
+                            current[op_type]) + " left")
 
         if self.config.is_onnxruntime_backend:
             expected = self.run_onnxruntime(origin_model_path, onnx_feed_dict, output_names_with_port)
@@ -179,14 +180,13 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         graph.outputs = [identity_op.input[0]]
         graph.remove_node(identity_op.name)
 
-        optimized_graph = GraphUtil.optimize_graph(graph, "onnx-tests")
+        optimized_graph = GraphUtil.optimize_graph(graph)
 
         self.assertTrue(optimized_graph, msg="graph after optimizer should not be None")
 
         trans_cnt = len(group_nodes_by_type(optimized_graph)["Transpose"])
 
-        self.assertTrue(trans_cnt == 1, msg="Expect 1 Transpose ops left, but actually " +
-                        str(trans_cnt) + " left")
+        self.assertTrue(trans_cnt == 1, msg="Expect 1 Transpose ops left, but actually " + str(trans_cnt) + " left")
 
     # Tranpose Optimizer Tests End
 
@@ -292,7 +292,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
              ],
             [helper.make_tensor_value_info("loop_cond_output", TensorProto.BOOL, ()),
              helper.make_tensor_value_info("loop_var_out_1", TensorProto.FLOAT, ())
-            ],
+             ],
         )
         # sub graph ends
 
@@ -394,7 +394,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
         self.run_merge_duplicated_nodes_compare(["value1", "mask", "value2"],
-                                                {"X": np.random.randn(5,).astype(np.float32)},
+                                                {"X": np.random.randn(5).astype(np.float32)},
                                                 model_proto,
                                                 op_type="Dropout", remaining_op_num=2)
 
@@ -417,9 +417,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         )
 
         model_proto = helper.make_model(graph, producer_name="onnx-tests")
-        self.run_merge_duplicated_nodes_compare(["res"], {"X": np.random.randn(5,).astype(np.float32)},
+        self.run_merge_duplicated_nodes_compare(["res"], {"X": np.random.randn(5).astype(np.float32)},
                                                 model_proto,
                                                 op_type="Log", remaining_op_num=3)
+
     # Merge Duplicated Nodes Optimizer Tests End
 
     # Const Fold Optimizer Tests Start

--- a/tf2onnx/__init__.py
+++ b/tf2onnx/__init__.py
@@ -6,8 +6,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
 __all__ = ["utils", "graph_matcher", "graph", "loader", "tfonnx", "shape_inference", "schemas"]
 
 from .version import version as __version__
+from . import logging
 from tf2onnx import tfonnx, utils, graph, graph_matcher, shape_inference, schemas  # pylint: disable=wrong-import-order

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -5,7 +5,9 @@
 common constants
 """
 
-from . import utils
+from onnx import helper
+
+TF2ONNX_PACKAGE_NAME = __name__.split('.')[0]
 
 # Built-in supported domains
 ONNX_DOMAIN = ""
@@ -16,7 +18,7 @@ MICROSOFT_DOMAIN = "com.microsoft"
 PREFERRED_OPSET = 7
 
 # Default opset for custom ops
-TENSORFLOW_OPSET = utils.make_opsetid("ai.onnx.converters.tensorflow", 1)
+TENSORFLOW_OPSET = helper.make_opsetid("ai.onnx.converters.tensorflow", 1)
 
 # Target for the generated onnx graph. It possible targets:
 # onnx-1.1 = onnx at v1.1 (winml in rs4 is based on this)
@@ -32,5 +34,3 @@ NCHW_TO_NHWC = [0, 2, 3, 1]
 NHWC_TO_NCHW = [0, 3, 1, 2]
 HWCN_TO_NCHW = [3, 2, 0, 1]
 NCHW_TO_HWCN = [2, 3, 1, 0]
-
-LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s: %(message)s"

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -34,3 +34,6 @@ NCHW_TO_NHWC = [0, 2, 3, 1]
 NHWC_TO_NCHW = [0, 3, 1, 2]
 HWCN_TO_NCHW = [3, 2, 0, 1]
 NCHW_TO_HWCN = [2, 3, 1, 0]
+
+# Environment variables
+ENV_TF2ONNX_DEBUG_MODE = "TF2ONNX_DEBUG_MODE"

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -32,3 +32,5 @@ NCHW_TO_NHWC = [0, 2, 3, 1]
 NHWC_TO_NCHW = [0, 3, 1, 2]
 HWCN_TO_NCHW = [3, 2, 0, 1]
 NCHW_TO_HWCN = [2, 3, 1, 0]
+
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s: %(message)s"

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -10,12 +10,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import logging
 import tensorflow as tf
 
-from tf2onnx import constants, loader, utils
 from tf2onnx.graph import GraphUtil
 from tf2onnx.tfonnx import process_tf_graph, tf_optimize
+from . import constants, loader, logging, utils
 
 
 # pylint: disable=unused-argument
@@ -38,7 +37,7 @@ def get_args():
     parser.add_argument("--target", default=",".join(constants.DEFAULT_TARGET), choices=constants.POSSIBLE_TARGETS,
                         help="target platform")
     parser.add_argument("--continue_on_error", help="continue_on_error", action="store_true")
-    parser.add_argument("--verbose", help="verbose output", action="store_true")
+    parser.add_argument("--verbose", "-v", help="verbose output, option is additive", action="count")
     parser.add_argument("--fold_const", help="enable tf constant_folding transformation before conversion",
                         action="store_true")
     # experimental
@@ -70,6 +69,7 @@ def get_args():
         if len(tokens) != 2:
             raise ValueError("invalid extra_opset argument")
         args.extra_opset = [utils.make_opsetid(tokens[0], int(tokens[1]))]
+
     return args
 
 
@@ -80,7 +80,7 @@ def default_custom_op_handler(ctx, node, name, args):
 
 def main():
     args = get_args()
-    logging.basicConfig(level=logging.INFO, format=constants.LOG_FORMAT)
+    logging.basicConfig(level=logging.get_adjusted_level(args.verbose))
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -112,7 +112,6 @@ def main():
     with tf.Session(graph=tf_graph):
         g = process_tf_graph(tf_graph,
                              continue_on_error=args.continue_on_error,
-                             verbose=args.verbose,
                              target=args.target,
                              opset=args.opset,
                              custom_op_handlers=custom_ops,

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -38,6 +38,7 @@ def get_args():
                         help="target platform")
     parser.add_argument("--continue_on_error", help="continue_on_error", action="store_true")
     parser.add_argument("--verbose", "-v", help="verbose output, option is additive", action="count")
+    parser.add_argument("--debug", help="debug mode", action="store_true")
     parser.add_argument("--fold_const", help="enable tf constant_folding transformation before conversion",
                         action="store_true")
     # experimental
@@ -81,6 +82,8 @@ def default_custom_op_handler(ctx, node, name, args):
 def main():
     args = get_args()
     logging.basicConfig(level=logging.get_verbosity_level(args.verbose))
+    if args.debug:
+        utils.set_debug_mode(True)
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -80,7 +80,7 @@ def default_custom_op_handler(ctx, node, name, args):
 
 def main():
     args = get_args()
-    logging.basicConfig(level=logging.get_adjusted_level(args.verbose))
+    logging.basicConfig(level=logging.get_verbosity_level(args.verbose))
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
+import logging
 import tensorflow as tf
 
 from tf2onnx import constants, loader, utils
@@ -79,6 +80,7 @@ def default_custom_op_handler(ctx, node, name, args):
 
 def main():
     args = get_args()
+    logging.basicConfig(level=logging.INFO)
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -80,7 +80,7 @@ def default_custom_op_handler(ctx, node, name, args):
 
 def main():
     args = get_args()
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, format=constants.LOG_FORMAT)
 
     # override unknown dimensions from -1 to 1 (aka batchsize 1) since not every runtime does
     # support unknown dimensions.

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -24,7 +24,7 @@ from tf2onnx import optimizer
 from tf2onnx.schemas import get_schema
 
 
-log = logging.getLogger("graph")
+logger = logging.getLogger(__name__)
 
 
 # todo(pengwa): remove protected-access later
@@ -90,8 +90,8 @@ class Node(object):
         """Return onnx valid attributes"""
         schema = get_schema(self.type, self.graph.opset, self.domain)
         if schema is None and not (self.is_const() or self.is_graph_input()):
-            log.debug("Node %s uses non-stardard onnx op <%s, %s>, skip attribute check",
-                      self.name, self.domain, self.type)
+            logger.debug("Node %s uses non-stardard onnx op <%s, %s>, skip attribute check",
+                         self.name, self.domain, self.type)
         onnx_attrs = {}
         for a in self._attr.values():
             if schema is None or schema.has_attribute(a.name):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1057,11 +1057,11 @@ class GraphUtil(object):
     """Utilities for Graph manipulation."""
 
     @staticmethod
-    def optimize_graph(graph, debug=False):
-        return optimizer.optimize_graph(graph, debug)
+    def optimize_graph(graph):
+        return optimizer.optimize_graph(graph)
 
     @staticmethod
-    def optimize_model_proto(onnx_model_proto, debug=False):
+    def optimize_model_proto(onnx_model_proto):
         """Optimize the model proto, for example: eliminating all useless Transpose pairs.
 
         Returns:
@@ -1071,7 +1071,7 @@ class GraphUtil(object):
         try:
             kwargs = GraphUtil.get_onnx_model_properties(onnx_model_proto)
             graph = GraphUtil.create_graph_from_onnx_model(onnx_model_proto)
-            graph = GraphUtil.optimize_graph(graph, debug)
+            graph = GraphUtil.optimize_graph(graph)
             model_proto = graph.make_model(onnx_model_proto.graph.doc_string,
                                            graph_name=onnx_model_proto.graph.name, **kwargs)
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -23,7 +23,7 @@ from tf2onnx.utils import port_name, find_opset
 from tf2onnx import optimizer
 from tf2onnx.schemas import get_schema
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("graph")
 
 

--- a/tf2onnx/loader.py
+++ b/tf2onnx/loader.py
@@ -16,7 +16,7 @@ from tensorflow.python.framework.graph_util import convert_variables_to_constant
 from tf2onnx import utils
 
 
-log = logging.getLogger("loader")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument
 
@@ -48,7 +48,7 @@ def remove_redundant_inputs(frozen_graph, input_names):
                 frozen_inputs.append(inp)
     deleted_inputs = list(set(input_names) - set(frozen_inputs))
     if deleted_inputs:
-        log.warning("inputs [%s] is not in frozen graph, delete them", ",".join(deleted_inputs))
+        logger.warning("inputs [%s] is not in frozen graph, delete them", ",".join(deleted_inputs))
     return frozen_inputs
 
 

--- a/tf2onnx/loader.py
+++ b/tf2onnx/loader.py
@@ -15,8 +15,8 @@ from tensorflow.python.framework.graph_util import convert_variables_to_constant
 
 from tf2onnx import utils
 
-
 logger = logging.getLogger(__name__)
+
 
 # pylint: disable=unused-argument
 

--- a/tf2onnx/loader.py
+++ b/tf2onnx/loader.py
@@ -15,7 +15,7 @@ from tensorflow.python.framework.graph_util import convert_variables_to_constant
 
 from tf2onnx import utils
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("loader")
 
 # pylint: disable=unused-argument

--- a/tf2onnx/logging.py
+++ b/tf2onnx/logging.py
@@ -17,6 +17,8 @@ from . import constants
 
 VERBOSE = 15
 
+_logging.addLevelName(VERBOSE, "VERBOSE")
+
 
 def _verbose(self, message, *args, **kwargs):
     if self.isEnabledFor(VERBOSE):
@@ -51,9 +53,9 @@ _VERBOSITY_TO_LEVEL = {
 }
 
 
-def get_adjusted_level(verbosity, raw_level=INFO):
-    """ If verbosity is specified, return corresponding level, otherwise, return raw_level. """
-    return _VERBOSITY_TO_LEVEL.get(verbosity, raw_level)
+def get_verbosity_level(verbosity, default_level=INFO):
+    """ If verbosity is specified, return corresponding level, otherwise, return default_level. """
+    return _VERBOSITY_TO_LEVEL.get(verbosity, default_level)
 
 
 def set_level(level):

--- a/tf2onnx/logging.py
+++ b/tf2onnx/logging.py
@@ -47,15 +47,15 @@ def basicConfig(**kwargs):  # pylint: disable=invalid-name, function-redefined
     set_tf_verbosity(_logging.getLogger().getEffectiveLevel())
 
 
-_VERBOSITY_TO_LEVEL = {
-    1: VERBOSE,
-    2: DEBUG
-}
+_VERBOSITY_TO_LEVEL = [INFO, VERBOSE, DEBUG]
 
 
 def get_verbosity_level(verbosity, default_level=INFO):
     """ If verbosity is specified, return corresponding level, otherwise, return default_level. """
-    return _VERBOSITY_TO_LEVEL.get(verbosity, default_level)
+    if verbosity is None:
+        return default_level
+    verbosity = min(max(0, verbosity), len(_VERBOSITY_TO_LEVEL) - 1)
+    return _VERBOSITY_TO_LEVEL[verbosity]
 
 
 def set_level(level):

--- a/tf2onnx/logging.py
+++ b/tf2onnx/logging.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+A wrapper of built-in logging with custom level support and utilities.
+"""
+
+from contextlib import contextmanager
+import logging as _logging
+from logging import *  # pylint: disable=wildcard-import, unused-wildcard-import
+import os
+import types
+
+import tensorflow as tf
+
+from . import constants
+
+VERBOSE = 15
+
+
+def _verbose(self, message, *args, **kwargs):
+    if self.isEnabledFor(VERBOSE):
+        self._log(VERBOSE, message, args, **kwargs)  # pylint: disable=protected-access
+
+
+def getLogger(name=None):  # pylint: disable=invalid-name, function-redefined
+    logger = _logging.getLogger(name)
+    # Inject verbose method to logger object instead logging module
+    logger.verbose = types.MethodType(_verbose, logger)
+    return logger
+
+
+_SIMPLE_LOG_FORMAT = "%(message)s"
+_VERBOSE_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s: %(message)s"
+
+
+def basicConfig(**kwargs):  # pylint: disable=invalid-name, function-redefined
+    """ Do basic configuration for the logging system. tf verbosity is updated accordingly. """
+    # Choose pre-defined format if format argument is not specified
+    if "format" not in kwargs:
+        level = kwargs.get("level", _logging.root.level)
+        kwargs["format"] = _SIMPLE_LOG_FORMAT if level >= INFO else _VERBOSE_LOG_FORMAT
+
+    _logging.basicConfig(**kwargs)
+    set_tf_verbosity(_logging.getLogger().getEffectiveLevel())
+
+
+_VERBOSITY_TO_LEVEL = {
+    1: VERBOSE,
+    2: DEBUG
+}
+
+
+def get_adjusted_level(verbosity, raw_level=INFO):
+    """ If verbosity is specified, return corresponding level, otherwise, return raw_level. """
+    return _VERBOSITY_TO_LEVEL.get(verbosity, raw_level)
+
+
+def set_level(level):
+    """ Set logging level for tf2onnx package. tf verbosity is updated accordingly. """
+    _logging.getLogger(constants.TF2ONNX_PACKAGE_NAME).setLevel(level)
+    set_tf_verbosity(level)
+
+
+def set_tf_verbosity(level):
+    """ Set TF logging verbosity."""
+    tf.logging.set_verbosity(level)
+
+    # TF_CPP_MIN_LOG_LEVEL:
+    #   0 = all messages are logged (default behavior)
+    #   1 = INFO messages are not printed
+    #   2 = INFO and WARNING messages are not printed
+    #   3 = INFO, WARNING, and ERROR messages are not printed
+    if level <= INFO:
+        tf_cpp_min_log_level = "0"
+    elif level <= WARNING:
+        tf_cpp_min_log_level = "1"
+    elif level <= ERROR:
+        tf_cpp_min_log_level = "2"
+    else:
+        tf_cpp_min_log_level = "3"
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = tf_cpp_min_log_level
+
+
+@contextmanager
+def set_scope_level(level, logger=None):
+    """
+    Set logging level to logger within context, reset level to previous value when exit context.
+    TF verbosity is NOT affected.
+    """
+    if logger is None:
+        logger = getLogger()
+
+    current_level = logger.level
+    logger.setLevel(level)
+
+    try:
+        yield logger
+    finally:
+        logger.setLevel(current_level)

--- a/tf2onnx/onnx_opset/common.py
+++ b/tf2onnx/onnx_opset/common.py
@@ -13,7 +13,7 @@ import logging
 
 from tf2onnx import constants
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.common")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/common.py
+++ b/tf2onnx/onnx_opset/common.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.math
+common
 """
 
 from __future__ import division
@@ -14,7 +14,7 @@ import logging
 from tf2onnx import constants
 
 
-log = logging.getLogger("onnx_opset.common")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/controlflow.py
+++ b/tf2onnx/onnx_opset/controlflow.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.controlflow
+controlflow
 """
 
 from __future__ import division
@@ -21,7 +21,7 @@ from tf2onnx.handler import tf_op
 from tf2onnx.utils import make_sure
 
 
-log = logging.getLogger("onnx_opset.controlflow")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/controlflow.py
+++ b/tf2onnx/onnx_opset/controlflow.py
@@ -20,7 +20,7 @@ from tf2onnx.onnx_opset.nn import spatial_map
 from tf2onnx.handler import tf_op
 from tf2onnx.utils import make_sure
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.controlflow")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.generator
+generator
 """
 
 from __future__ import division
@@ -17,7 +17,7 @@ from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
 
-log = logging.getLogger("onnx_opset.generator")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -16,7 +16,7 @@ from onnx import onnx_pb, numpy_helper
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.generator")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/logical.py
+++ b/tf2onnx/onnx_opset/logical.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.logical
+logical
 """
 
 from __future__ import division
@@ -17,7 +17,7 @@ from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common
 
 
-log = logging.getLogger("onnx_opset.logical")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/logical.py
+++ b/tf2onnx/onnx_opset/logical.py
@@ -16,7 +16,7 @@ from tf2onnx import utils
 from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.logical")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -17,7 +17,7 @@ from tf2onnx import constants, utils
 from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.math")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.math
+math
 """
 
 from __future__ import division
@@ -18,7 +18,7 @@ from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common
 
 
-log = logging.getLogger("onnx_opset.math")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/misc.py
+++ b/tf2onnx/onnx_opset/misc.py
@@ -13,7 +13,7 @@ import logging
 
 from tf2onnx.handler import tf_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.misc")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/misc.py
+++ b/tf2onnx/onnx_opset/misc.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.misc
+misc
 """
 
 from __future__ import division
@@ -14,7 +14,7 @@ import logging
 from tf2onnx.handler import tf_op
 
 
-log = logging.getLogger("onnx_opset.misc")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.nn
+nn
 """
 
 from __future__ import division
@@ -19,7 +19,7 @@ from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common, controlflow, tensor
 
 
-log = logging.getLogger("onnx_opset.nn")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring,unused-variable
 
@@ -143,15 +143,15 @@ def add_padding(ctx, node, kernel_shape, strides, dilations=None, spatial=2):
             output_shape = ctx.get_shape(node.output[0])
             # check if the input shape is valid
             if len(input_shape) != len(pads):
-                log.error("node %s input needs to be rank %d, is %d", node.name, len(pads), len(input_shape))
+                logger.error("node %s input needs to be rank %d, is %d", node.name, len(pads), len(input_shape))
             # transpose shape to nchw
             if node.is_nhwc():
                 input_shape = spatial_map(input_shape, constants.NHWC_TO_NCHW)
                 output_shape = spatial_map(output_shape, constants.NHWC_TO_NCHW)
             # calculate pads
             if any(input_shape[i + 2] == -1 for i in range(spatial)):
-                log.debug("node %s has unknown dim %d for pads calculation, fallback to auto_pad",
-                          node.name, input_shape)
+                logger.debug("node %s has unknown dim %d for pads calculation, fallback to auto_pad",
+                             node.name, input_shape)
                 node.set_attr("auto_pad", "SAME_UPPER")
             else:
                 for i in range(spatial):

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -18,7 +18,7 @@ from tf2onnx import constants, utils
 from tf2onnx.handler import tf_op
 from tf2onnx.onnx_opset import common, controlflow, tensor
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.nn")
 
 # pylint: disable=unused-argument,missing-docstring,unused-variable

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.generator
+reduction
 """
 
 from __future__ import division
@@ -18,7 +18,7 @@ from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
 
-log = logging.getLogger("onnx_opset.reduction")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -17,7 +17,7 @@ from onnx import onnx_pb, helper
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.reduction")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -15,7 +15,7 @@ import numpy as np
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.rnn")
 
 

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.generator
+rnn
 """
 
 from __future__ import division
@@ -16,7 +16,7 @@ from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
 
-log = logging.getLogger("onnx_opset.rnn")
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.generator
+tensor
 """
 
 from __future__ import division
@@ -20,7 +20,7 @@ from tf2onnx import constants, utils
 from tf2onnx.handler import tf_op
 
 
-log = logging.getLogger("onnx_opset.tensor")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring,unused-variable
 
@@ -86,7 +86,7 @@ class Reshape:
         shape_node = node.inputs[1]
         shape = shape_node.get_tensor_value()
         if shape is None:
-            log.error("Reshape on node %s does not have a const shape", node.name)
+            logger.error("Reshape on node %s does not have a const shape", node.name)
             return
         ctx.remove_input(node, node.input[1])
         node.set_attr("shape", shape)
@@ -737,7 +737,7 @@ class OneHot:
         output_dtype = ctx.get_dtype(node.input[2])
         if ctx.is_target(constants.TARGET_RS6) \
             and output_dtype not in [onnx_pb.TensorProto.INT64, onnx_pb.TensorProto.INT32]:
-            log.warning("unsupported dtype in onnxruntime, onehot-9 can't be used directly")
+            logger.warning("unsupported dtype in onnxruntime, onehot-9 can't be used directly")
             cls.version_5(ctx, node, **kwargs)
             return
 

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -19,7 +19,7 @@ import tf2onnx
 from tf2onnx import constants, utils
 from tf2onnx.handler import tf_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.tensor")
 
 # pylint: disable=unused-argument,missing-docstring,unused-variable

--- a/tf2onnx/onnx_opset/traditionalml.py
+++ b/tf2onnx/onnx_opset/traditionalml.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.tf2onnx.onnx_opset.generator
+traditional ml
 """
 
 from __future__ import division
@@ -11,7 +11,4 @@ from __future__ import unicode_literals
 
 import logging
 
-
-log = logging.getLogger("onnx_opset.traditional")
-
-# pylint: disable=unused-argument,missing-docstring
+logger = logging.getLogger(__name__)

--- a/tf2onnx/onnx_opset/traditionalml.py
+++ b/tf2onnx/onnx_opset/traditionalml.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 import logging
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("onnx_opset.traditional")
 
 # pylint: disable=unused-argument,missing-docstring

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -15,7 +15,6 @@ from tf2onnx.optimizer.identity_optimizer import IdentityOptimizer
 from tf2onnx.optimizer.merge_duplicated_nodes_optimizer import MergeDuplicatedNodesOptimizer
 from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
 
-
 # pylint: disable=missing-docstring, broad-except
 
 # optimizer sequence need to be considered carefully

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -28,11 +28,11 @@ _optimizers = OrderedDict([
 ])
 
 
-def optimize_graph(graph, debug=False):
+def optimize_graph(graph):
     try:
         opts = _get_optimizers()
         for opt in opts.values():
-            graph = opt(debug=debug).optimize(graph)
+            graph = opt().optimize(graph)
 
         graph.update_proto()
         return graph

--- a/tf2onnx/optimizer/const_fold_optimizer.py
+++ b/tf2onnx/optimizer/const_fold_optimizer.py
@@ -20,13 +20,14 @@ def _register_func(op_type):
     def _internal_fun(func):
         _func_map[op_type] = func
         return func
+
     return _internal_fun
 
 
 class ConstFoldOptimizer(GraphOptimizerBase):
 
-    def __init__(self, debug=False):
-        super(ConstFoldOptimizer, self).__init__("ConstFoldOptimizer", debug)
+    def __init__(self, debug=False):  # pylint: disable=useless-super-delegation
+        super(ConstFoldOptimizer, self).__init__(debug)
 
     def _optimize(self, graph):
         return self._apply_optimization(graph, self._optimize_at_current_graph_level)
@@ -68,7 +69,7 @@ class ConstFoldOptimizer(GraphOptimizerBase):
                 const_outputs = process_func(node, graph)
                 self._replace_node_with_const(node, graph, const_outputs)
                 return True
-        self.log.debug("need to add function to fold op %s whose op_type is %s", node.name, node.type)
+        self.logger.debug("need to add function to fold op %s whose op_type is %s", node.name, node.type)
         return False
 
     @staticmethod

--- a/tf2onnx/optimizer/const_fold_optimizer.py
+++ b/tf2onnx/optimizer/const_fold_optimizer.py
@@ -26,8 +26,8 @@ def _register_func(op_type):
 
 class ConstFoldOptimizer(GraphOptimizerBase):
 
-    def __init__(self, debug=False):  # pylint: disable=useless-super-delegation
-        super(ConstFoldOptimizer, self).__init__(debug)
+    def __init__(self):  # pylint: disable=useless-super-delegation
+        super(ConstFoldOptimizer, self).__init__()
 
     def _optimize(self, graph):
         return self._apply_optimization(graph, self._optimize_at_current_graph_level)

--- a/tf2onnx/optimizer/identity_optimizer.py
+++ b/tf2onnx/optimizer/identity_optimizer.py
@@ -16,8 +16,8 @@ from tf2onnx.optimizer.optimizer_base import GraphOptimizerBase
 class IdentityOptimizer(GraphOptimizerBase):
     """Identity Optimizer."""
 
-    def __init__(self, debug=False):
-        super(IdentityOptimizer, self).__init__(debug)
+    def __init__(self):
+        super(IdentityOptimizer, self).__init__()
         self._g = None
 
     def optimize(self, graph):

--- a/tf2onnx/optimizer/identity_optimizer.py
+++ b/tf2onnx/optimizer/identity_optimizer.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from tf2onnx.optimizer.optimizer_base import GraphOptimizerBase
 
+
 # pylint: disable=logging-not-lazy,unused-argument,missing-docstring,unused-variable,arguments-differ
 
 
@@ -16,7 +17,7 @@ class IdentityOptimizer(GraphOptimizerBase):
     """Identity Optimizer."""
 
     def __init__(self, debug=False):
-        super(IdentityOptimizer, self).__init__("IdentityOptimizer", debug)
+        super(IdentityOptimizer, self).__init__(debug)
         self._g = None
 
     def optimize(self, graph):
@@ -25,7 +26,7 @@ class IdentityOptimizer(GraphOptimizerBase):
         self._optimize_recursively(self._g)
         current_counter = self._g.dump_node_statistics()
         identity_cnt = current_counter["Identity"]
-        self.log.info(" %d identity op(s) left", identity_cnt)
+        self.logger.info(" %d identity op(s) left", identity_cnt)
         self._print_stat_diff(previous_counter, current_counter)
         return self._g
 
@@ -36,9 +37,9 @@ class IdentityOptimizer(GraphOptimizerBase):
             body_graphs = n.get_body_graphs()
             if body_graphs:
                 for attr, b_g in body_graphs.items():
-                    self.log.debug("start handling subgraph of %s's attribute %s", n.name, attr)
+                    self.logger.debug("start handling subgraph of %s's attribute %s", n.name, attr)
                     self._optimize_recursively(b_g)
-                    self.log.debug("finish handling subgraph of %s's attribute %s", n.name, attr)
+                    self.logger.debug("finish handling subgraph of %s's attribute %s", n.name, attr)
 
     def _optimize(self, g):
         has_update = True
@@ -47,7 +48,7 @@ class IdentityOptimizer(GraphOptimizerBase):
             nodes = [n for n in g.get_nodes() if n.type == "Identity"]
             for n in nodes:
                 if n.graph is None:
-                    self.log.info("node has been removed from this graph, skip")
+                    self.logger.info("node has been removed from this graph, skip")
                     continue
 
                 graph_outputs = set(n.output).intersection(g.outputs)
@@ -72,12 +73,12 @@ class IdentityOptimizer(GraphOptimizerBase):
 
         if input_node.graph != graph:
             # If input node is in parent graph, we don't handle it now
-            self.log.debug("input node in parent graph, skip")
+            self.logger.debug("input node in parent graph, skip")
             return False
 
         if input_node.is_graph_input():
             # Identity between input and output should not be removed.
-            self.log.debug("skip identity between input and output")
+            self.logger.debug("skip identity between input and output")
             return False
 
         output_id = identity.output[0]
@@ -86,7 +87,7 @@ class IdentityOptimizer(GraphOptimizerBase):
         if input_id in graph.outputs:
             # input id already be graph output, so we cannot make that be another graph output.
             # this Identity must be kept.
-            self.log.debug("identity input already be graph output")
+            self.logger.debug("identity input already be graph output")
             return False
 
         graph.remove_node(identity.name)

--- a/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
+++ b/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
@@ -20,8 +20,8 @@ class MergeDuplicatedNodesOptimizer(GraphOptimizerBase):
     """Remove duplicate nodes.
     """
 
-    def __init__(self, debug=False):
-        super(MergeDuplicatedNodesOptimizer, self).__init__(debug)
+    def __init__(self):
+        super(MergeDuplicatedNodesOptimizer, self).__init__()
         # used internally
         self._graph_can_be_optimized = True
 

--- a/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
+++ b/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
@@ -11,7 +11,6 @@ from collections import defaultdict, namedtuple
 
 from tf2onnx.optimizer.optimizer_base import GraphOptimizerBase
 
-
 # pylint: disable=logging-not-lazy,unused-argument,missing-docstring
 
 _KeyToGroupNodes = namedtuple("key", "type input")
@@ -20,8 +19,9 @@ _KeyToGroupNodes = namedtuple("key", "type input")
 class MergeDuplicatedNodesOptimizer(GraphOptimizerBase):
     """Remove duplicate nodes.
     """
+
     def __init__(self, debug=False):
-        super(MergeDuplicatedNodesOptimizer, self).__init__("MergeDuplicatedNodesOptimizer", debug)
+        super(MergeDuplicatedNodesOptimizer, self).__init__(debug)
         # used internally
         self._graph_can_be_optimized = True
 

--- a/tf2onnx/optimizer/optimizer_base.py
+++ b/tf2onnx/optimizer/optimizer_base.py
@@ -11,10 +11,9 @@ class GraphOptimizerBase(object):
     """optimizer graph to improve performance
     """
 
-    def __init__(self, name, debug=False):
+    def __init__(self, debug=False):
         self._debug = debug
-        self._name = name
-        self._log = logging.getLogger("tf2onnx.optimizer.%s" % self._name)
+        self._logger = logging.getLogger('.'.join(__name__.split('.')[:-1] + [self.__class__.__name__]))
 
     def optimize(self, graph):
         original_node_statistics = graph.dump_node_statistics()
@@ -28,12 +27,8 @@ class GraphOptimizerBase(object):
         raise NotImplementedError
 
     @property
-    def name(self):
-        return self._name
-
-    @property
-    def log(self):
-        return self._log
+    def logger(self):
+        return self._logger
 
     @staticmethod
     def _apply_optimization(graph, optimize_func):
@@ -59,4 +54,4 @@ class GraphOptimizerBase(object):
         for key, value in nodes_after_optimized.items():
             if value != 0:
                 res[key] = value
-        self.log.info("the optimization gain is %s", res)
+        self.logger.info("the optimization gain is %s", res)

--- a/tf2onnx/optimizer/optimizer_base.py
+++ b/tf2onnx/optimizer/optimizer_base.py
@@ -4,16 +4,24 @@
 """Graph Optimizer Base"""
 
 from __future__ import unicode_literals
-import logging
+
+from tf2onnx import logging, utils
 
 
 class GraphOptimizerBase(object):
     """optimizer graph to improve performance
     """
 
-    def __init__(self, debug=False):
-        self._debug = debug
+    def __init__(self):
         self._logger = logging.getLogger('.'.join(__name__.split('.')[:-1] + [self.__class__.__name__]))
+
+    @property
+    def logger(self):
+        return self._logger
+
+    @property
+    def is_debug_mode(self):
+        return utils.is_debug_mode()
 
     def optimize(self, graph):
         original_node_statistics = graph.dump_node_statistics()
@@ -25,10 +33,6 @@ class GraphOptimizerBase(object):
 
     def _optimize(self, graph):
         raise NotImplementedError
-
-    @property
-    def logger(self):
-        return self._logger
 
     @staticmethod
     def _apply_optimization(graph, optimize_func):

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -6,7 +6,6 @@
 from __future__ import unicode_literals
 from collections import defaultdict
 
-
 import numpy as np
 
 from tf2onnx import utils
@@ -36,7 +35,7 @@ class TransposeOptimizer(GraphOptimizerBase):
     """Transpose Optimizer."""
 
     def __init__(self, debug=False):
-        super(TransposeOptimizer, self).__init__("TransposeOptimizer", debug)
+        super(TransposeOptimizer, self).__init__(debug)
 
         self._handler_map = {}
         self._force_stop = {}
@@ -158,17 +157,17 @@ class TransposeOptimizer(GraphOptimizerBase):
             if "stop" in self._force_stop and self._force_stop["stop"] == 1:
                 break
 
-        self.log.debug("finish after " + str(iteration_cnt) + " iteration(s)")
+        self.logger.debug("finish after " + str(iteration_cnt) + " iteration(s)")
 
         self.merge_duplicated_transposes()
         self.post_optimize_action()
 
         current_counter = self._g.dump_node_statistics()
         transpose_cnt = current_counter["Transpose"]
-        self.log.info(" %d transpose op(s) left", transpose_cnt)
+        self.logger.info(" %d transpose op(s) left", transpose_cnt)
         self._print_stat_diff(previous_counter, current_counter)
         if transpose_cnt > 2:
-            self.log.warning("please try add --fold_const to help remove more transpose")
+            self.logger.warning("please try add --fold_const to help remove more transpose")
         return self._g
 
     def _initialize_handlers(self):
@@ -219,7 +218,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                 self._g.remove_node(n.name)
             return True
 
-        self.log.debug("input transpose does not have single consumer, skipping...")
+        self.logger.debug("input transpose does not have single consumer, skipping...")
         return False
 
     # get the input index of transpose op in node's inputs.
@@ -257,13 +256,13 @@ class TransposeOptimizer(GraphOptimizerBase):
     # otherwise, it means that we skip handling since it is not in our support set
     def _handle_nhwc_tranpose(self, trans):
         if trans.output[0] in self._g.outputs:
-            self.log.debug("%s connects to graph outputs, skip", trans.output[0])
+            self.logger.debug("%s connects to graph outputs, skip", trans.output[0])
             return False
         out_nodes = self._g.find_output_consumers(trans.output[0])
         if len(out_nodes) == 1:
             p = out_nodes[0]
             if p.name in self._output_names:
-                self.log.debug("cannot move transpose down since it met output node %s", p.name)
+                self.logger.debug("cannot move transpose down since it met output node %s", p.name)
                 return False
 
             if p.type in self._handler_map:

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -34,8 +34,8 @@ def is_useless_transpose(transpose_node):
 class TransposeOptimizer(GraphOptimizerBase):
     """Transpose Optimizer."""
 
-    def __init__(self, debug=False):
-        super(TransposeOptimizer, self).__init__(debug)
+    def __init__(self):
+        super(TransposeOptimizer, self).__init__()
 
         self._handler_map = {}
         self._force_stop = {}

--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -18,7 +18,7 @@ from tf2onnx.rewriter.bilstm_rewriter import slice_bilstm_for_original_lstm_cons
      get_reverse_nodes_after_y_output, get_np_val_for_const, _process_single_init_node
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.bigru_rewriter")
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -15,7 +15,7 @@ import numpy as np
 from tf2onnx import utils
 from tf2onnx.rewriter.rnn_utils import is_reverse_op
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.bilstm_rewriter")
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring

--- a/tf2onnx/rewriter/bilstm_rewriter.py
+++ b/tf2onnx/rewriter/bilstm_rewriter.py
@@ -16,15 +16,15 @@ from tf2onnx import utils
 from tf2onnx.rewriter.rnn_utils import is_reverse_op
 
 
-log = logging.getLogger("tf2onnx.rewriter.bilstm_rewriter")
+logger = logging.getLogger(__name__)
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
 def process_bilstm(g, bi_lstms):
     for fw, bw in bi_lstms:
         input_id = fw[0]
-        log.debug("=========================")
-        log.debug("start handling potential bidirectional lstm %s", input_id)
+        logger.debug("=========================")
+        logger.debug("start handling potential bidirectional lstm %s", input_id)
 
         lstm_fw = fw[1]
         lstm_bw = bw[1]
@@ -44,7 +44,7 @@ def process_bilstm(g, bi_lstms):
             if len(lstm_fw.inputs) > 4:
                 h_node, c_node = process_ch_init_nodes(g, lstm_fw, lstm_bw, all_nodes)
         else:
-            log.error("fw, bw lstm inputs num is not consistent. stop")
+            logger.error("fw, bw lstm inputs num is not consistent. stop")
             continue
 
         # create node
@@ -67,13 +67,13 @@ def process_bilstm(g, bi_lstms):
         if lstm_fw.get_attr("hidden_size").i == lstm_bw.get_attr("hidden_size").i:
             hidden_size = lstm_fw.get_attr("hidden_size").i
         else:
-            log.error("fw and bw has different hidden_size, skip")
+            logger.error("fw and bw has different hidden_size, skip")
             continue
 
         attr = {"direction": direction, "hidden_size": hidden_size}
         bi_lstm_node = g.make_node("LSTM", lstm_inputs, attr=attr, output_count=3)
         all_nodes.append(bi_lstm_node)
-        log.debug("processing output nodes")
+        logger.debug("processing output nodes")
 
         to_remove = [lstm_fw.name, lstm_fw.input[1], lstm_fw.input[2], lstm_fw.input[3],
                      lstm_bw.name, lstm_bw.input[1], lstm_bw.input[2], lstm_bw.input[3]]
@@ -90,7 +90,7 @@ def process_bilstm(g, bi_lstms):
         # this is guaranteed by dynamic_rnn logic.
         old_x_has_lstm_as_consumer = [n for n in old_x_consumers if n.type == "LSTM"]
         if not old_x_has_lstm_as_consumer:
-            log.debug("plan to remove useless reverse op in bw")
+            logger.debug("plan to remove useless reverse op in bw")
             reverse_node = g.get_node_by_output(lstm_bw_old_x)
 
             if reverse_node.type == "Transpose":
@@ -118,7 +118,7 @@ def slice_bilstm_for_original_lstm_consumers(g, lstm_fw, lstm_bw, bi_lstm, lstm_
             raise ValueError("should not happen y_output is not followed with reverse node")
 
         for r_op in reverse_nodes:
-            log.debug("remove reverse op called %s", r_op.name)
+            logger.debug("remove reverse op called %s", r_op.name)
             g.replace_all_inputs(all_nodes, r_op.output[0], r_op.input[0])
             to_remove.append(r_op.name)
     elif lstm_output_index in [1, 2]:
@@ -194,10 +194,10 @@ def rewrite_bidirectional_lstms(g, ops):
             if g.find_output_consumers(n.output[0]) and not get_reverse_nodes_after_y_output(g, n):
                 continue
 
-            log.debug("find bw lstm %s", input_id)
+            logger.debug("find bw lstm %s", input_id)
             bw_lstm[input_id] = [input_id, n]
         else:
-            log.debug("find fw lstm %s", input_id)
+            logger.debug("find fw lstm %s", input_id)
             fw_lstm[input_id] = [input_id, n]
 
     bilstm_input = list(set(fw_lstm.keys()).intersection(bw_lstm.keys()))
@@ -221,18 +221,18 @@ def get_reverse_nodes_after_y_output(g, lstm_bw):
             elif is_reverse_op(trans_nodes[0]):
                 reverse_nodes = trans_nodes
             else:
-                log.debug("not found reverse op, unexpected")
+                logger.debug("not found reverse op, unexpected")
                 return None
 
             are_all_reverse = all([is_reverse_op(r_op) for r_op in reverse_nodes])
             if are_all_reverse:
                 return reverse_nodes
 
-            log.debug("bw y output is used followed by reverse node")
+            logger.debug("bw y output is used followed by reverse node")
             return None
 
-        log.debug("unexpected number of transpose after LSTM 1st output:%s", s_cnt)
+        logger.debug("unexpected number of transpose after LSTM 1st output:%s", s_cnt)
         return None
 
-    log.debug("unexpected number of squeeze following LSTM 1st output:%s", s_cnt)
+    logger.debug("unexpected number of squeeze following LSTM 1st output:%s", s_cnt)
     return None

--- a/tf2onnx/rewriter/cond_rewriter.py
+++ b/tf2onnx/rewriter/cond_rewriter.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from enum import Enum
 from tf2onnx import utils
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.cond_rewriter_base")
 
 

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -7,18 +7,20 @@ tf2onnx.rewriter.custom_rnn_rewriter - custom rnn support
 
 from __future__ import division
 from __future__ import print_function
+
 import logging
 import sys
 import traceback
+
 from onnx import onnx_pb
 import numpy as np
+
 from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase, Context
 from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT, get_rnn_scope_name, parse_rnn_loop
-from tf2onnx.tfonnx import utils
-
-
+from tf2onnx import utils
 
 logger = logging.getLogger(__name__)
+
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
 
@@ -159,7 +161,6 @@ class CustomRnnRewriter(LoopRewriterBase):
                     self.g.replace_all_inputs(self.g.get_nodes(), out_tensor_value_info.id, scan_node.output[index])
             index += 1
 
-
     def _adapt_scan_sequence_input_or_output(self, target_name, input_id, handle_output=False):
         nodes_to_add = []
         shape_node = self.g.make_node("Shape", [input_id])
@@ -198,7 +199,7 @@ class CustomRnnRewriter(LoopRewriterBase):
             else:
                 # add a fake batch size : 1
                 fake_batch_size_node = self.g.make_const(utils.make_name(target_name + "_target_shape"),
-                                                         np.array([1,], dtype=np.int64))
+                                                         np.array([1], dtype=np.int64))
                 nodes_to_add.append(fake_batch_size_node)
                 new_shape_node = self.g.make_node("Concat",
                                                   [fake_batch_size_node.output[0], shape_node.output[0]],

--- a/tf2onnx/rewriter/custom_rnn_rewriter.py
+++ b/tf2onnx/rewriter/custom_rnn_rewriter.py
@@ -17,7 +17,7 @@ from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT, get_rnn_scope_name, pars
 from tf2onnx.tfonnx import utils
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.custom_rnn_rewriter")
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -19,7 +19,7 @@ from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
 
-log = logging.getLogger("tf2onnx.rewriter.gru_rewriter")
+logger = logging.getLogger(__name__)
 
 
 class GRUUnitRewriter(UnitRnnRewriterBase):
@@ -36,9 +36,9 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
             cell_match = self._match_cell(context, cell_type)
             if cell_match:
                 self.gru_cell_type = cell_type
-                log.debug("parsing unit is %s", cell_type)
+                logger.debug("parsing unit is %s", cell_type)
                 return cell_match
-        log.debug("cannot parse unit")
+        logger.debug("cannot parse unit")
         return None
 
     def get_weight_and_bias(self, context):
@@ -49,10 +49,10 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
         hidden_kernel = get_weights_from_const_node(self.g, match.get_op("hidden_kernel"))
         hidden_bias = get_weights_from_const_node(self.g, match.get_op("hidden_bias"))
         if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
-            log.debug("rnn weights check failed, skip")
+            logger.debug("rnn weights check failed, skip")
             return None
 
-        log.debug("find needed weights")
+        logger.debug("find needed weights")
         res = {"gate_kernel": gate_kernel,
                "gate_bias": gate_bias,
                "hidden_kernel": hidden_kernel,
@@ -91,13 +91,13 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
         other_state_variables_num = len(context.loop_properties.state_variables) - \
             len(context.state_variables)
         if other_state_variables_num > 2:
-            log.debug("found %d other state variables", other_state_variables_num)
+            logger.debug("found %d other state variables", other_state_variables_num)
             return False
 
         # output should be no more than 1
         outputs = context.loop_properties.scan_outputs_exits
         if len(outputs) > 1:
-            log.debug("found %d outputs for gru: %s", len(outputs), outputs)
+            logger.debug("found %d outputs for gru: %s", len(outputs), outputs)
             return False
         return True
 
@@ -200,7 +200,7 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
         # in onnx, output shape is: [number_directions, batch, hidden]
         exit_output_id = context.state_variables["state"].exit_output.id
         if not exit_output_id:
-            log.debug("no one consume state variable")
+            logger.debug("no one consume state variable")
             return
         output_id = context.rnn_node.output[1]
         gru_state_shape = self.g.get_shape(output_id)

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -18,7 +18,7 @@ from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.gru_rewriter")
 
 

--- a/tf2onnx/rewriter/loop_rewriter.py
+++ b/tf2onnx/rewriter/loop_rewriter.py
@@ -7,16 +7,17 @@ tf2onnx.rewriter.loop_rewriter - generic loop support
 
 from __future__ import division
 from __future__ import print_function
+
 import logging
 import sys
 import traceback
+
 from onnx import TensorProto
 import numpy as np
+
 from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase, Context
 from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT
-from tf2onnx.tfonnx import utils
-
-
+from tf2onnx import utils
 
 logger = logging.getLogger(__name__)
 

--- a/tf2onnx/rewriter/loop_rewriter.py
+++ b/tf2onnx/rewriter/loop_rewriter.py
@@ -17,7 +17,7 @@ from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT
 from tf2onnx.tfonnx import utils
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.loop_rewriter")
 
 

--- a/tf2onnx/rewriter/loop_rewriter.py
+++ b/tf2onnx/rewriter/loop_rewriter.py
@@ -18,7 +18,7 @@ from tf2onnx.tfonnx import utils
 
 
 
-log = logging.getLogger("tf2onnx.rewriter.loop_rewriter")
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
@@ -30,14 +30,14 @@ class LoopRewriter(LoopRewriterBase):
         return Context()
 
     def run(self):
-        log.debug("enter loop rewriter")
+        logger.debug("enter loop rewriter")
         return self.run_internal()
 
     def need_rewrite(self, context):
         return True
 
     def rewrite(self, context):
-        log.debug("enter rewrite function")
+        logger.debug("enter rewrite function")
         loop_node = None
         try:
             loop_props = context.loop_properties
@@ -89,16 +89,16 @@ class LoopRewriter(LoopRewriterBase):
             ## create Loop node
             loop_node = self._create_loop_node(context, loop_props)
             if not loop_node:
-                log.error("failed to create loop node during rewrite")
+                logger.error("failed to create loop node during rewrite")
                 return REWRITER_RESULT.FAIL
             loop_node.set_body_graph_as_attr("body", loop_body_g)
 
-            log.debug("rewrite successfully")
+            logger.debug("rewrite successfully")
             return REWRITER_RESULT.OK
 
         except Exception as ex:
             tb = traceback.format_exc()
-            log.error("loop rewrite failed, due to exception: %s, details:%s", ex, tb)
+            logger.error("loop rewrite failed, due to exception: %s, details:%s", ex, tb)
             return REWRITER_RESULT.FAIL
 
     def _create_loop_node(self, context, loop_props):

--- a/tf2onnx/rewriter/loop_rewriter_base.py
+++ b/tf2onnx/rewriter/loop_rewriter_base.py
@@ -17,7 +17,7 @@ from tf2onnx.rewriter.rnn_utils import is_tensor_array_gather_op, is_tensor_arra
 from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT
 from tf2onnx.utils import TensorValueInfo
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.loop_rewriter_base")
 INVALID_INPUT_ID = utils.make_name("invalid_input_id")
 

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -19,7 +19,7 @@ from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.lstm_rewriter")
 
 

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -20,7 +20,7 @@ from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
 
-log = logging.getLogger("tf2onnx.rewriter.lstm_rewriter")
+logger = logging.getLogger(__name__)
 
 
 class LSTMUnitRewriter(UnitRnnRewriterBase):
@@ -43,9 +43,9 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
             cell_match = self._match_cell(context, cell_type)
             if cell_match:
                 self.lstm_cell_type = cell_type
-                log.debug("parsing unit is %s", cell_type)
+                logger.debug("parsing unit is %s", cell_type)
                 return cell_match
-        log.debug("cannot parse unit")
+        logger.debug("cannot parse unit")
         return None
 
     def get_weight_and_bias(self, context):
@@ -61,13 +61,13 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
         w_node = cell_match.get_op("cell_kernel")
         w = get_weights_from_const_node(self.g, w_node)
         if not w:
-            log.warning("Cannot find weight, SKIP")
+            logger.warning("Cannot find weight, SKIP")
             return None
 
         b_node = cell_match.get_op("cell_bias")
         b = get_weights_from_const_node(self.g, b_node)
         if not b or b.value.shape[0] != w.value.shape[1]:
-            log.warning("cell_kernel and cell_bias's dimension doesn't match, SKIP")
+            logger.warning("cell_kernel and cell_bias's dimension doesn't match, SKIP")
             return None
 
         lstm_block_cell = cell_match.get_op("lstm_block_cell")
@@ -95,13 +95,13 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
         # for bias_add data format
         bias_add = match.get_op("bias_add")
         if bias_add.data_format != "NHWC":
-            log.debug("BiasAdd data_format is not NHWC, SKIP")
+            logger.debug("BiasAdd data_format is not NHWC, SKIP")
             return None
 
         b_e = match.get_op("cell_bias")
         b = get_weights_from_const_node(self.g, b_e)
         if not b or b.value.shape[0] != w.value.shape[1]:
-            log.warning("cell_kernel and cell_bias's dimensions does not match, skip")
+            logger.warning("cell_kernel and cell_bias's dimensions does not match, skip")
             return None
 
         ft_bias_node = match.get_op("ft_bias")
@@ -171,7 +171,7 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
         ct_concat = [c for c in self.g.find_output_consumers(ct) if is_concat_op(c)]
         ht_concat = [c for c in self.g.find_output_consumers(ht) if is_concat_op(c)]
         if len(ct_concat) != 1 or len(ht_concat) != 1 or ct_concat[0] != ht_concat[0]:
-            log.debug("failed to find ct-ht concat")
+            logger.debug("failed to find ct-ht concat")
             return None
         ct_ht_shared_output = ct_concat[0].output[0]
 
@@ -181,7 +181,7 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
         ct_slice = [c for c in ct_identity_consumer.inputs if is_slice_op(c)]
         ht_slice = [c for c in ht_identity_consumer.inputs if is_slice_op(c)]
         if len(ct_slice) != 1 or len(ht_slice) != 1:
-            log.debug("failed to find slice op before identity consumers")
+            logger.debug("failed to find slice op before identity consumers")
             return None
         consumers.extend([ct_slice[0], ht_slice[0]])
 
@@ -200,7 +200,7 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
         # output is no more than 1
         outputs = context.loop_properties.scan_outputs_exits
         if len(outputs) > 1:
-            log.debug("found %d outputs for lstm: %s", len(outputs), outputs)
+            logger.debug("found %d outputs for lstm: %s", len(outputs), outputs)
             return False
         return True
 

--- a/tf2onnx/rewriter/rnn.py
+++ b/tf2onnx/rewriter/rnn.py
@@ -20,7 +20,7 @@ from tf2onnx.rewriter.gru_rewriter import GRUUnitRewriter
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.rnn")
 
 

--- a/tf2onnx/rewriter/rnn.py
+++ b/tf2onnx/rewriter/rnn.py
@@ -21,7 +21,7 @@ from tf2onnx.rewriter.gru_rewriter import GRUUnitRewriter
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
 
-log = logging.getLogger("tf2onnx.rewriter.rnn")
+logger = logging.getLogger(__name__)
 
 
 def rewrite_single_direction_lstm(g, ops):

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -17,7 +17,7 @@ from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher # pylint: disable=
 
 
 
-log = logging.getLogger("tf2onnx.rewriter.rnn_utils")
+logger = logging.getLogger(__name__)
 
 
 class REWRITER_RESULT(Enum):
@@ -235,12 +235,12 @@ def parse_rnn_loop(graph, loop_properties, rnn_scope, while_context_scope):
             iteration_var = val
 
     if not found_time or is_rnn_out_ta is False:
-        log.debug("this should not be a dynamic_rnn loop, found_time: %s, is_rnn_out_ta: %s",
-                  found_time, is_rnn_out_ta)
+        logger.debug("this should not be a dynamic_rnn loop, found_time: %s, is_rnn_out_ta: %s",
+                     found_time, is_rnn_out_ta)
         return None
 
     if not loop_properties.tensor_array_inputs:
-        log.debug("this should not be a dynamic_rnn loop, no ta input is found")
+        logger.debug("this should not be a dynamic_rnn loop, no ta input is found")
         return None
 
     return time_var, iteration_var
@@ -257,9 +257,9 @@ def get_weights_from_const_node(g, node):
     if temp and temp.type == 'Const':
         val = temp.get_tensor_value(as_list=False)
         dtype = utils.map_onnx_to_numpy_type(g.get_dtype(temp.output[0]))
-        log.debug("found weights %s", temp.name)
+        logger.debug("found weights %s", temp.name)
     else:
-        log.debug("weight node seems not to be Const, skip, node name is %s", temp.name)
+        logger.debug("weight node seems not to be Const, skip, node name is %s", temp.name)
         return None
 
     return RnnWeight(node, val, dtype)

--- a/tf2onnx/rewriter/rnn_utils.py
+++ b/tf2onnx/rewriter/rnn_utils.py
@@ -16,7 +16,7 @@ from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher # pylint: disable=
 # pylint: disable=invalid-name,unused-argument,missing-docstring
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.rnn_utils")
 
 

--- a/tf2onnx/rewriter/unit_rnn_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rnn_rewriter_base.py
@@ -16,7 +16,7 @@ from tf2onnx.rewriter.rnn_utils import REWRITER_RESULT, get_pattern, \
 from tf2onnx.graph_matcher import GraphMatcher
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.rewriter.unit_rnn_rewriter_base")
 
 

--- a/tf2onnx/rewriter/unit_rnn_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rnn_rewriter_base.py
@@ -17,7 +17,7 @@ from tf2onnx.graph_matcher import GraphMatcher
 
 
 
-log = logging.getLogger("tf2onnx.rewriter.unit_rnn_rewriter_base")
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
@@ -58,7 +58,7 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         return UnitRnnContext()
 
     def run(self):
-        log.debug("enter unit rnn rewriter base")
+        logger.debug("enter unit rnn rewriter base")
         return self.run_internal()
 
     def need_rewrite(self, context):
@@ -66,15 +66,15 @@ class UnitRnnRewriterBase(LoopRewriterBase):
 
         if not parse_rnn_loop(self.g, context.loop_properties, context.rnn_scope,
                               context.while_context_scope):
-            log.debug("parse_rnn_loop failed, SKIP")
+            logger.debug("parse_rnn_loop failed, SKIP")
             return False
 
         if not self.parse_unit_rnn(context):
-            log.debug("failed to parse unit rnn, SKIP")
+            logger.debug("failed to parse unit rnn, SKIP")
             return False
 
         if not self.is_valid(context):
-            log.debug("parsed rnn is not valid, SKIP")
+            logger.debug("parsed rnn is not valid, SKIP")
             return False
         return True
 
@@ -90,41 +90,41 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         4 input_x
         5 attributes, e.g., activation_alpha, activation_beta... optional
         """
-        log.debug("parse unit rnn")
+        logger.debug("parse unit rnn")
 
-        log.debug("match unit cell against loop body graph")
+        logger.debug("match unit cell against loop body graph")
         cell_match = self.find_cell(context)
         if not cell_match:
-            log.debug('failed to match cell pattern')
+            logger.debug('failed to match cell pattern')
             return False
         context.cell_match = cell_match
 
-        log.debug("get_weight_and_bias starts")
+        logger.debug("get_weight_and_bias starts")
         weights = self.get_weight_and_bias(context)
         if not weights:
-            log.debug("rnn weights check failed, SKIP")
+            logger.debug("rnn weights check failed, SKIP")
             return False
         context.weights = weights
 
         if not self.get_state_variables(context):
-            log.debug("no cell variable initializers found, SKIP")
+            logger.debug("no cell variable initializers found, SKIP")
             return False
 
         seq_len_node = self.find_sequence_length_node(context)
         if seq_len_node:
-            log.debug("find sequence node: %s", seq_len_node.name)
+            logger.debug("find sequence node: %s", seq_len_node.name)
             context.seq_len_node = seq_len_node
 
         # require exact one input
         inputs = context.loop_properties.scan_inputs_initial_values
         if len(inputs) != 1:
-            log.debug("found %d inputs for the unit rnn: %s",
-                      len(inputs), inputs)
+            logger.debug("found %d inputs for the unit rnn: %s",
+                         len(inputs), inputs)
             return False
         context.onnx_input_ids["X"] = inputs[0]
 
         if not self.parse_attributes(context):
-            log.debug("wrong attributes found")
+            logger.debug("wrong attributes found")
             return False
 
         return True
@@ -160,25 +160,25 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         return True
 
     def rewrite(self, context):
-        log.debug("enter unit rnn rewrite function")
+        logger.debug("enter unit rnn rewrite function")
 
-        log.debug("process the weights/bias/ft_bias, to fit onnx weights/bias requirements")
+        logger.debug("process the weights/bias/ft_bias, to fit onnx weights/bias requirements")
         self.process_weights_and_bias(context)
 
         self.process_seq_length(context)
 
         self.process_var_init_nodes(context)
 
-        log.debug("start to build new rnn node")
+        logger.debug("start to build new rnn node")
 
         rnn_node = self.create_rnn_node(context)
         context.rnn_node = rnn_node
 
-        log.debug("start to handle outputs")
+        logger.debug("start to handle outputs")
         # format of ONNX output is different with tf
         self.process_outputs(context)
 
-        log.debug("rewrite successfully")
+        logger.debug("rewrite successfully")
         return REWRITER_RESULT.OK
 
     def get_state_variables(self, context):
@@ -194,10 +194,10 @@ class UnitRnnRewriterBase(LoopRewriterBase):
                 finder = funcs[0]
                 state_variable = finder(context)
                 if state_variable:
-                    log.debug("found state variable %s", var_name)
+                    logger.debug("found state variable %s", var_name)
                     context.state_variables[var_name] = state_variable
                 else:
-                    log.debug("failed to get state variable %s", var_name)
+                    logger.debug("failed to get state variable %s", var_name)
                     can_handle = False
                     break
             if can_handle:
@@ -210,7 +210,7 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         state_variable = list(context.state_variables.values())[0]
         next_iter_input_node = self.g.get_node_by_output(state_variable.next_iteration_input.id)
         if not is_select_op(next_iter_input_node):
-            log.debug("no sequence length node is given")
+            logger.debug("no sequence length node is given")
             return None
         matcher = GraphMatcher(seq_len_pattern)
         match_result = matcher.match_op(next_iter_input_node)
@@ -265,18 +265,18 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         for var_name, funcs in self.state_variable_handler.items():
             output_connector = funcs[1]
             output_connector(context)
-            log.debug("connect output of %s to graph", var_name)
+            logger.debug("connect output of %s to graph", var_name)
 
         self.connect_unit_rnn_output_to_graph(context)
 
     def connect_unit_rnn_output_to_graph(self, context):
         outputs = context.loop_properties.scan_outputs_exits
         if not outputs:
-            log.debug("no one consume output")
+            logger.debug("no one consume output")
             return
 
         gather_output_id = outputs[0].id
-        log.debug("found output for rnn: %s", gather_output_id)
+        logger.debug("found output for rnn: %s", gather_output_id)
 
         # in tf batch major mode, output shape is : [batch, time, hidden]
         # in time major mode, output shape is: [time, batch, hidden]
@@ -313,7 +313,7 @@ class UnitRnnRewriterBase(LoopRewriterBase):
             next_iteration_input = select[0].output[0]
             switch_true_identity_consumers.append(select[0])
 
-        log.debug(
+        logger.debug(
             "try to find state variable from [%s, %s]",
             next_iteration_input,
             switch_true_identity_consumers
@@ -329,6 +329,6 @@ class UnitRnnRewriterBase(LoopRewriterBase):
 
         state_variables = context.loop_properties.get_variables(checker)
         if len(state_variables) != 1:
-            log.debug("found %d state variables", len(state_variables))
+            logger.debug("found %d state variables", len(state_variables))
             return None
         return state_variables[0]

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -16,7 +16,7 @@ from tf2onnx import utils
 
 
 
-log = logging.getLogger("tf2onnx.shape_inference")
+logger = logging.getLogger(__name__)
 
 direct_ops = [
     "Cast",
@@ -81,7 +81,7 @@ def infer_shape_for_node(g, node):
             no_shape.append(i)
 
     if not are_all_input_shape_ready:
-        log.debug("node %s has inputs don't have shape specified, they are: %s", node.name, no_shape)
+        logger.debug("node %s has inputs don't have shape specified, they are: %s", node.name, no_shape)
         return False
 
     if node.type in direct_ops:
@@ -105,7 +105,7 @@ def infer_shape_for_node(g, node):
 
         if new_shape is not None:
             g.set_shape(node.output[0], new_shape)
-            log.debug("set placeholder node [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set placeholder node [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -141,7 +141,7 @@ def infer_shape_for_node(g, node):
             new_shape += s1[axis + 1:]
 
         g.set_shape(node.output[0], new_shape)
-        log.debug("set ConcatV2 node [%s] with new shape %s", node.output[0], new_shape)
+        logger.debug("set ConcatV2 node [%s] with new shape %s", node.output[0], new_shape)
         return True
 
     if node.type == "Gather":
@@ -175,7 +175,7 @@ def infer_shape_for_node(g, node):
                 new_shape.append(shape[i])
 
         g.set_shape(node.output[0], new_shape)
-        log.debug("set %s node [%s] with new shape %s", node.type, node.output[0], new_shape)
+        logger.debug("set %s node [%s] with new shape %s", node.type, node.output[0], new_shape)
         return True
 
     if node.type == "ExpandDims":
@@ -191,7 +191,7 @@ def infer_shape_for_node(g, node):
 
         new_shape = input_shape[:dim] + [1] + input_shape[dim:]
         g.set_shape(node.output[0], new_shape)
-        log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+        logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
         return True
 
     return False
@@ -207,7 +207,7 @@ def infer_input_shapes(g, node):
             if new_shape is not None:
                 g.set_shape(node.input[1], new_shape)
                 g.set_shape(node.input[2], new_shape)
-                log.debug("set [%s, %s] with new shape %s", node.input[1], node.input[2], new_shape)
+                logger.debug("set [%s, %s] with new shape %s", node.input[1], node.input[2], new_shape)
                 return True
     return False
 
@@ -224,7 +224,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
             g.set_shape(node.input[0], new_shape)
             g.set_shape(node.input[1], new_shape)
             g.set_shape(node.output[0], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -233,8 +233,8 @@ def infer_output_shapes_with_partial_inputs(g, node):
         if new_shape is not None:
             g.set_shape(node.output[0], new_shape)
             g.set_shape(node.output[1], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[1], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[1], new_shape)
             return True
         return False
 
@@ -246,7 +246,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
             g.set_shape(node.output[0], new_shape)
             g.set_shape(node.input[1], new_shape)
             g.set_shape(node.input[2], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -265,10 +265,10 @@ def infer_output_shapes_with_partial_inputs(g, node):
         for i in node.input:
             if not g.get_shape(i):
                 g.set_shape(i, input_shape)
-                log.debug("set [%s] with new shape %s", i, input_shape)
+                logger.debug("set [%s] with new shape %s", i, input_shape)
         new_shape = input_shape[:axis] + [len(node.input)] + input_shape[axis:]
         g.set_shape(node.output[0], new_shape)
-        log.debug("set Pack node [%s] with new shape %s", node.output[0], new_shape)
+        logger.debug("set Pack node [%s] with new shape %s", node.output[0], new_shape)
         return True
 
     if node.type == "TensorArrayGatherV3":
@@ -293,7 +293,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
         if shape is not None:
             new_shape = [-1] + shape
             g.set_shape(node.output[0], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -314,7 +314,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
         new_shape = value_shape_before_scatter[1:]
         if new_shape is not None:
             g.set_shape(node.output[0], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -325,7 +325,7 @@ def infer_output_shapes_with_partial_inputs(g, node):
             new_shape = g.get_shape(node.input[1])
         if new_shape is not None:
             g.set_shape(node.output[0], new_shape)
-            log.debug("set [%s] with new shape %s", node.output[0], new_shape)
+            logger.debug("set [%s] with new shape %s", node.output[0], new_shape)
             return True
         return False
 
@@ -336,7 +336,7 @@ def set_shape_from_input(g, input_id, output_id):
     new_shape = g.get_shape(input_id)
     if new_shape is not None:
         g.set_shape(output_id, new_shape)
-        log.debug("set [%s] with new shape %s", output_id, new_shape)
+        logger.debug("set [%s] with new shape %s", output_id, new_shape)
         return True
     return False
 
@@ -347,7 +347,7 @@ def set_shape_from_inputs_broadcast(g, input_ids, output_id):
     new_shape = broadcast_shape_inference(s1, s2)
     if new_shape is not None:
         g.set_shape(output_id, new_shape)
-        log.debug("set [%s] with new shape %s", output_id, new_shape)
+        logger.debug("set [%s] with new shape %s", output_id, new_shape)
         return True
     return False
 
@@ -386,7 +386,7 @@ def broadcast_shape_inference(shape_0, shape_1):
         elif shape_1[i] == -1:
             new_shape[i] = shape_0[i]
         else:
-            log.warning("two shapes not possible to broadcast, %s, %s", shape_0, shape_1)
+            logger.warning("two shapes not possible to broadcast, %s, %s", shape_0, shape_1)
             return None
         i -= 1
     return new_shape

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -15,7 +15,7 @@ from tf2onnx import utils
 # pylint: disable=logging-not-lazy,missing-docstring,consider-swap-variables
 
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx.shape_inference")
 
 direct_ops = [

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -30,7 +30,7 @@ from tf2onnx.rewriter import *  # pylint: disable=wildcard-import
 from tf2onnx.shape_inference import infer_shape_for_graph
 from tf2onnx.utils import port_name
 
-logging.basicConfig(level=logging.INFO)
+
 log = logging.getLogger("tf2onnx")
 
 

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -21,8 +21,8 @@ from tensorflow.python.framework import graph_util
 from tensorflow.tools.graph_transforms import TransformGraph
 
 import tf2onnx
-import tf2onnx.onnx_opset # pylint: disable=unused-import
-import tf2onnx.custom_opsets # pylint: disable=unused-import
+import tf2onnx.onnx_opset  # pylint: disable=unused-import
+import tf2onnx.custom_opsets  # pylint: disable=unused-import
 from tf2onnx import constants, schemas, utils, handler
 from tf2onnx.graph import Graph
 from tf2onnx.graph_matcher import OpTypePattern, GraphMatcher
@@ -30,8 +30,7 @@ from tf2onnx.rewriter import *  # pylint: disable=wildcard-import
 from tf2onnx.shape_inference import infer_shape_for_graph
 from tf2onnx.utils import port_name
 
-
-log = logging.getLogger("tf2onnx")
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=useless-return,broad-except,logging-not-lazy,unused-argument,missing-docstring
@@ -115,7 +114,7 @@ def tflist_to_onnx(node_list, shape_override):
                 onnx_node = helper.make_node(node.type, input_names, output_names, name=node.name, **attr)
                 onnx_nodes.append(onnx_node)
             except Exception as ex:
-                log.error("pass1 convert failed for %s, ex=%s", node, ex)
+                logger.error("pass1 convert failed for %s, ex=%s", node, ex)
                 raise
 
     return onnx_nodes, op_cnt, attr_cnt, output_shapes, dtypes
@@ -349,9 +348,9 @@ def rewrite_constant_fold(g, ops):
                         break
                     inputs.append(node.get_tensor_value(as_list=False))
 
-                log.debug("op name %s, %s, %s", op.name, len(op.input), len(inputs))
+                logger.debug("op name %s, %s, %s", op.name, len(op.input), len(inputs))
                 if inputs and len(op.input) == len(inputs):
-                    log.info("folding node type=%s, name=%s" % (op.type, op.name))
+                    logger.info("folding node type=%s, name=%s" % (op.type, op.name))
                     if op.type == "Cast":
                         dst = op.get_attr_int("to")
                         np_type = tf2onnx.utils.map_onnx_to_numpy_type(dst)
@@ -380,11 +379,11 @@ def rewrite_constant_fold(g, ops):
                     new_output_name = new_node_name
                     old_output_name = op.output[0]
                     old_node_name = op.name
-                    log.debug("create const node [%s] replacing [%s]", new_node_name, old_node_name)
+                    logger.debug("create const node [%s] replacing [%s]", new_node_name, old_node_name)
                     ops[idx] = g.make_const(new_node_name, val)
                     ref_cnt_per_node[new_node_name] = ref_cnt_per_node[old_node_name]
 
-                    log.debug("replace old output [%s] with new output [%s]", old_output_name, new_output_name)
+                    logger.debug("replace old output [%s] with new output [%s]", old_output_name, new_output_name)
                     # need to re-write the consumers input name to use the const name
                     consumers = g.find_output_consumers(old_output_name)
                     if consumers:
@@ -400,7 +399,7 @@ def rewrite_constant_fold(g, ops):
                     keep_looking = True
             except Exception as ex:
                 tb = traceback.format_exc()  # pylint: disable=bare-except
-                log.info("exception: %s, details: %s", ex, tb)
+                logger.info("exception: %s, details: %s", ex, tb)
                 # ignore errors
 
         # pylint: enable=too-many-nested-blocks
@@ -432,12 +431,12 @@ def rewrite_incomplete_type_support(g, ops, impacted_ops):
                 input_name = op.input[i]
                 dtype = g.get_dtype(input_name)
                 if dtype is None:
-                    log.warning("adding Cast for op %s (type is %s)' input: %s, dtype should not be None",
-                                op.name, op.type, input_name)
+                    logger.warning("adding Cast for op %s (type is %s)' input: %s, dtype should not be None",
+                                   op.name, op.type, input_name)
 
                 if dtype != onnx_pb.TensorProto.FLOAT:
                     output_dtype = dtype
-                    log.debug("insert cast for node %s on input %s", op.name, input_name)
+                    logger.debug("insert cast for node %s on input %s", op.name, input_name)
                     if input_node and input_node.type == "Cast" \
                             and len(g.find_output_consumers(input_node.output[0])) == 1:
                         input_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
@@ -452,8 +451,8 @@ def rewrite_incomplete_type_support(g, ops, impacted_ops):
                 # insert reverse cast if needed
                 for output_name in op.output:
                     name = utils.make_name(op.name)
-                    log.debug("insert cast back for node %s on output %s [dtype=%s]", op.name, output_name,
-                              output_dtype)
+                    logger.debug("insert cast back for node %s on output %s [dtype=%s]", op.name, output_name,
+                                 output_dtype)
                     output_cast = g.insert_new_node_on_output("Cast", output_name, name=name)
                     output_cast.set_attr("to", output_dtype)
                     g.set_dtype(output_cast.output[0], output_dtype)
@@ -511,7 +510,7 @@ def rewrite_conv2d_with_pad(g, ops):
         if conv.get_attr("padding") == "SAME":
             continue
 
-        log.debug("merge pad [%s] into conv [%s]", pad.name, conv.name)
+        logger.debug("merge pad [%s] into conv [%s]", pad.name, conv.name)
         paddings_val = np.array(paddings.get_tensor_value())
         # can't pad on batch or channel dimensions
         if np.any(paddings_val[0]) or np.any(paddings_val[3]):
@@ -537,7 +536,7 @@ def tensorflow_onnx_mapping(g, continue_on_error, ops_mapping):
     ops = [n for n in g.get_nodes()]
     for node in ops:
         if node.need_skip():
-            log.debug("explicitly skip node " + node.name)
+            logger.debug("explicitly skip node " + node.name)
             continue
 
         op = node.type
@@ -559,7 +558,7 @@ def tensorflow_onnx_mapping(g, continue_on_error, ops_mapping):
             body_graphs = node.get_body_graphs()
             if body_graphs:
                 for attr, b_g in body_graphs.items():
-                    log.debug("start handling subgraph of %s's attribute %s", node.name, attr)
+                    logger.debug("start handling subgraph of %s's attribute %s", node.name, attr)
                     b_g.topological_sort(b_g.get_nodes())
                     # we assume only ONNX nodes have subgraph defined in pre-rewriters.
                     # that means, if we create node having subgraphs in this step, the
@@ -567,16 +566,16 @@ def tensorflow_onnx_mapping(g, continue_on_error, ops_mapping):
                     m_ops, unm_ops = tensorflow_onnx_mapping(b_g, continue_on_error, ops_mapping)
                     mapped_op += m_ops
                     unmapped_op += unm_ops
-                    log.debug("finish handling subgraph of %s's attribute %s", node.name, attr)
+                    logger.debug("finish handling subgraph of %s's attribute %s", node.name, attr)
 
             func(g, node, **kwargs)
             node.skip_conversion = True
         except Exception as ex:
             type_, value_, traceback_ = sys.exc_info()
-            log.error("node %s: exception %s" % (node.name, ex))
+            logger.error("node %s: exception %s" % (node.name, ex))
             ex_ext = traceback.format_exception(type_, value_, traceback_)
             if continue_on_error:
-                log.info(ex_ext)
+                logger.info(ex_ext)
             else:
                 raise ex
 
@@ -591,7 +590,7 @@ def transpose_inputs(ctx, inputs_as_nchw):
             if output_name in inputs_as_nchw:
                 shape = ctx.get_shape(output_name)
                 if len(shape) != len(constants.NCHW_TO_NHWC):
-                    log.warning("transpose_input for %s: shape must be rank 4, ignored" % output_name)
+                    logger.warning("transpose_input for %s: shape must be rank 4, ignored" % output_name)
                     ops.append(node)
                     continue
                 # insert transpose
@@ -649,10 +648,10 @@ def run_rewriters(g, funcs, continue_on_error):
             g.reset_nodes(ops)
         except Exception as ex:
             type_, value_, traceback_ = sys.exc_info()
-            log.error("rewriter %s: exception %s", func, ex)
+            logger.error("rewriter %s: exception %s", func, ex)
             ex_ext = traceback.format_exception(type_, value_, traceback_)
             if continue_on_error:
-                log.info(ex_ext)
+                logger.info(ex_ext)
             else:
                 raise ex
 
@@ -689,9 +688,9 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
         tf2onnx.__version__, tf2onnx.version.git_version[:6]))
 
     if opset > schemas.get_max_supported_opset_version():
-        log.warning("currently installed onnx package %s is too low to support opset %s, "
-                    "please upgrade onnx package to avoid potential conversion issue.",
-                    utils.get_onnx_version(), opset)
+        logger.warning("currently installed onnx package %s is too low to support opset %s, "
+                       "please upgrade onnx package to avoid potential conversion issue.",
+                       utils.get_onnx_version(), opset)
 
     if shape_override is None:
         shape_override = {}
@@ -712,9 +711,9 @@ def process_tf_graph(tf_graph, continue_on_error=False, verbose=False, target=No
         # check output existence in case user passed in wrong output ids
         non_exists = set(io_to_check) - set(output_shapes.keys())
         if non_exists:
-            log.error("\nFailed to convert: inputs/outputs specified do not exist, make sure your passed"
-                      "in format: input/output_node_name:port_id. Problematical inputs/outputs are: %s \n",
-                      non_exists)
+            logger.error("\nFailed to convert: inputs/outputs specified do not exist, make sure your passed"
+                         "in format: input/output_node_name:port_id. Problematical inputs/outputs are: %s \n",
+                         non_exists)
             raise ValueError("Inputs/Outputs Not Found")
 
     g = Graph(onnx_nodes, output_shapes, dtypes, target, opset, extra_opset, output_names)

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -437,3 +437,21 @@ def is_onnx_domain(domain):
     if domain is None or domain == "":
         return True
     return False
+
+
+def parse_bool(val):
+    if val is None:
+        return False
+    return val.lower() in ("yes", "true", "t", "y", "1")
+
+
+_is_debug_mode = parse_bool(os.environ.get(constants.ENV_TF2ONNX_DEBUG_MODE))
+
+
+def is_debug_mode():
+    return _is_debug_mode
+
+
+def set_debug_mode(enabled):
+    global _is_debug_mode
+    _is_debug_mode = enabled

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from contextlib import contextmanager
 import os
 import re
 import shutil
@@ -437,3 +438,15 @@ def is_onnx_domain(domain):
     if domain is None or domain == "":
         return True
     return False
+
+
+@contextmanager
+def set_log_level(logger, level):
+    """ Override current logger level within context. """
+    current_level = logger.getEffectiveLevel()
+    logger.setLevel(level)
+
+    try:
+        yield logger
+    finally:
+        logger.setLevel(current_level)

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -9,7 +9,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from contextlib import contextmanager
 import os
 import re
 import shutil
@@ -438,15 +437,3 @@ def is_onnx_domain(domain):
     if domain is None or domain == "":
         return True
     return False
-
-
-@contextmanager
-def set_log_level(logger, level):
-    """ Override current logger level within context. """
-    current_level = logger.getEffectiveLevel()
-    logger.setLevel(level)
-
-    try:
-        yield logger
-    finally:
-        logger.setLevel(current_level)

--- a/tools/onnx-experiments.py
+++ b/tools/onnx-experiments.py
@@ -24,7 +24,7 @@ import tf2onnx.utils
 from tf2onnx.graph import GraphUtil
 
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("onnx-experiments")
+logger = logging.getLogger("onnx-experiments")
 
 
 def get_args():
@@ -75,10 +75,10 @@ def rewrite_constant_fold(g, ops):
             if inputs and len(op.input) == len(inputs):
                 func = func_map.get(op.type)
                 if func is None:
-                    log.info("can fold but don't know how, type=%s, name=%s", op.type, op.name)
+                    logger.info("can fold but don't know how, type=%s, name=%s", op.type, op.name)
                     continue
                 try:
-                    log.info("folding node type=%s, name=%s", op.type, op.name)
+                    logger.info("folding node type=%s, name=%s", op.type, op.name)
                     if op.type == "Cast":
                         dst = op.get_attr_int("to")
                         np_type = tf2onnx.utils.map_onnx_to_numpy_type(dst)
@@ -92,7 +92,7 @@ def rewrite_constant_fold(g, ops):
                     elif op.type == "Slice":
                         axis = op.get_attr_int("axis")
                         if axis != 0:
-                            log.info("can fold slice with axis!=0, type=%s, name=%s", op.type, op.name)
+                            logger.info("can fold slice with axis!=0, type=%s, name=%s", op.type, op.name)
                             continue
                         starts = op.get_attr_int("starts")
                         ends = op.get_attr_int("ends")
@@ -107,7 +107,7 @@ def rewrite_constant_fold(g, ops):
                     new_output_name = new_node_name
                     old_output_name = op.output[0]
                     old_node_name = op.name
-                    log.debug("create const node [%s] replacing [%s]", new_node_name, old_node_name)
+                    logger.debug("create const node [%s] replacing [%s]", new_node_name, old_node_name)
                     ops[idx] = g.make_const(new_node_name, val)
                     consumers = g.find_output_consumers(old_output_name)
                     if consumers:
@@ -119,7 +119,7 @@ def rewrite_constant_fold(g, ops):
                     keep_looking = True
                 except Exception as ex:  # pylint: disable=broad-except
                     tb = traceback.format_exc()
-                    log.info("exception: %s, details: %s", ex, tb)
+                    logger.info("exception: %s, details: %s", ex, tb)
                     # pylint: enable=too-many-nested-blocks
     return ops
 
@@ -140,7 +140,7 @@ def main():
     try:
         g.topological_sort(ops)
     except Exception as ex:  # pylint: disable=broad-except,unused-variable
-        log.error("graph has cycles, ignored ...")
+        logger.error("graph has cycles, ignored ...")
 
     model_proto = g.make_model(producer_name)
 

--- a/tools/quantitize_weights.py
+++ b/tools/quantitize_weights.py
@@ -15,7 +15,7 @@ from onnx import ModelProto, helper, onnx_pb, numpy_helper
 
 
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("quantitize_weights")
+logger = logging.getLogger("quantitize_weights")
 
 
 def _get_args():
@@ -99,7 +99,7 @@ def quantitize_graph(g, verbose=False):
         remove.append(i)
         name = w.name
         if verbose:
-            log.info("quantitizing %s", name)
+            logger.info("quantitizing %s", name)
         w_quant, zp, scale = eight_bit_quantitize(w_np)
         nw = numpy_helper.from_array(w_quant, name=name)
         if verbose:
@@ -109,9 +109,9 @@ def quantitize_graph(g, verbose=False):
             for j in [1.0, 5.0, 10.0, 20.0]:
                 above_rtol = np.sum(rtol > np.abs(j * w_np / 100.)) / w_np.size
                 s["> " + str(j) + "%"] = "{:.2f}".format(100. * above_rtol)
-            log.info("above_rtol: %s", str(s))
-            log.info("raw:   %s", stats(w_np))
-            log.info("quant: %s", stats(w_dequant))
+            logger.info("above_rtol: %s", str(s))
+            logger.info("raw:   %s", stats(w_np))
+            logger.info("quant: %s", stats(w_dequant))
         output_name = _compose_quantitize(nodes, new_weights, zp, scale, name)
         remap[name] = output_name
         quantitized_weights.append(nw)


### PR DESCRIPTION
this PR is for logging infrastructure, refine logging message will be in future PRs.

- unify logging level setup

for converter from command line, default level is INFO. 
for test, default level is WARNING.
user can pass argument ```--verbose``` to override logging level. ```-v``` is VERBOSE, ```-vv``` is DEBUG.

for invocation via script, respect caller's logging level
user can call ```tf2onnx.logging.set_level``` to set log level for tf2onnx explicitly.



- debug mode

introduce debug mode formally.
converter may do extra work under debug mode. e.g. dump intermediate tf/onnx graph, print shape information. 
to avoid pass a debug flag argument down to a deep function call chains, use global flag instead.


