### PR TITLE
support retry for url get

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class create_version(Command):
 
     def finalize_options(self):
         pass
-        
+
     def run(self):
         with open(os.path.join(SRC_DIR, 'version.py'), 'w') as f:
             f.write(dedent('''
@@ -74,11 +74,11 @@ setup(
     version=VersionInfo.version,
     description='Tensorflow to ONNX converter',
     setup_requires=['pytest-runner'],
-    tests_require=['graphviz', 'requests', 'parameterized', 'pytest', 'pytest-cov', 'pyyaml'],
+    tests_require=['graphviz', 'parameterized', 'pytest', 'pytest-cov', 'pyyaml'],
     cmdclass=cmdclass,
     packages=find_packages(),
     author='onnx@microsoft.com',
     author_email='onnx@microsoft.com',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'six']
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six']
 )

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -17,7 +17,6 @@ import zipfile
 
 import PIL.Image
 import numpy as np
-import requests
 import six
 import tensorflow as tf
 # contrib ops are registered only when the module is imported, the following import statement is needed,
@@ -119,11 +118,7 @@ class Test(object):
         os.makedirs(dir_name, exist_ok=True)
         fpath = os.path.join(dir_name, fname)
         if not os.path.exists(fpath):
-            response = requests.get(url)
-            if response.status_code not in [200]:
-                response.raise_for_status()
-            with open(fpath, "wb") as f:
-                f.write(response.content)
+            utils.get_url(url, fpath)
         model_path = os.path.join(dir_name, self.local)
         if not os.path.exists(model_path):
             if ftype == 'tgz':


### PR DESCRIPTION
saw several times that pre-trained model test failed to download model due to temporary network issue.
add retry to mitigate this issue.
