### PR TITLE
calculate condition initialization for Loop

### DIFF
--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -160,6 +160,33 @@ class LoopTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["i:0", "output_ta:0"]
         self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
+    def test_while_loop_with_cond_init_false(self):
+        i = tf.placeholder(tf.int32, (), name="input_1")
+        inputs = tf.placeholder(tf.float32, (10,), name="input_2")
+
+        inputs_2 = tf.identity(inputs)
+        input_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True).unstack(inputs_2)
+        output_ta = tf.TensorArray(dtype=tf.float32, size=0, dynamic_size=True)
+
+        c = lambda i, *_: tf.logical_and(i < 10, i >= 0)
+
+        def b(i, out_ta):
+            new_i = tf.add(i, 1)
+            x = input_ta.read(i)
+            y = x + 3
+            out_ta_new = out_ta.write(i, y)
+            return new_i, out_ta_new
+
+        i_final, out_final = tf.while_loop(c, b, [i, output_ta])
+        _ = tf.identity(i_final, name="i")
+        _ = tf.identity(out_final.stack(), name="output_ta")
+        input_names_with_port = ["input_1:0", "input_2:0"]
+        feed_dict = {"input_1:0": np.array(20, dtype=np.int32),
+                     "input_2:0": np.array([2.0, 16.0, 5.0, 1.6, 5.0, 6.0, 7.0, 8.0, 9.0, 10.], dtype=np.float32)}
+
+        output_names_with_port = ["i:0", "output_ta:0"]
+        self.run_test_case(feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
+
     def test_map_fn(self):
         def fn0(elem):
             res = elem + elem * elem

--- a/tf2onnx/rewriter/loop_rewriter_base.py
+++ b/tf2onnx/rewriter/loop_rewriter_base.py
@@ -295,9 +295,11 @@ class LoopRewriterBase(object):
             loop_var = context.loop_properties.all_variables[enter_node.name]
 
             # cut off connection between condition graph and Merge node.
+            # replace condition graph's inputs to be cell graph's outputs, because we want condition graph
+            # to consumer cell graph outputs.
             non_switch_consumers = [n for n in self.g.find_output_consumers(merge_node.output[0]) if n.type != "Switch"]
             self.g.replace_all_inputs(non_switch_consumers, merge_node.output[0],
-                                      loop_var.switch_true_identity_output.id)
+                                      loop_var.next_iteration_input.id)
             dependent_vars.append(loop_var)
 
         # cut off connection between condition graph and LoopCond node.


### PR DESCRIPTION
Address #541 
Copy the condition graph from Loop body graph to main graph, bind its inputs to their initializer and connect its output to Loop condition input. 
Fix a bug by setting output of condition graph to next_iteration_input rather than switch_true_identity_output that might be None, so that we cannot find its corresponding state variable later.