### PR TITLE
fix bug in leaky_relu for tf_version <= 1.5

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -14,7 +14,7 @@ from parameterized import parameterized
 from tf2onnx import constants, logging, utils
 
 __all__ = ["TestConfig", "get_test_config", "unittest_main", "check_onnxruntime_backend",
-           "check_tf_min_version", "skip_tf_versions", "check_onnxruntime_min_version",
+           "check_tf_min_version", "check_tf_max_version", "skip_tf_versions", "check_onnxruntime_min_version",
            "check_opset_min_version", "check_target", "skip_caffe2_backend", "skip_onnxruntime_backend",
            "skip_opset", "check_onnxruntime_incompatibility", "validate_const_node",
            "group_nodes_by_type", "test_ms_domain", "check_node_domain"]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -800,9 +800,9 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @skip_caffe2_backend("fails on caffe2 with dim issue")
     @check_onnxruntime_incompatibility("Mul")
     @check_tf_min_version("1.6")
-    def test_leaky_relu(self):
+    def test_leaky_relu_int(self):
         # starting from tf 1.6, leaky_relu supports `feature` x of int type
-        x_types = [np.float32, np.int32, np.int64]
+        x_types = [np.int32, np.int64]
         for x_type in x_types:
             x_val = 1000 * np.random.random_sample([1000, 100]).astype(x_type)
             for alpha in [0.1, -0.1, 1.0, -1.0]:
@@ -814,9 +814,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @skip_caffe2_backend("fails on caffe2 with dim issue")
     @check_onnxruntime_incompatibility("Mul")
-    @check_tf_max_version("1.5")
-    def test_leaky_relu_old(self):
-        # for tf_version <= 1.5, leaky_relu requires `feature` x to be of type `float32`
+    def test_leaky_relu_float(self):
         x_val = 1000 * np.random.random_sample([1000, 100]).astype(np.float32)
         for alpha in [0.1, -0.1, 1.0, -1.0]:
             x = tf.placeholder(x_val.dtype, [None] * x_val.ndim, name=_TFINPUT)


### PR DESCRIPTION
When running UnitTest for tf 1.5, ValueError was raised in `test_leaky_relu` for `x` of int type. The following lines are missing in `leaky_relu` for old tf versions (1.4, 1.5) compared with tf_version >= 1.6

```python
    if features.dtype.is_integer:
      features = math_ops.to_float(features)
```

Therefore, another test case `test_leaky_relu_old` is added for tf_version <= 1.5, while the original test case `test_leaky_relu` now requires tf_version >= 1.6.