### PR TITLE
math lrn op set shape after transpose

### DIFF
--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -262,6 +262,7 @@ class LRN:
         node.set_attr("alpha", size * node.get_attr("alpha").f)
 
         ctx.insert_new_node_on_input(node, "Transpose", node.input[0], perm=constants.NHWC_TO_NCHW)
+        ctx.update_node_shape_dtype(node, override=True)
         op_name = utils.make_name(node.name)
         ctx.insert_new_node_on_output("Transpose", node.output[0], perm=constants.NCHW_TO_NHWC, name=op_name)
 

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -261,7 +261,13 @@ class LRN:
         node.set_attr("size", size)
         node.set_attr("alpha", size * node.get_attr("alpha").f)
 
+        input_shape = ctx.get_shape(node.input[0])
+        new_shape = input_shape[:]
+        for i in constants.NHWC_TO_NCHW:
+            new_shape[i] = input_shape[constants.NHWC_TO_NCHW[i]]
+
         ctx.insert_new_node_on_input(node, "Transpose", node.input[0], perm=constants.NHWC_TO_NCHW)
+        ctx.set_shape(node.output[0], new_shape)
         ctx.update_node_shape_dtype(node, override=True)
         op_name = utils.make_name(node.name)
         ctx.insert_new_node_on_output("Transpose", node.output[0], perm=constants.NCHW_TO_NHWC, name=op_name)

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -261,16 +261,14 @@ class LRN:
         node.set_attr("size", size)
         node.set_attr("alpha", size * node.get_attr("alpha").f)
 
-        input_shape = ctx.get_shape(node.input[0])
-        new_shape = input_shape[:]
-        for i in constants.NHWC_TO_NCHW:
-            new_shape[i] = input_shape[constants.NHWC_TO_NCHW[i]]
+        shapes = node.output_shapes[0]
+        dtypes = node.output_dtypes[0]
 
         ctx.insert_new_node_on_input(node, "Transpose", node.input[0], perm=constants.NHWC_TO_NCHW)
-        ctx.set_shape(node.output[0], new_shape)
         ctx.update_node_shape_dtype(node, override=True)
         op_name = utils.make_name(node.name)
-        ctx.insert_new_node_on_output("Transpose", node.output[0], perm=constants.NCHW_TO_NHWC, name=op_name)
+        ctx.insert_new_node_on_output("Transpose", node.output[0], perm=constants.NCHW_TO_NHWC,
+                                      name=op_name, shapes=shapes, dtypes=dtypes)
 
 
 @tf_op(["MatMul", "BatchMatMul"])


### PR DESCRIPTION
It needs override=True to set shape. Issue #531 is fixed, the model can run.