### PR TITLE
support CudnnCompatibleGRUCell

### DIFF
--- a/tests/test_cudnn_compatible_gru.py
+++ b/tests/test_cudnn_compatible_gru.py
@@ -1,0 +1,481 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""Unit Tests for gru."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.contrib import cudnn_rnn
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import variable_scope
+from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main, check_gru_count
+
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
+
+
+# TODO: as a workaround, set batch_size to 1 for now to bypass a onnxruntime bug, revert it when the bug is fixed
+class CudnnCompatibleGRUTests(Tf2OnnxBackendTestBase):
+    def test_single_dynamic_gru(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(units)
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        input_names_with_port = ["input_1:0"]
+        feed_dict = {"input_1:0": x_val}
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_multiple_dynamic_gru(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        _ = tf.placeholder(tf.float32, x_val.shape, name="input_2")
+
+        gru_output_list = []
+        gru_cell_state_list = []
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(units)
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32)
+        gru_output_list.append(outputs)
+        gru_cell_state_list.append(cell_state)
+
+        # given scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(units)
+        with variable_scope.variable_scope("root1") as scope:
+            outputs, cell_state = tf.nn.dynamic_rnn(
+                cell,
+                x,
+                dtype=tf.float32,
+                sequence_length=[4],
+                scope=scope)
+        gru_output_list.append(outputs)
+        gru_cell_state_list.append(cell_state)
+
+        _ = tf.identity(gru_output_list, name="output")
+        _ = tf.identity(gru_cell_state_list, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 2))
+
+    def test_single_dynamic_gru_seq_length_is_const(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.], [5., 5.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32,
+            sequence_length=[5])
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_single_dynamic_gru_seq_length_is_not_const(self):
+        for np_dtype, tf_dtype in [[np.int32, tf.int32], [np.int64, tf.int64], [np.float32, tf.float32]]:
+            tf.reset_default_graph()
+            units = 5
+            batch_size = 1
+            x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.], [5., 5.]], dtype=np.float32)
+            x_val = np.stack([x_val] * batch_size)
+            x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+            initializer = init_ops.constant_initializer(0.5)
+
+            y_val = np.array([5], dtype=np_dtype)
+            seq_length = tf.placeholder(tf_dtype, y_val.shape, name="input_2")
+
+            # no scope
+            cell = cudnn_rnn.CudnnCompatibleGRUCell(
+                units,
+                kernel_initializer=initializer)
+            outputs, cell_state = tf.nn.dynamic_rnn(
+                cell,
+                x,
+                dtype=tf.float32,
+                sequence_length=tf.identity(seq_length))
+
+            _ = tf.identity(outputs, name="output")
+            _ = tf.identity(cell_state, name="cell_state")
+
+            feed_dict = {"input_1:0": x_val, "input_2:0": y_val}
+            input_names_with_port = ["input_1:0", "input_2:0"]
+            output_names_with_port = ["output:0", "cell_state:0"]
+            self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                               graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_single_dynamic_gru_placeholder_input(self):
+        units = 5
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]], dtype=np.float32)
+        x_val = np.stack([x_val] * 1)
+        x = tf.placeholder(tf.float32, shape=(None, 4, 2), name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32)  # by default zero initializer is used
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_single_dynamic_gru_ch_zero_state_initializer(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.], [5., 5.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+
+        # defining initial state
+        initial_state = cell.zero_state(batch_size, dtype=tf.float32)
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            initial_state=initial_state,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-03, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_single_dynamic_gru_random_weights(self):
+        hidden_size = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = tf.random_uniform_initializer(-1.0, 1.0)
+
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            hidden_size,
+            kernel_initializer=initializer)
+
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_single_dynamic_gru_random_weights2(self):
+        hidden_size = 128
+        batch_size = 1
+        x_val = np.random.randn(1, 133).astype('f')
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = tf.random_uniform_initializer(0.0, 1.0)
+        # no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            hidden_size,
+            kernel_initializer=initializer)
+
+        outputs, cell_state = tf.nn.dynamic_rnn(
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.01,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_gru_output_consumed_only(self):
+        units = 5
+        batch_size = 6
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = tf.random_uniform_initializer(-1.0, 1.0)
+        cell1 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+
+        outputs, _ = tf.nn.dynamic_rnn(
+            cell1,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, 0.0001,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_gru_state_consumed_only(self):
+        units = 5
+        batch_size = 6
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = tf.random_uniform_initializer(-1.0, 1.0)
+        cell1 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+
+        _, cell_state = tf.nn.dynamic_rnn(
+            cell1,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=0.0001, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bigru(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # bigru, no scope
+        cell1 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        cell2 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        outputs, cell_state = tf.nn.bidirectional_dynamic_rnn(
+            cell1,
+            cell2,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bigru_output_consumed_only(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # bigru, no scope
+        cell1 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        cell2 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        outputs, _ = tf.nn.bidirectional_dynamic_rnn(
+            cell1,
+            cell2,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bigru_state_consumed_only(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # bigru, no scope
+        cell1 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        cell2 = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        _, cell_state = tf.nn.bidirectional_dynamic_rnn(
+            cell1,
+            cell2,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bidirectional_but_one_gru(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+        initializer = init_ops.constant_initializer(0.5)
+
+        # bigru, no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units,
+            kernel_initializer=initializer)
+        outputs, cell_state = tf.nn.bidirectional_dynamic_rnn(
+            cell,
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bidirectional_but_one_gru_and_output_consumed_only(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+
+        # bigru, no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units)
+        outputs, _ = tf.nn.bidirectional_dynamic_rnn(
+            cell,
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(outputs, name="output")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["output:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+    def test_dynamic_bidirectional_but_one_gru_and_state_consumed_only(self):
+        units = 5
+        batch_size = 1
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        x = tf.placeholder(tf.float32, x_val.shape, name="input_1")
+
+        # bigru, no scope
+        cell = cudnn_rnn.CudnnCompatibleGRUCell(
+            units)
+        _, cell_state = tf.nn.bidirectional_dynamic_rnn(
+            cell,
+            cell,
+            x,
+            dtype=tf.float32)
+
+        _ = tf.identity(cell_state, name="cell_state")
+
+        feed_dict = {"input_1:0": x_val}
+        input_names_with_port = ["input_1:0"]
+        output_names_with_port = ["cell_state:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-3, atol=1e-06,
+                           graph_validator=lambda g: check_gru_count(g, 1))
+
+
+if __name__ == '__main__':
+    unittest_main()

--- a/tf2onnx/graph_matcher.py
+++ b/tf2onnx/graph_matcher.py
@@ -20,8 +20,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import copy
+import logging
 
 import six
+
+
+logger = logging.getLogger(__name__)
 
 
 class OpTypePattern(object):
@@ -157,6 +161,12 @@ class GraphMatcher(object):
 
         if pattern.op_type != '*':
             if op is None or op.type not in pattern.op_type.split('|'):
+                logger.debug(
+                    "mismatched type at %s: [%s, %s]",
+                    op.name if op else "None",
+                    pattern.op_type,
+                    op.type if op else "None"
+                )
                 return False
 
         self._match_result.add(pattern, op, tensor)
@@ -167,6 +177,12 @@ class GraphMatcher(object):
             return True
 
         if not op or len(op.inputs) != len(pattern.inputs):
+            logger.debug(
+                "mismatched input number at %s: [%s, %s]",
+                op.name if op else "None",
+                len(pattern.inputs),
+                len(op.inputs)
+            )
             return False
 
         if self._allow_reorder:
@@ -203,6 +219,7 @@ class GraphMatcher(object):
           Returns a `MatchResult` if `op` matches the pattern; otherwise, returns
           None.
         """
+        logger.debug("match %s against the pattern", op.name)
         self._match_result = MatchResult()
         if not self._match_pattern(self._pattern, op, tensor=None):
             return None

--- a/tf2onnx/rewriter/bigru_rewriter.py
+++ b/tf2onnx/rewriter/bigru_rewriter.py
@@ -68,10 +68,26 @@ def process_bigru(g, bi_grus):
             gru_inputs.extend([gru_fw.input[4], initializer_node.output[0]])
 
         direction = "bidirectional"
-        if gru_fw.get_attr("hidden_size").i == gru_bw.get_attr("hidden_size").i:
-            hidden_size = gru_fw.get_attr("hidden_size").i
-        else:
-            logger.error("fw and bw has different hidden_size, skip")
+        # FIXME: put forth the following checks, do the same in bi-lstm
+        attr = {}
+        attr_map = {
+            "clip": "f",
+            "hidden_size": "i",
+            "linear_before_reset": "i"
+        }
+        matched = True
+        for name, key in attr_map.items():
+            fw_attr = gru_fw.get_attr(name)
+            bw_attr = gru_bw.get_attr(name)
+            if not fw_attr and not bw_attr:
+                continue
+            if fw_attr and bw_attr and getattr(fw_attr, key) == getattr(bw_attr, key):
+                attr[name] = getattr(fw_attr, key)
+            else:
+                logger.error("fw and bw has different %s: %s, %s, skip", name, fw_attr, bw_attr)
+                matched = False
+                break
+        if not matched:
             continue
         # activation has to be took care
         # attr here is proto
@@ -79,8 +95,7 @@ def process_bigru(g, bi_grus):
                        for act in gru_fw.get_attr("activations").strings]
         activations += [act.decode("utf-8")
                         for act in gru_bw.get_attr("activations").strings]
-        attr = {"direction": direction, "hidden_size": hidden_size,
-                "activations": activations}
+        attr.update({"direction": direction, "activations": activations})
         bi_gru_node = g.make_node("GRU", gru_inputs, attr=attr, output_count=2)
         all_nodes.append(bi_gru_node)
         logger.debug("processing output nodes")

--- a/tf2onnx/rewriter/gru_rewriter.py
+++ b/tf2onnx/rewriter/gru_rewriter.py
@@ -30,8 +30,12 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
             {"state": (self._state_variable_finder, self._connect_gru_state_to_graph)}
         ]
 
+    def run(self):
+        logger.debug("enter gru rewriter")
+        return super(GRUUnitRewriter, self).run()
+
     def find_cell(self, context):
-        gru_cell_types = [RNNUnitType.GRUCell, RNNUnitType.GRUBlockCell]
+        gru_cell_types = [RNNUnitType.GRUCell, RNNUnitType.GRUBlockCell, RNNUnitType.CudnnCompatibleGRUCell]
         for cell_type in gru_cell_types:
             cell_match = self._match_cell(context, cell_type)
             if cell_match:
@@ -46,21 +50,58 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
 
         gate_kernel = get_weights_from_const_node(self.g, match.get_op("gate_kernel"))
         gate_bias = get_weights_from_const_node(self.g, match.get_op("gate_bias"))
-        hidden_kernel = get_weights_from_const_node(self.g, match.get_op("hidden_kernel"))
-        hidden_bias = get_weights_from_const_node(self.g, match.get_op("hidden_bias"))
-        if not all([gate_kernel, gate_bias, hidden_kernel, hidden_bias]):
+        res = {
+            "gate_kernel": gate_kernel,
+            "gate_bias": gate_bias
+        }
+
+        # differ on memory gate:
+        # GRUCell: h'_t = tanh(concat(x_t, r_t .* h_t-1) * W + b)
+        # CudnnCompatibleGRUCell: h'_t = tanh(x_t * W_x + b_x + r_t .* (h_t-1 * W_h + b_h))
+        if self.gru_cell_type == RNNUnitType.CudnnCompatibleGRUCell:
+            hidden_state_kernel = get_weights_from_const_node(
+                self.g, match.get_op("hidden_state_kernel")
+            )
+            hidden_state_bias = get_weights_from_const_node(
+                self.g, match.get_op("hidden_state_bias")
+            )
+            hidden_input_kernel = get_weights_from_const_node(
+                self.g, match.get_op("hidden_input_kernel")
+            )
+            hidden_input_bias = get_weights_from_const_node(
+                self.g, match.get_op("hidden_input_bias")
+            )
+            if not all(val is not None for val in [
+                    hidden_state_kernel, hidden_state_bias,
+                    hidden_input_kernel, hidden_input_bias
+            ]):
+                logger.debug("rnn weights check failed, skip")
+                return None
+            hidden_kernel = np.concatenate([hidden_input_kernel, hidden_state_kernel])
+            # apply the linear transformation before multiplying by the output of reset gate
+            context.attributes["linear_before_reset"] = 1
+            res["hidden_kernel"] = hidden_kernel
+            res["hidden_bias"] = hidden_input_bias
+            # recurrence bias for hidden gate
+            res["Rb_h"] = hidden_state_bias
+        elif self.gru_cell_type in [RNNUnitType.GRUCell, RNNUnitType.GRUBlockCell]:
+            hidden_kernel = get_weights_from_const_node(self.g, match.get_op("hidden_kernel"))
+            hidden_bias = get_weights_from_const_node(self.g, match.get_op("hidden_bias"))
+            res["hidden_kernel"] = hidden_kernel
+            res["hidden_bias"] = hidden_bias
+
+        if not all(val is not None for val in res.values()):
             logger.debug("rnn weights check failed, skip")
             return None
 
         logger.debug("find needed weights")
-        res = {"gate_kernel": gate_kernel,
-               "gate_bias": gate_bias,
-               "hidden_kernel": hidden_kernel,
-               "hidden_bias": hidden_bias}
         return res
 
     def _state_variable_finder(self, context):
-        if self.gru_cell_type == RNNUnitType.GRUCell:
+        if self.gru_cell_type in [
+                RNNUnitType.GRUCell,
+                RNNUnitType.CudnnCompatibleGRUCell
+        ]:
             gru_cell = context.cell_match
             return self._find_state_variable_with_select(
                 context,
@@ -108,17 +149,17 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
         weights = context.weights
         # from code of tensorflow GRU cell, it can be known that shape of hidden_kernel(or candidate_kernel)
         # is (input_size+hidden_unit, hidden_unit)
-        hidden_size = weights["hidden_kernel"].value.shape[1]
-        input_size = weights["hidden_kernel"].value.shape[0] - hidden_size
+        hidden_size = weights["hidden_kernel"].shape[1]
+        input_size = weights["hidden_kernel"].shape[0] - hidden_size
         weight_dtype = weights["hidden_kernel"].dtype
         bias_dtype = weights["hidden_bias"].dtype
         # below code will use same notation as ONNX document
         # z means update gate, r means reset gate, h means hidden gate;
         # at this time weights of gate include input and state, will split it next
-        r_kernel, z_kernel = np.split(weights["gate_kernel"].value, [hidden_size], axis=1)
-        h_kernel = weights["hidden_kernel"].value
-        r_bias, z_bias = np.split(weights["gate_bias"].value, [hidden_size], axis=0)
-        h_bias = weights["hidden_bias"].value
+        r_kernel, z_kernel = np.split(weights["gate_kernel"], [hidden_size], axis=1)
+        h_kernel = weights["hidden_kernel"]
+        r_bias, z_bias = np.split(weights["gate_bias"], [hidden_size], axis=0)
+        h_bias = weights["hidden_bias"]
         # ONNX GRU split weights of input and state, so have to split *_kernel
         input_r_kernel, state_r_kernel = np.split(r_kernel, [input_size], axis=0)
         input_z_kernel, state_z_kernel = np.split(z_kernel, [input_size], axis=0)
@@ -133,9 +174,11 @@ class GRUUnitRewriter(UnitRnnRewriterBase):
         assert W_zrh.shape == (1, 3*hidden_size, input_size)
         assert R_zrh.shape == (1, 3*hidden_size, hidden_size)
         Wb_zrh = np.concatenate((z_bias, r_bias, h_bias), axis=0)
-        # tf don't have bias for state, so use 0 instead
+        # if tf doesn't provide bias for state, use 0
         zero = np.zeros_like(z_bias)
-        Rb_zrh = np.concatenate((zero, zero, zero), axis=0)
+        # Rb_h is set in CudnnCompatibleGRUCell
+        Rb_h = weights["Rb_h"] if "Rb_h" in weights else zero
+        Rb_zrh = np.concatenate((zero, zero, Rb_h), axis=0)
         B_zrh = np.concatenate((Wb_zrh, Rb_zrh), axis=0)
         B_zrh = np.expand_dims(B_zrh, axis=0)
         B_zrh = B_zrh.astype(bias_dtype)

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -13,7 +13,7 @@ import logging
 import numpy as np
 from tf2onnx import utils
 from tf2onnx.graph_builder import GraphBuilder
-from tf2onnx.rewriter.rnn_utils import RNNUnitType, RnnWeight, get_weights_from_const_node
+from tf2onnx.rewriter.rnn_utils import RNNUnitType, get_weights_from_const_node
 from tf2onnx.utils import is_tf_concat_op, is_tf_slice_op
 
 from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase
@@ -38,6 +38,10 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
             }
         ]
 
+    def run(self):
+        logger.debug("enter lstm rewriter")
+        return super(LSTMUnitRewriter, self).run()
+
     def find_cell(self, context):
         lstm_cell_types = [RNNUnitType.LSTMCell, RNNUnitType.LSTMBlockCell]
         for cell_type in lstm_cell_types:
@@ -61,13 +65,13 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
 
         w_node = cell_match.get_op("cell_kernel")
         w = get_weights_from_const_node(self.g, w_node)
-        if not w:
+        if w is None:
             logger.warning("Cannot find weight, SKIP")
             return None
 
         b_node = cell_match.get_op("cell_bias")
         b = get_weights_from_const_node(self.g, b_node)
-        if not b or b.value.shape[0] != w.value.shape[1]:
+        if b is None or b.shape[0] != w.shape[1]:
             logger.warning("cell_kernel and cell_bias's dimension doesn't match, SKIP")
             return None
 
@@ -76,12 +80,11 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
             lstm_block_cell.get_attr("forget_bias").f,
             dtype=b.dtype
         )
-        ft_bias = RnnWeight(None, ft_bias_val, ft_bias_val.dtype)
 
         return {
             "weight": w,
             "bias": b,
-            "ft_bias": ft_bias
+            "ft_bias": ft_bias_val
         }
 
     def _get_weight_and_bias_for_lstm_cell(self, context):
@@ -89,7 +92,7 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
 
         w_e = match.get_op("cell_kernel")
         w = get_weights_from_const_node(self.g, w_e)
-        if not w:
+        if w is None:
             return None
 
         # check https://www.tensorflow.org/versions/r1.8/api_docs/cc/class/tensorflow/ops/bias-add
@@ -101,13 +104,13 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
 
         b_e = match.get_op("cell_bias")
         b = get_weights_from_const_node(self.g, b_e)
-        if not b or b.value.shape[0] != w.value.shape[1]:
+        if b is None or b.shape[0] != w.shape[1]:
             logger.warning("cell_kernel and cell_bias's dimensions does not match, skip")
             return None
 
         ft_bias_node = match.get_op("ft_bias")
         ft_bias = get_weights_from_const_node(self.g, ft_bias_node)
-        if not ft_bias:
+        if ft_bias is None:
             return None
 
         if not b.dtype == ft_bias.dtype:
@@ -207,11 +210,11 @@ class LSTMUnitRewriter(UnitRnnRewriterBase):
 
     def process_weights_and_bias(self, context):
         weights = context.weights
-        w_r_icfo = weights["weight"].value
+        w_r_icfo = weights["weight"]
         w_dtype = weights["weight"].dtype
-        b_r_icfo = weights["bias"].value
+        b_r_icfo = weights["bias"]
         b_dtype = weights["bias"].dtype
-        ft_bias_scalar = weights["ft_bias"].value
+        ft_bias_scalar = weights["ft_bias"]
 
         # split bias for each hidden unit
         # b_r_icfo: (4 * num_units,)

--- a/tf2onnx/rewriter/unit_rnn_rewriter_base.py
+++ b/tf2onnx/rewriter/unit_rnn_rewriter_base.py
@@ -59,7 +59,6 @@ class UnitRnnRewriterBase(LoopRewriterBase):
         return UnitRnnContext()
 
     def run(self):
-        logger.debug("enter unit rnn rewriter base")
         return self.run_internal()
 
     def need_rewrite(self, context):


### PR DESCRIPTION
CudnnCompatibleGRUCell only differs from GRUCell on memory gate `(h'_t = tanh(x_t * W_h + (r_t .* h_t-1) * R_h + b_{Wh})`, which can be covered by linear_before_reset attribute of GRU: https://github.com/onnx/onnx/blob/master/docs/Operators.md#GRU.