### PR TITLE
update CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For pytorch/caffe2, follow the instructions here:
 We tested with pytorch/caffe2 and onnxruntime and unit tests are passing for those.
 
 ## Supported Tensorflow and Python Versions
-We tested with tensorflow 1.5-1.12 and anaconda **3.5,3.6**.
+We tested with tensorflow 1.5-1.13 and anaconda **3.5,3.6**.
 
 # Installation
 ## From pypi

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -5,7 +5,7 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    tf_versions: ['1.12']
+    tf_versions: ['1.13.1']
     onnx_opsets: ['9']
     onnx_backends:
       onnxruntime: ['']

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -1,15 +1,11 @@
 # Test against latest onnxruntime nightly package
 
-# TODO: change onnxruntime package name when nightly package is ready
-
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     tf_versions: ['1.13.1']
-    onnx_opsets: ['9']
     onnx_backends:
       onnxruntime: ['']
     job:
-      displayName: 'unit_test'
       steps:
       - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -9,3 +9,5 @@ jobs:
     job:
       steps:
       - template: 'unit_test.yml'
+      parameters:
+          onnx_opsets: ['10', '9', '8', '7']

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -6,8 +6,6 @@ jobs:
     platforms: ['linux', 'windows', 'mac']
     tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
     onnx_opsets: ['9', '8', '7']
