### PR TITLE
enhance cond_rewriter by allowing different output shapes

### DIFF
--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -12,7 +12,7 @@ import numpy as np
 import tensorflow as tf
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main, check_opset_min_version
+from common import unittest_main, check_opset_min_version, check_tf_min_version
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
@@ -267,7 +267,8 @@ class CondTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port)
 
-    @check_opset_min_version(9, "")
+    @check_tf_min_version("1.8", "shape inference for Reshape op screws up")
+    @check_opset_min_version(9, "ConstantOfShape")
     def test_cond_with_different_output_shape(self):
         input_shape = (10, 5, 20)
         inputs = tf.placeholder(tf.float32, input_shape, name="input")
@@ -277,29 +278,29 @@ class CondTests(Tf2OnnxBackendTestBase):
         inputs = tf.reshape(inputs, shape)
 
         def pad_tensor(t, length):
-          """Pads the input tensor with 0s along the first dimension up to the length.
+            """Pads the input tensor with 0s along the first dimension up to the length.
 
-          Args:
-            t: the input tensor, assuming the rank is at least 1.
-            length: a tensor of shape [1]  or an integer, indicating the first dimension
-              of the input tensor t after padding, assuming length <= t.shape[0].
+            Args:
+              t: the input tensor, assuming the rank is at least 1.
+              length: a tensor of shape [1]  or an integer, indicating the first dimension
+                of the input tensor t after padding, assuming length <= t.shape[0].
 
-          Returns:
-            padded_t: the padded tensor, whose first dimension is length. If the length
-              is an integer, the first dimension of padded_t is set to length
-              statically.
-          """
-          t_rank = tf.rank(t)
-          t_shape = tf.shape(t)
-          t_d0 = t_shape[0]
-          pad_d0 = tf.expand_dims(length - t_d0, 0)
-          pad_shape = tf.cond(
-              # shape is [3], depending on input shape
-              tf.greater(t_rank, 1), lambda: tf.concat([pad_d0, t_shape[1:]], 0),
-              # shape is always [1]
-              lambda: tf.expand_dims(length - t_d0, 0))
-          padded_t = tf.concat([t, tf.zeros(pad_shape, dtype=t.dtype)], 0)
-          return padded_t
+            Returns:
+              padded_t: the padded tensor, whose first dimension is length. If the length
+                is an integer, the first dimension of padded_t is set to length
+                statically.
+            """
+            t_rank = tf.rank(t)
+            t_shape = tf.shape(t)
+            t_d0 = t_shape[0]
+            pad_d0 = tf.expand_dims(length - t_d0, 0)
+            pad_shape = tf.cond(
+                # shape is [3], depending on input shape
+                tf.greater(t_rank, 1), lambda: tf.concat([pad_d0, t_shape[1:]], 0),
+                # shape is always [1]
+                lambda: tf.expand_dims(length - t_d0, 0))
+            padded_t = tf.concat([t, tf.zeros(pad_shape, dtype=t.dtype)], 0)
+            return padded_t
 
         output = pad_tensor(inputs, 20)
         _ = tf.identity(output, name="output")

--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -12,7 +12,7 @@ import numpy as np
 import tensorflow as tf
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main
+from common import unittest_main, check_opset_min_version
 
 
 # pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
