### PR TITLE
enhance pre-trained model test

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -55,15 +55,8 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
         results = prepared_backend.run(inputs)
         return results
 
-    def run_onnxmsrtnext(self, model_path, inputs, output_names):
-        """Run test against msrt-next backend."""
-        import lotus
-        m = lotus.InferenceSession(model_path)
-        results = m.run(output_names, inputs)
-        return results
-
     def run_onnxruntime(self, model_path, inputs, output_names):
-        """Run test against msrt-next backend."""
+        """Run test against onnxruntime backend."""
         import onnxruntime as rt
         m = rt.InferenceSession(model_path)
         results = m.run(output_names, inputs)
@@ -73,9 +66,7 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
         model_proto = g.make_model("test")
         model_path = self.save_onnx_model(model_proto, input_dict)
 
-        if self.config.backend == "onnxmsrtnext":
-            y = self.run_onnxmsrtnext(model_path, input_dict, outputs)
-        elif self.config.backend == "onnxruntime":
+        if self.config.backend == "onnxruntime":
             y = self.run_onnxruntime(model_path, input_dict, outputs)
         elif self.config.backend == "caffe2":
             y = self.run_onnxcaffe2(model_proto, input_dict)

--- a/tests/common.py
+++ b/tests/common.py
@@ -102,7 +102,7 @@ class TestConfig(object):
         if "pytest" not in sys.argv[0]:
             parser = argparse.ArgumentParser()
             parser.add_argument("--backend", default=config.backend,
-                                choices=["caffe2", "onnxmsrtnext", "onnxruntime"],
+                                choices=["caffe2", "onnxruntime"],
                                 help="backend to test against")
             parser.add_argument("--opset", type=int, default=config.opset, help="opset to test against")
             parser.add_argument("--target", default=",".join(config.target), choices=constants.POSSIBLE_TARGETS,

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -163,21 +163,8 @@ class Test(object):
             self.onnx_runtime = time.time() - start
         return results
 
-    def run_onnxmsrtnext(self, name, model_proto, inputs):
-        """Run test against msrt-next backend."""
-        import lotus
-        model_path = utils.save_onnx_model(TEMP_DIR, name, inputs, model_proto)
-        m = lotus.InferenceSession(model_path)
-        results = m.run(self.output_names, inputs)
-        if self.perf:
-            start = time.time()
-            for _ in range(PERFITER):
-                _ = m.run(self.output_names, inputs)
-            self.onnx_runtime = time.time() - start
-        return results
-
     def run_onnxruntime(self, name, model_proto, inputs):
-        """Run test against msrt-next backend."""
+        """Run test against onnxruntime backend."""
         import onnxruntime as rt
         model_path = utils.save_onnx_model(TEMP_DIR, name, inputs, model_proto, include_test_data=True)
         logger.info("Model saved to %s", model_path)
@@ -279,8 +266,6 @@ class Test(object):
             onnx_results = None
             if backend == "caffe2":
                 onnx_results = self.run_caffe2(name, model_proto, inputs)
-            elif backend == "onnxmsrtnext":
-                onnx_results = self.run_onnxmsrtnext(name, model_proto, inputs)
             elif backend == "onnxruntime":
                 onnx_results = self.run_onnxruntime(name, model_proto, inputs)
             else:
@@ -316,7 +301,7 @@ def get_args():
     parser.add_argument("--tests", help="tests to run")
     parser.add_argument("--target", default="", help="target platform")
     parser.add_argument("--backend", default="onnxruntime",
-                        choices=["caffe2", "onnxmsrtnext", "onnxruntime"], help="backend to use")
+                        choices=["caffe2", "onnxruntime"], help="backend to use")
     parser.add_argument("--opset", type=int, default=None, help="opset to use")
     parser.add_argument("--extra_opset", default=None,
                         help="extra opset with format like domain:version, e.g. com.microsoft:1")

--- a/tests/run_pretrained_models.yaml
+++ b/tests/run_pretrained_models.yaml
@@ -2,7 +2,7 @@
 # simple models for basic functional test
 #
 regression-graphdef:
-  model: tests/models/regression/graphdef/frozen.pb
+  model: models/regression/graphdef/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1]
@@ -10,7 +10,7 @@ regression-graphdef:
     - pred:0
 
 regression-checkpoint:
-  model: tests/models/regression/checkpoint/model.meta
+  model: models/regression/checkpoint/model.meta
   model_type: checkpoint
   input_get: get_ramp
   inputs:
@@ -19,7 +19,7 @@ regression-checkpoint:
     - pred:0
 
 regression-saved-model:
-  model: tests/models/regression/saved_model
+  model: models/regression/saved_model
   model_type: saved_model
   input_get: get_ramp
   inputs:
@@ -28,7 +28,7 @@ regression-saved-model:
     - pred:0
 
 saved_model_with_redundant_inputs:
-  model: tests/models/saved_model_with_redundant_inputs
+  model: models/saved_model_with_redundant_inputs
   model_type: saved_model
   input_get: get_ramp
   inputs:
@@ -38,7 +38,7 @@ saved_model_with_redundant_inputs:
     - Add:0
 
 graphdef_with_redundant_inputs:
-  model: tests/models/regression/graphdef/frozen.pb
+  model: models/regression/graphdef/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 10]
@@ -47,7 +47,7 @@ graphdef_with_redundant_inputs:
     - Add:0
 
 checkpoint_with_redundant_inputs:
-  model: tests/models/regression/checkpoint/model.meta
+  model: models/regression/checkpoint/model.meta
   model_type: checkpoint
   input_get: get_ramp
   inputs:
@@ -57,7 +57,7 @@ checkpoint_with_redundant_inputs:
     - pred:0
 
 benchtf-fc:
-  model: tests/models/fc-layers/frozen.pb
+  model: models/fc-layers/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]
@@ -65,7 +65,7 @@ benchtf-fc:
     - output:0
 
 benchtf-conv:
-  model: tests/models/conv-layers/frozen.pb
+  model: models/conv-layers/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]
@@ -74,7 +74,7 @@ benchtf-conv:
 
 benchtf-convbn:
   disabled: true # some if from training isn't removed
-  model: tests/models/convbn-layers/frozen.pb
+  model: models/convbn-layers/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]
@@ -82,7 +82,7 @@ benchtf-convbn:
     - output:0
 
 benchtf-ae0:
-  model: tests/models/ae0/frozen.pb
+  model: models/ae0/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]
@@ -91,7 +91,7 @@ benchtf-ae0:
 
 benchtf-lstm:
   disabled: true
-  model: tests/models/lstm/frozen.pb
+  model: models/lstm/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]
@@ -100,7 +100,7 @@ benchtf-lstm:
 
 benchtf-gru:
   disabled: true
-  model: tests/models/gru/frozen.pb
+  model: models/gru/frozen.pb
   input_get: get_ramp
   inputs:
     "X:0": [1, 784]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -512,7 +512,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
     def test_add_bcast(self):
         x1_val = np.array([1.0, 2.0, -3.0, -4.0], dtype=np.float32).reshape((2, 2))
         x2_val = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=np.float32).reshape((2, 2, 2))
-        # if we'd broadcast 2,2 to 2,1 onnxmsrt will fail
         x1 = tf.placeholder(tf.float32, x1_val.shape, name="input")
         x2 = tf.placeholder(tf.float32, x2_val.shape, name=_TFINPUT1)
         x_ = tf.add(x1, x2)
@@ -830,8 +829,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: x_val}, check_shape=True)
 
-    @unittest.skipIf(get_test_config().opset < 5 or get_test_config().backend in ["onnxmsrtnext"],
-                     "since opset 5, broken in msrtnext")
     @check_opset_min_version(6, "cast")
     def test_reshape_dynamic(self):
         x_val = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32).reshape((2, 2))
@@ -1025,7 +1022,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @skip_caffe2_backend()
     def test_slice1(self):
-        # FIXME: only 1 dimension supported by caffe2 and msrt
+        # FIXME: only 1 dimension supported by caffe2
         x_val = np.array([[[1, 1, 1], [2, 2, 2]], [[3, 3, 3], [4, 4, 4]], [[5, 5, 5], [6, 6, 6]]], dtype=np.float32)
         t1 = tf.constant([1, 0, 0], dtype=tf.int32)
         t2 = tf.constant([1, 1, 3], dtype=tf.int32)

--- a/tf2onnx/verbose_logging.py
+++ b/tf2onnx/verbose_logging.py
@@ -32,7 +32,7 @@ def getLogger(name=None):  # pylint: disable=invalid-name, function-redefined
     return logger
 
 
-_SIMPLE_LOG_FORMAT = "%(message)s"
+_BASIC_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 _VERBOSE_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s: %(message)s"
 
 
@@ -41,7 +41,7 @@ def basicConfig(**kwargs):  # pylint: disable=invalid-name, function-redefined
     # Choose pre-defined format if format argument is not specified
     if "format" not in kwargs:
         level = kwargs.get("level", _logging.root.level)
-        kwargs["format"] = _SIMPLE_LOG_FORMAT if level >= INFO else _VERBOSE_LOG_FORMAT
+        kwargs["format"] = _BASIC_LOG_FORMAT if level >= INFO else _VERBOSE_LOG_FORMAT
 
     _logging.basicConfig(**kwargs)
     set_tf_verbosity(_logging.getLogger().getEffectiveLevel())
@@ -67,8 +67,7 @@ def set_level(level):
 def set_tf_verbosity(level):
     """ Set TF logging verbosity."""
     # TF log is too verbose, adjust it
-    level = WARNING if level >= VERBOSE else level
-
+    level = ERROR if level >= INFO else level
     tf.logging.set_verbosity(level)
 
     # TF_CPP_MIN_LOG_LEVEL:


### PR DESCRIPTION
- make relative path in yaml relative to yaml config directory
it will be easier to share yaml and model files to others.

- support opset constraints
can skip test for certain condition, similar to unit test.

- refine input dtype check

- removed more_inputs option in yaml
seems not in use anymore

- removed onnxmsrtnext backend
i assume it is not needed anymore?
