### PR TITLE
combine and report unittest results

### DIFF
--- a/ci_build/azure_pipelines/coveragerc
+++ b/ci_build/azure_pipelines/coveragerc
@@ -1,0 +1,3 @@
+[paths]
+source =
+  ./

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -12,3 +12,6 @@ jobs:
       - template: 'unit_test.yml'
         parameters:
             onnx_opsets: ['10', '9', '8', '7']
+    report_coverage: 'True'
+
+- template: 'templates/combine_test_coverage.yml'

--- a/ci_build/azure_pipelines/templates/combine_test_coverage.yml
+++ b/ci_build/azure_pipelines/templates/combine_test_coverage.yml
@@ -1,0 +1,48 @@
+# combine and report unittest coverage
+
+parameters:
+  artifact_name: 'single_test_coverage'
+
+stages:
+- stage:
+  jobs:
+  - job: 'combine_and_report_coverage'
+    variables:
+      CI_ARTIFACT_NAME: '${{ parameters.artifact_name }}'
+  
+    pool:
+      vmImage: 'ubuntu-16.04'
+  
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Single Test Coverage'
+      inputs:
+        artifactName: '${{ parameters.artifact_name }}'
+        downloadPath: $(System.DefaultWorkingDirectory)
+  
+    - task: CondaEnvironment@1
+      inputs:
+        createCustomEnvironment: 'true'
+        environmentName: 'tf2onnx'
+        packageSpecs: 'python=3.6'
+        updateConda: 'false'
+  
+    - bash: |
+        pip install -U coverage
+      condition: succeeded()
+      displayName: 'Install Coverage'
+  
+    - bash: |
+        cat ${CI_ARTIFACT_NAME}/.coveragerc_paths* >> ci_build/azure_pipelines/coveragerc
+        coverage combine --rcfile ci_build/azure_pipelines/coveragerc ${CI_ARTIFACT_NAME}
+        coverage report
+        coverage html -d ${BUILD_ARTIFACTSTAGINGDIRECTORY}/coverage_report
+      condition: succeeded()
+      displayName: 'Combine And Report Test Coverage'
+  
+    - task: PublishBuildArtifacts@1
+      condition: succeeded()
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: 'test_coverage_report'
+      displayName: 'Deploy Test Coverage Report'

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -9,73 +9,83 @@ parameters:
   onnx_backends: {onnxruntime: ['0.4.0']}
   job: {}
   run_setup: 'True'
+  report_coverage: 'False'
+  artifact_name: 'single_test_coverage'
 
 jobs:
-- ${{ each platform in parameters.platforms }}:
   - job: ${{ parameters.job.name }}
     pool:
-      ${{ if eq(platform, 'linux') }}:
-        vmImage: 'ubuntu-16.04'
-      ${{ if eq(platform, 'windows') }}:
-        vmImage: 'vs2017-win2016'
-      ${{ if eq(platform, 'mac') }}:
-        vmImage: 'macOS-10.13'
+        vmImage: $(CI_VM_IMAGE)
 
     # Generate matrix
     strategy:
       matrix:
-        ${{ each python_version in parameters.python_versions }}:
-          ${{ each tf_version in parameters.tf_versions }}:
-            ${{ each onnx_version in parameters.onnx_versions }}:
-              ${{ each onnx_backend in parameters.onnx_backends }}:
-                ${{ each onnx_backend_version in onnx_backend.value }}:
-                  ${{ each onnx_opset in parameters.onnx_opsets }}:
-                    ${{ if ne(onnx_opset, '') }}:
-                      ${{ format('{0} python{1} tf{2} onnx{3} opset{4} {5}{6}', platform, python_version, tf_version, onnx_version, onnx_opset, onnx_backend.key, onnx_backend_version) }}:
-                        CI_PYTHON_VERSION: '${{ python_version }}'
-                        CI_TF_VERSION: '${{ tf_version }}'
-                        CI_ONNX_VERSION: '${{ onnx_version }}'
-                        CI_ONNX_OPSET: '${{ onnx_opset }}'
-                        CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
-                        CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
+        ${{ each platform in parameters.platforms }}:
+          ${{ each python_version in parameters.python_versions }}:
+            ${{ each tf_version in parameters.tf_versions }}:
+              ${{ each onnx_version in parameters.onnx_versions }}:
+                ${{ each onnx_backend in parameters.onnx_backends }}:
+                  ${{ each onnx_backend_version in onnx_backend.value }}:
+                    ${{ each onnx_opset in parameters.onnx_opsets }}:
+                      ${{ if ne(onnx_opset, '') }}:
+                        ${{ format('{0} python{1} tf{2} onnx{3} opset{4} {5}{6}', platform, python_version, tf_version, onnx_version, onnx_opset, onnx_backend.key, onnx_backend_version) }}:
+                          ${{ if eq(platform, 'linux') }}:
+                            CI_VM_IMAGE: 'ubuntu-16.04'
+                          ${{ if eq(platform, 'windows') }}:
+                            CI_VM_IMAGE: 'vs2017-win2016'
+                          ${{ if eq(platform, 'mac') }}:
+                            CI_VM_IMAGE: 'macOS-10.13'
+                          CI_PYTHON_VERSION: '${{ python_version }}'
+                          CI_TF_VERSION: '${{ tf_version }}'
+                          CI_ONNX_VERSION: '${{ onnx_version }}'
+                          CI_ONNX_OPSET: '${{ onnx_opset }}'
+                          CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
+                          CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
 