-    onnx_backends:
-      onnxruntime: ['0.3.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -4,6 +4,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows', 'mac']
+    python_versions: ['3.6', '3.5']
     tf_versions: ['1.13.1', '1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
     onnx_opsets: ['9', '8', '7']
     job:

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -4,7 +4,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows', 'mac']
-    tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+    tf_versions: ['1.13.1', '1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
     onnx_opsets: ['9', '8', '7']
     job:
       steps:

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -5,8 +5,6 @@ jobs:
   parameters:
     tf_versions: ['1.12']
     onnx_opsets: ['9', '8', '7']
-    onnx_backends:
-      onnxruntime: ['0.3.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -3,7 +3,7 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    tf_versions: ['1.12']
+    tf_versions: ['1.13.1']
     onnx_opsets: ['9', '8', '7']
     job:
       steps:

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -3,6 +3,16 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
+    python_versions: ['3.6', '3.5']
+    tf_versions: ['1.13.1']
+    onnx_opsets: ['9', '8', '7']
+    job:
+      steps:
+      - template: 'pretrained_model_test.yml'
+
+- template: 'templates/job_generator.yml'
+  parameters:
+    platforms: ['windows', 'mac']
     tf_versions: ['1.13.1']
     onnx_opsets: ['9', '8', '7']
     job:

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -6,7 +6,7 @@ parameters:
   tf_versions: ['']
   onnx_versions: ['']
   onnx_opsets: ['']
-  onnx_backends: {onnxruntime: ['']}
+  onnx_backends: {onnxruntime: ['0.3.0']}
   job: {}
   run_setup: 'True'
 
@@ -27,31 +27,55 @@ jobs:
         ${{ each python_version in parameters.python_versions }}:
           ${{ each tf_version in parameters.tf_versions }}:
             ${{ each onnx_version in parameters.onnx_versions }}:
-              ${{ each onnx_opset in parameters.onnx_opsets }}:
-                ${{ each onnx_backend in parameters.onnx_backends }}:
-                  ${{ each onnx_backend_version in onnx_backend.value }}:
-                    ${{ format('{0} python{1} tf{2} onnx{3} opset{4} {5}{6}', platform, python_version, tf_version, onnx_version, onnx_opset, onnx_backend.key, onnx_backend_version) }}:
-                      CI_PYTHON_VERSION: '${{ python_version }}'
-                      CI_TF_VERSION: '${{ tf_version }}'
-                      CI_ONNX_VERSION: '${{ onnx_version }}'
-                      CI_ONNX_OPSET: '${{ onnx_opset }}'
-                      CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
-                      CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
+              ${{ each onnx_backend in parameters.onnx_backends }}:
+                ${{ each onnx_backend_version in onnx_backend.value }}:
+                  ${{ each onnx_opset in parameters.onnx_opsets }}:
+                    ${{ if ne(onnx_opset, '') }}:
+                      ${{ format('{0} python{1} tf{2} onnx{3} opset{4} {5}{6}', platform, python_version, tf_version, onnx_version, onnx_opset, onnx_backend.key, onnx_backend_version) }}:
+                        CI_PYTHON_VERSION: '${{ python_version }}'
+                        CI_TF_VERSION: '${{ tf_version }}'
+                        CI_ONNX_VERSION: '${{ onnx_version }}'
+                        CI_ONNX_OPSET: '${{ onnx_opset }}'
+                        CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
+                        CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
 
-                      ${{ if eq(tf_version, '') }}:
-                        CI_PIP_TF_NAME: 'tensorflow'
-                      ${{ if ne(tf_version, '') }}:
-                        CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
+                        ${{ if eq(tf_version, '') }}:
+                          CI_PIP_TF_NAME: 'tensorflow'
+                        ${{ if ne(tf_version, '') }}:
+                          CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
 
-                      ${{ if eq(onnx_version, '') }}:
-                        CI_PIP_ONNX_NAME: 'onnx'
-                      ${{ if ne(onnx_version, '') }}:
-                        CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
+                        ${{ if eq(onnx_version, '') }}:
+                          CI_PIP_ONNX_NAME: 'onnx'
+                        ${{ if ne(onnx_version, '') }}:
+                          CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
 
-                      ${{ if eq(onnx_backend_version, '') }}:
-                        CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
-                      ${{ if ne(onnx_backend_version, '') }}:
-                        CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
+                        ${{ if eq(onnx_backend_version, '') }}:
+                          CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
+                        ${{ if ne(onnx_backend_version, '') }}:
+                          CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
+
+                    ${{ if eq(onnx_opset, '') }}:
+                      ${{ format('{0} python{1} tf{2} onnx{3} {4}{5}', platform, python_version, tf_version, onnx_version, onnx_backend.key, onnx_backend_version) }}:
+                        CI_PYTHON_VERSION: '${{ python_version }}'
+                        CI_TF_VERSION: '${{ tf_version }}'
+                        CI_ONNX_VERSION: '${{ onnx_version }}'
+                        CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
+                        CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
+
+                        ${{ if eq(tf_version, '') }}:
+                          CI_PIP_TF_NAME: 'tensorflow'
+                        ${{ if ne(tf_version, '') }}:
+                          CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
+
+                        ${{ if eq(onnx_version, '') }}:
+                          CI_PIP_ONNX_NAME: 'onnx'
+                        ${{ if ne(onnx_version, '') }}:
+                          CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
+
+                        ${{ if eq(onnx_backend_version, '') }}:
+                          CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
+                        ${{ if ne(onnx_backend_version, '') }}:
+                          CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
 
     # Insert all properties other than pool/steps/strategy
     ${{ each pair in parameters.job }}:

--- a/ci_build/azure_pipelines/templates/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/templates/pretrained_model_test.yml
@@ -5,7 +5,7 @@ steps:
     set -x
     status=0
     # TODO: fix unity model path
-    # python tests/run_pretrained_models.py --backend $(CI_ONNX_BACKEND) --opset $(CI_ONNX_OPSET) --config tests/unity.yaml || status=$?
-    python tests/run_pretrained_models.py --backend $(CI_ONNX_BACKEND) --opset $(CI_ONNX_OPSET) --config tests/run_pretrained_models.yaml || status=$?
+    # python tests/run_pretrained_models.py --backend $CI_ONNX_BACKEND --opset $CI_ONNX_OPSET --config tests/unity.yaml || status=$?
+    python tests/run_pretrained_models.py --backend $CI_ONNX_BACKEND --opset $CI_ONNX_OPSET --config tests/run_pretrained_models.yaml || status=$?
     exit $status
   displayName: 'Test Pre-trained Model'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -31,7 +31,7 @@ steps:
 - bash: |
     site_dir=$(python -c "import site; print(site.getsitepackages()[1])")
     echo "##vso[task.prependpath]$site_dir\numpy\.libs"
-  displayName: 'Fix numpy path'
+  displayName: 'Fix Numpy Path'
   condition: and(succeeded(), in(variables['Agent.OS'], 'Windows_NT'))
 
 - bash: env

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -13,10 +13,9 @@ steps:
         pip install $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME) numpy --no-deps -U
     fi
 
-    # HACK: before onnxruntime nightly package is ready, install onnxruntime from pypi test
-    if [[ $CI_ONNXRUNTIME_FROM_PYPI_TEST == "true" ]] ;
+    if [[ $CI_ONNXRUNTIME_NIGHTLY == "true" ]] ;
     then
-      pip install --index-url https://test.pypi.org/simple/ onnxruntime --force-reinstall
+      pip install --index-url https://test.pypi.org/simple/ ort-nightly --force-reinstall
     fi
 
     python setup.py install

--- a/ci_build/azure_pipelines/templates/unit_test.yml
+++ b/ci_build/azure_pipelines/templates/unit_test.yml
@@ -1,9 +1,16 @@
 # Run unit test
 
+parameters:
+    onnx_opsets: ['9', '8', '7']
+
 steps:
-- bash: |
-    export TF2ONNX_TEST_BACKEND=$(CI_ONNX_BACKEND)
-    export TF2ONNX_TEST_OPSET=$(CI_ONNX_OPSET)
-    python -m pytest --cov=tf2onnx --cov-report=term --disable-pytest-warnings -r s tests
-  timeoutInMinutes: 5
-  displayName: 'Run UnitTest'
+- ${{ each onnx_opset in parameters.onnx_opsets }}:
+  - bash: |
+      export TF2ONNX_TEST_BACKEND=$CI_ONNX_BACKEND
+      export TF2ONNX_TEST_OPSET=$CI_ONNX_OPSET
+      python -m pytest --cov=tf2onnx --cov-report=term --disable-pytest-warnings -r s tests
+    timeoutInMinutes: 5
+    displayName: ${{ format('Run UnitTest - Opset{0}', onnx_opset) }}
+    condition: succeededOrFailed()
+    env:
+        CI_ONNX_OPSET: '${{ onnx_opset }}'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -5,9 +5,6 @@ jobs:
   parameters:
     platforms: ['linux', 'windows', 'mac']
     tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
-    onnx_opsets: ['9', '8', '7']
-    onnx_backends:
-      onnxruntime: ['0.3.0']
     job:
       steps:
       - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -4,7 +4,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows', 'mac']
-    tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+    tf_versions: ['1.13.1', '1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
     job:
       steps:
       - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -4,6 +4,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows', 'mac']
+    python_versions: ['3.6', '3.5']
     tf_versions: ['1.13.1', '1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
     job:
       steps:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -3,7 +3,7 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    tf_versions: ['1.12']
+    tf_versions: ['1.13.1']
     job:
       steps:
       - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -3,6 +3,22 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
+    python_versions: ['3.6', '3.5']
+    tf_versions: ['1.13.1']
+    job:
+      steps:
+      - template: 'unit_test.yml'
+
+- template: 'templates/job_generator.yml'
+  parameters:
+    tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+    job:
+      steps:
+      - template: 'unit_test.yml'
+
+- template: 'templates/job_generator.yml'
+  parameters:
+    platforms: ['windows', 'mac']
     tf_versions: ['1.13.1']
     job:
       steps:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -4,9 +4,6 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     tf_versions: ['1.12']
-    onnx_opsets: ['9', '8', '7']
-    onnx_backends:
-      onnxruntime: ['0.3.0']
     job:
       steps:
       - template: 'unit_test.yml'


### PR DESCRIPTION
- adjust test matrix
currently, we only test linux + python 3.6 + latest tf for PR unit test, some tf version and/or os related issue can only be caught after merge.
so adjust unit_test.yml to cover: 
-- linux + python 3.5/3.6 + tf latest
-- linux + python 3.6 + all tf versions
--  linux/windows/mac + python 3.6 + tf latest
adjust pretrained_model_test.yml similarly.

- enable tf 1.13 in CI
- run unit test for multiple opsets in single job to reduce setup time.
- update onnxruntime nightly