### PR TITLE
fix conv_convert_inputs bug

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -251,8 +251,8 @@ class Test(object):
                 # convert model to onnx
                 onnx_graph = self.to_onnx(sess.graph, opset=opset, extra_opset=extra_opset,
                                           shape_override=shape_override, input_names=inputs.keys())
+                onnx_graph = optimizer.optimize_graph(onnx_graph)
                 model_proto = onnx_graph.make_model("converted from tf2onnx")
-                model_proto = optimizer.optimize_graph(onnx_graph).make_model("optimized")
                 logger.info("To_ONNX, OK")
                 if onnx_file:
                     self.create_onnx_file(name, model_proto, inputs, onnx_file)

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -50,7 +50,7 @@ def optimize_graph(graph):
     diff = copy.deepcopy(after)
     diff.subtract(before)
     diff = ["{} {} ({}->{})".format(k, str(v) if v < 0 else '+' + str(v), before.get(k, 0), after.get(k, 0))
-            for k, v in diff.most_common() if v != 0]
+            for k, v in sorted(diff.items()) if v != 0]
     logger.info("After optimization: %s", ', '.join(diff) if diff else "no change")
 
     return graph

--- a/tf2onnx/optimizer/const_fold_optimizer.py
+++ b/tf2onnx/optimizer/const_fold_optimizer.py
@@ -69,7 +69,7 @@ class ConstFoldOptimizer(GraphOptimizerBase):
                 const_outputs = process_func(node, graph)
                 self._replace_node_with_const(node, graph, const_outputs)
                 return True
-        self.logger.debug("need to add function to fold op %s whose op_type is %s", node.name, node.type)
+            self.logger.debug("need to add function to fold op %s whose op_type is %s", node.name, node.type)
         return False
 
     @staticmethod

--- a/tf2onnx/optimizer/optimizer_base.py
+++ b/tf2onnx/optimizer/optimizer_base.py
@@ -63,5 +63,5 @@ class GraphOptimizerBase(object):
         diff = copy.deepcopy(after)
         diff.subtract(before)
         diff = ["{} {} ({}->{})".format(k, str(v) if v < 0 else '+' + str(v), before.get(k, 0), after.get(k, 0))
-                for k, v in diff.most_common() if v != 0]
+                for k, v in sorted(diff.items()) if v != 0]
         self.logger.verbose(', '.join(diff) if diff else "no change")

--- a/tf2onnx/shape_inference.py
+++ b/tf2onnx/shape_inference.py
@@ -24,7 +24,9 @@ logger = logging.getLogger(__name__)
 def infer_shape(tf_graph, shape_override):
     """Infer shape for TF graph with shape_override set first."""
     if shape_override:
+        logger.info("Apply shape override:")
         for name, shape in shape_override.items():
+            logger.info("\tSet %s shape to %s", name, shape)
             tf_graph.get_tensor_by_name(name).set_shape(shape)
         tf_graph = reload_tf_graph(tf_graph)
 


### PR DESCRIPTION
for this pattern:
![image](https://user-images.githubusercontent.com/32868157/57783688-2488f800-7761-11e9-9515-c7666310207e.png)


```rewrite_conv2d_with_pad``` calls ```conv_convert_inputs``` internally, while https://github.com/onnx/tensorflow-onnx/blob/e59757ba903c42fe0816b764bad22de33ae1e343/tf2onnx/onnx_opset/nn.py#L54-L73 L73 will set MaxPool data_format to NCHW, which prevents ```conv_convert_inputs``` to transpose input when dealing with MaxPool at mapping stage.

