### PR TITLE
make topological sort in alphabetic order

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -87,10 +87,10 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] ' \
                    'n1 [op_type=Abs] n7 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] ' \
-                   'n4 [op_type=Add] n5 [op_type=Abs] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
-                   'n6 [op_type=Identity] input -> n1 n1:0 -> n7 n7:0 -> n2 n1:0 -> n3 ' \
-                   'n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 ' \
-                   'n5_raw_output___2:0 -> n6 }'
+                   'n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
+                   'n5_graph_outputs_Identity__3 [op_type=Identity] input -> n1 n1:0 -> n7 ' \
+                   'n7:0 -> n2 n1:0 -> n3 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n6 ' \
+                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
         self.assertEqual(expected, result)
 
     def test_insert_node2(self):
@@ -102,9 +102,9 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n7 [op_type=Abs] ' \
                    'n3 [op_type=Abs] n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
-                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 ' \
-                   'n4:0 -> n5 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 n5_raw_output___2:0 -> n6 }'
+                   'n6 [op_type=Identity] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
+                   'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 ' \
+                   'n5_raw_output___2:0 -> n6 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
         self.assertEqual(expected, result)
 
     def test_remove_input(self):
@@ -116,10 +116,10 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n3 [op_type=Abs] ' \
-                   'n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
-                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> n4 n4:0 -> n5 ' \
-                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 n5_raw_output___2:0 -> n6 }'
+                   'n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
+                   'n5_graph_outputs_Identity__3 [op_type=Identity] input -> n1 n1:0 -> n3 ' \
+                   'n1:0 -> n2 n2:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n6 ' \
+                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
         self.assertEqual(expected, result)
 
     def test_rewrite_subgraph(self):
@@ -145,10 +145,9 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         result = onnx_to_graphviz(g)
         expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] ' \
                    'n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__5 [op_type=Sub] ' \
-                   'n5_graph_outputs_Identity__3 [op_type=Identity] n6 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__5 ' \
-                   'n3:0 -> ReplacedOp__5 ReplacedOp__5:0 -> n5_graph_outputs_Identity__3 ' \
-                   'ReplacedOp__5:0 -> n6 }'
+                   'n6 [op_type=Identity] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
+                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__5 n3:0 -> ReplacedOp__5 ' \
+                   'ReplacedOp__5:0 -> n6 ReplacedOp__5:0 -> n5_graph_outputs_Identity__3 }'
         self.assertEqual(expected, result)
 
     def test_match_flipped(self):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -723,6 +723,8 @@ class Graph(object):
 
     def topological_sort(self, ops):
         """Topological sort of graph."""
+        # sort by name, the result will be reversed alphabeta
+        ops.sort(key=lambda op: op.name)
 
         def _push_stack(stack, node, in_stack):
             stack.append(node)
@@ -748,7 +750,7 @@ class Graph(object):
             all_input |= set(implicit_inputs)
             # remove those empty inputs
             all_input = list(filter(lambda a: a != '', all_input))
-            for inp in all_input:
+            for inp in sorted(all_input):
                 j = self.get_node_by_output(inp)
                 utils.make_sure(j is not None, "Cannot find node with output {}".format(inp))
                 if self.parent_graph and j.name not in op_name_to_index:


### PR DESCRIPTION
Arrange nodes in alphabetic order before performing topological sort so that the outputs are in reversed alphabetic order.

In new shape inference, we will save and import tensorflow graph several times, that may disorder the ops.