### PR TITLE
fix bug found in "bert"

### DIFF
--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -175,12 +175,10 @@ class Transpose:
             if perm.is_const():
                 # perms is passed as const
                 dims = perm.get_tensor_value()
+                ctx.remove_input(node, node.input[1])
+                node.set_attr("perm", dims)
             else:
-                # calculate perms from shape
-                shape = ctx.get_shape(node.input[1])
-                dims = [i for i in range(len(shape) - 1, -1)]
-            ctx.remove_input(node, node.input[1])
-            node.set_attr("perm", dims)
+                utils.make_sure(False, "perm can't be dynamic in ONNX")
         else:
             # graph rewrite moved perm to attribute
             pass

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 import logging
 
 import numpy as np
@@ -356,7 +357,7 @@ def make_gathernd(ctx, params, indices, output, scope_name, t_params, shapes, dt
     # reshape indices into [sum(indices[:-1]), indices[-1]]
     indices_shape = ctx.make_node("Shape", [indices], dtypes=[TensorProto.INT64])
     indices_size = ctx.make_node("Size", [indices])
-    attr = {"axes": [0], "ends": [utils.get_max_value(np.int64)], "starts": [-1]}
+    attr = {"axes": [0], "ends": [sys.maxsize], "starts": [-1]}
     inputs_map = {"data": indices_shape.output[0], **attr}
     inner_shape = GraphBuilder(ctx).make_slice(inputs_map, dtypes=[TensorProto.INT64])
     outter_shape = ctx.make_node("Div",
@@ -414,7 +415,7 @@ def make_gathernd(ctx, params, indices, output, scope_name, t_params, shapes, dt
                                       [inner_loop_shape.output[0], one_const.output[0]],
                                       attr={"axis": 0},
                                       dtypes=[TensorProto.INT64])
-    attr = {"axes": [0], "ends": [utils.get_max_value(np.int64)], "starts": [1]}
+    attr = {"axes": [0], "ends": [sys.maxsize], "starts": [1]}
     inputs_map = {"data": inner_loop_shape_.output[0], **attr}
     output_inner_shape = GraphBuilder(ctx).make_slice(inputs_map, dtypes=[TensorProto.INT64])
     attr = {"axes": [0], "ends": [-1], "starts": [0]}

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -60,7 +60,9 @@ class TransposeOptimizer(GraphOptimizerBase):
             target_t = reshape_op.inputs[0].get_tensor_value(as_list=False)
             target_shape = reshape_op.inputs[1].get_tensor_value(as_list=False)
             new_data = np.reshape(target_t, tuple(target_shape))
-            const_name = utils.port_name(utils.make_name("Const"))
+            const_name = reshape_op.output[0]
+            self._g.remove_node(reshape_op.name)
+            self._g.make_const(const_name, new_data)
 
             # point all children nodes inputs to the new node
             for output_name in reshape_op.output:
@@ -68,8 +70,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                     for i, name in enumerate(child.input):
                         if name == output_name:
                             child.input[i] = const_name
-            self._g.make_const(const_name, new_data)
-            self._g.remove_node(reshape_op.name)
+
             self._g.topological_sort(self._g.get_nodes())
 
     def post_optimize_action(self):


### PR DESCRIPTION
1 when perm is dynamic, we can't assume it's a reversed transpose

2 can't remove node directly if it's used by others

3 dtype of slice's input should be same