-                        ${{ if eq(tf_version, '') }}:
-                          CI_PIP_TF_NAME: 'tensorflow'
-                        ${{ if ne(tf_version, '') }}:
-                          CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
+                          ${{ if eq(tf_version, '') }}:
+                            CI_PIP_TF_NAME: 'tensorflow'
+                          ${{ if ne(tf_version, '') }}:
+                            CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
 
-                        ${{ if eq(onnx_version, '') }}:
-                          CI_PIP_ONNX_NAME: 'onnx'
-                        ${{ if ne(onnx_version, '') }}:
-                          CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
+                          ${{ if eq(onnx_version, '') }}:
+                            CI_PIP_ONNX_NAME: 'onnx'
+                          ${{ if ne(onnx_version, '') }}:
+                            CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
 
-                        ${{ if eq(onnx_backend_version, '') }}:
-                          CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
-                        ${{ if ne(onnx_backend_version, '') }}:
-                          CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
+                          ${{ if eq(onnx_backend_version, '') }}:
+                            CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
+                          ${{ if ne(onnx_backend_version, '') }}:
+                            CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
 
-                    ${{ if eq(onnx_opset, '') }}:
-                      ${{ format('{0} python{1} tf{2} onnx{3} {4}{5}', platform, python_version, tf_version, onnx_version, onnx_backend.key, onnx_backend_version) }}:
-                        CI_PYTHON_VERSION: '${{ python_version }}'
-                        CI_TF_VERSION: '${{ tf_version }}'
-                        CI_ONNX_VERSION: '${{ onnx_version }}'
-                        CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
-                        CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
+                      ${{ if eq(onnx_opset, '') }}:
+                        ${{ format('{0} python{1} tf{2} onnx{3} {4}{5}', platform, python_version, tf_version, onnx_version, onnx_backend.key, onnx_backend_version) }}:
+                          ${{ if eq(platform, 'linux') }}:
+                            CI_VM_IMAGE: 'ubuntu-16.04'
+                          ${{ if eq(platform, 'windows') }}:
+                            CI_VM_IMAGE: 'vs2017-win2016'
+                          ${{ if eq(platform, 'mac') }}:
+                            CI_VM_IMAGE: 'macOS-10.13'
+                          CI_PLATFORM: '${{ platform }}'
+                          CI_PYTHON_VERSION: '${{ python_version }}'
+                          CI_TF_VERSION: '${{ tf_version }}'
+                          CI_ONNX_VERSION: '${{ onnx_version }}'
+                          CI_ONNX_BACKEND: '${{ onnx_backend.key }}'
+                          CI_ONNX_BACKEND_VERSION: '${{ onnx_backend_version }}'
 
-                        ${{ if eq(tf_version, '') }}:
-                          CI_PIP_TF_NAME: 'tensorflow'
-                        ${{ if ne(tf_version, '') }}:
-                          CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
+                          ${{ if eq(tf_version, '') }}:
+                            CI_PIP_TF_NAME: 'tensorflow'
+                          ${{ if ne(tf_version, '') }}:
+                            CI_PIP_TF_NAME: ${{ format('tensorflow=={0}', tf_version) }}
 
-                        ${{ if eq(onnx_version, '') }}:
-                          CI_PIP_ONNX_NAME: 'onnx'
-                        ${{ if ne(onnx_version, '') }}:
-                          CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
+                          ${{ if eq(onnx_version, '') }}:
+                            CI_PIP_ONNX_NAME: 'onnx'
+                          ${{ if ne(onnx_version, '') }}:
+                            CI_PIP_ONNX_NAME: ${{ format('onnx=={0}', onnx_version) }}
 
-                        ${{ if eq(onnx_backend_version, '') }}:
-                          CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
-                        ${{ if ne(onnx_backend_version, '') }}:
-                          CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
+                          ${{ if eq(onnx_backend_version, '') }}:
+                            CI_PIP_ONNX_BACKEND_NAME: '${{ onnx_backend.key }}'
+                          ${{ if ne(onnx_backend_version, '') }}:
+                            CI_PIP_ONNX_BACKEND_NAME: ${{ format('{0}=={1}', onnx_backend.key, onnx_backend_version) }}
 
     # Insert all properties other than pool/steps/strategy
     ${{ each pair in parameters.job }}:
@@ -108,3 +118,19 @@ jobs:
 
     # Insert original steps
     - ${{ parameters.job.steps }}