@@ -266,6 +266,51 @@ class CondTests(Tf2OnnxBackendTestBase):
         input_names_with_port = ["input_1:0", "input_2:0"]
         output_names_with_port = ["output:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port)
+
+    @check_opset_min_version(9, "")
+    def test_cond_with_different_output_shape(self):
+        input_shape = (10, 5, 20)
+        inputs = tf.placeholder(tf.float32, input_shape, name="input")
+
+        shape = tf.placeholder(tf.int32, (len(input_shape),), name="shape")
+        # cheat onnx shape inference
+        inputs = tf.reshape(inputs, shape)
+
+        def pad_tensor(t, length):
+          """Pads the input tensor with 0s along the first dimension up to the length.
+
+          Args:
+            t: the input tensor, assuming the rank is at least 1.
+            length: a tensor of shape [1]  or an integer, indicating the first dimension
+              of the input tensor t after padding, assuming length <= t.shape[0].
+
+          Returns:
+            padded_t: the padded tensor, whose first dimension is length. If the length
+              is an integer, the first dimension of padded_t is set to length
+              statically.
+          """
+          t_rank = tf.rank(t)
+          t_shape = tf.shape(t)
+          t_d0 = t_shape[0]
+          pad_d0 = tf.expand_dims(length - t_d0, 0)
+          pad_shape = tf.cond(
+              # shape is [3], depending on input shape
+              tf.greater(t_rank, 1), lambda: tf.concat([pad_d0, t_shape[1:]], 0),
+              # shape is always [1]
+              lambda: tf.expand_dims(length - t_d0, 0))
+          padded_t = tf.concat([t, tf.zeros(pad_shape, dtype=t.dtype)], 0)
+          return padded_t
+
+        output = pad_tensor(inputs, 20)
+        _ = tf.identity(output, name="output")
+        input_names_with_port = ["input:0", "shape:0"]
+        feed_dict = {
+            "input:0": np.ones(input_shape, dtype=np.float32),
+            "shape:0": np.array(input_shape, dtype=np.int32)
+        }
+
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
 
 if __name__ == '__main__':

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -42,7 +42,9 @@ class Fill:
         # T output = Fill(int32 dims, T value, @int32 index_type)
         # T outputs = Tile(T value, int64 repeats (e.g. dims))
         fill_shape = ctx.get_shape(node.input[0])
+        utils.make_sure(fill_shape is not None, "shape of {} is None".format(node.input[0]))
         fill_shape_dims = fill_shape[0]
+        utils.make_sure(fill_shape_dims > 0, "opset 7 requires fill shape length > 0, or please try opset > 7")
         val_dtype = ctx.get_dtype(node.input[1])
         val_shape = ctx.get_shape(node.input[1])
 

--- a/tf2onnx/rewriter/cond_rewriter.py
+++ b/tf2onnx/rewriter/cond_rewriter.py
@@ -107,7 +107,7 @@ class CondRewriter:
             false_output = cond_context.false_branch_context.output[i]
             true_shape = self.g.get_shape(true_output)
             utils.make_sure(true_shape is not None, "Shape of {} is None".format(true_output))
-            true_rank  = len(true_shape)
+            true_rank = len(true_shape)
             true_dtype = self.g.get_dtype(true_output)
             false_shape = self.g.get_shape(false_output)
             utils.make_sure(false_shape is not None, "Shape of {} is None".format(false_output))

--- a/tf2onnx/rewriter/cond_rewriter.py
+++ b/tf2onnx/rewriter/cond_rewriter.py
@@ -106,16 +106,21 @@ class CondRewriter:
             true_output = cond_context.true_branch_context.output[i]
             false_output = cond_context.false_branch_context.output[i]
             true_shape = self.g.get_shape(true_output)
+            utils.make_sure(true_shape is not None, "Shape of {} is None".format(true_output))
+            true_rank  = len(true_shape)
             true_dtype = self.g.get_dtype(true_output)
             false_shape = self.g.get_shape(false_output)
+            utils.make_sure(false_shape is not None, "Shape of {} is None".format(false_output))
+            false_rank = len(false_shape)
             false_dtype = self.g.get_dtype(false_output)
-            if not utils.are_shapes_compatible(true_shape, false_shape):
+            # just require rank is equal
+            if true_rank != false_rank:
                 raise RuntimeError(
-                    "the shape of outputs {} and {} mismatch: {}, {}".format(
+                    "the rank of outputs {} and {} mismatch: {}, {}".format(
                         true_output,
                         false_output,
-                        true_shape,
-                        false_shape
+                        true_rank,
+                        false_rank
                     )
                 )
             if true_dtype != false_dtype:
@@ -127,10 +132,7 @@ class CondRewriter:
                         false_dtype
                     )
                 )
-            # in tf, the shape of different branched can be different,
-            # for example output shape of branch A can be [-1] while branch B can be [1].
-            # Under this case, we should set output shape to be [-1]
-            output_shapes.append(utils.create_vague_shape_like(utils.merge_shapes(true_shape, false_shape)))
+            output_shapes.append(utils.create_vague_shape_like(true_shape))
             output_dtypes.append(true_dtype)
         return output_shapes, output_dtypes
 


### PR DESCRIPTION
In SSD-mobilenet, some tf.cond will return outputs of different shapes from the true and false branch.
Although current onnx spec requires the shape of If op should be the same, onnxruntime doesn't care about it.
To support this objection detection model, this PR loosen the shape requirement to rank requirement in cond_rewriter.
Will file an issue to onnx and discuss the incompatible shape issue further.