+
+    # Report and publish test coverage
+    # Save source path for combining coverage cross platform
+    - bash: |
+        coverage report
+        mv .coverage ${BUILD_ARTIFACTSTAGINGDIRECTORY}/.coverage.${CI_PLATFORM}_python${CI_PYTHON_VERSION}_tf${CI_TF_VERSION}_onnx${CI_ONNX_VERSION}_${CI_ONNX_BACKEND}${CI_ONNX_VERSION}
+        echo "  ${SYSTEM_DEFAULTWORKINGDIRECTORY}" > ${BUILD_ARTIFACTSTAGINGDIRECTORY}/.coveragerc_paths.${CI_PLATFORM}_python${CI_PYTHON_VERSION}_tf${CI_TF_VERSION}_onnx${CI_ONNX_VERSION}_${CI_ONNX_BACKEND}${CI_ONNX_VERSION}
+      condition: and(succeededOrFailed(), eq(${{ parameters.report_coverage }}, 'True'))
+      displayName: 'Report Single Test Coverage'
+
+    - task: PublishBuildArtifacts@1
+      condition: succeeded()
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '${{ parameters.artifact_name }}'
+      displayName: 'Deploy Single Test Coverage'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -3,7 +3,7 @@
 steps:
 - bash: |
     set -ex
-    pip install pytest pytest-cov pytest-runner graphviz requests pyyaml pillow pandas parameterized
+    pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME) $(CI_PIP_ONNX_BACKEND_NAME)
 
     # TF 1.10 requires numpy <=1.14.5 and >=1.13.3, but onnxruntime 0.2.1 does not work with numpy <= 1.14.5

--- a/ci_build/azure_pipelines/templates/unit_test.yml
+++ b/ci_build/azure_pipelines/templates/unit_test.yml
@@ -8,7 +8,7 @@ steps:
   - bash: |
       export TF2ONNX_TEST_BACKEND=$CI_ONNX_BACKEND
       export TF2ONNX_TEST_OPSET=$CI_ONNX_OPSET
-      python -m pytest --cov=tf2onnx --cov-report=term --disable-pytest-warnings -r s tests
+      python -m pytest --cov=tf2onnx --cov-report=term --disable-pytest-warnings -r s tests --cov-append
     timeoutInMinutes: 5
     displayName: ${{ format('Run UnitTest - Opset{0}', onnx_opset) }}
     condition: succeededOrFailed()

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -1,22 +1,28 @@
 # Unit test, full matrix
 
-jobs:
-- template: 'templates/job_generator.yml'
-  parameters:
-    platforms: ['linux', 'windows', 'mac']
-    python_versions: ['3.6', '3.5']
-    tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
-    onnx_opsets: ['']
-    job:
-      steps:
-      - template: 'unit_test.yml'
+stages:
+  - stage:
+    jobs:
+    - template: 'templates/job_generator.yml'
+      parameters:
+        platforms: ['linux', 'windows', 'mac']
+        python_versions: ['3.6', '3.5']
+        tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+    
+    - template: 'templates/job_generator.yml'
+      parameters:
+        platforms: ['linux', 'windows', 'mac']
+        python_versions: ['3.7']
+        tf_versions: ['1.13.1']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
 
-- template: 'templates/job_generator.yml'
-  parameters:
-    platforms: ['linux', 'windows', 'mac']
-    python_versions: ['3.7']
-    tf_versions: ['1.13.1']
-    onnx_opsets: ['']
-    job:
-      steps:
-      - template: 'unit_test.yml'
+  - template: 'templates/combine_test_coverage.yml'

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -1,28 +1,35 @@
 # Unit test
 
-jobs:
-- template: 'templates/job_generator.yml'
-  parameters:
-    python_versions: ['3.7', '3.6', '3.5']
-    tf_versions: ['1.13.1']
-    onnx_opsets: ['']
-    job:
-      steps:
-      - template: 'unit_test.yml'
+stages:
+  - stage:
+    jobs:
+    - template: 'templates/job_generator.yml'
+      parameters:
+        python_versions: ['3.7', '3.6', '3.5']
+        tf_versions: ['1.13.1']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+    
+    - template: 'templates/job_generator.yml'
+      parameters:
+        tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+    
+    - template: 'templates/job_generator.yml'
+      parameters:
+        platforms: ['windows', 'mac']
+        tf_versions: ['1.13.1']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
 
-- template: 'templates/job_generator.yml'
-  parameters:
-    tf_versions: ['1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
-    onnx_opsets: ['']
-    job:
-      steps:
-      - template: 'unit_test.yml'
-
-- template: 'templates/job_generator.yml'
-  parameters:
-    platforms: ['windows', 'mac']
-    tf_versions: ['1.13.1']
-    onnx_opsets: ['']
-    job:
-      steps:
-      - template: 'unit_test.yml'
+  - template: 'templates/combine_test_coverage.yml'


### PR DESCRIPTION
Merge all unittests cross different platform, different TF version, different python version, etc.
You can find the unittest coverage report in `combine_and_report_coverage` job of unittest build.
Report of html is also available as a build artifact.