### PR TITLE
Revert constant

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -141,7 +141,7 @@ class Node(object):
 
     def is_const(self):
         """Return True if node is a constant."""
-        return self.type in ["Const", "ConstV2", "Constant"]
+        return self.type in ["Const", "ConstV2"]
 
     def is_graph_input(self):
         return self.type in ["Placeholder", "PlaceholderWithDefault", "PlaceholderV2"]
@@ -862,6 +862,7 @@ class Graph(object):
         for op in self.get_nodes():
             if op.is_const():
                 const_ops.append(op)
+                continue
             elif op.is_graph_input():
                 if op not in self._order_sensitive_inputs:
                     order_non_sensitive_placeholders.append(op)
@@ -871,6 +872,7 @@ class Graph(object):
 
         # create initializers for placeholder with default nodes
         initializers = []
+        placeholder_default_const_ops = []
         for op in placeholder_ops:
             if op.type == "PlaceholderWithDefault":
                 utils.make_sure(op.inputs[0] is not None, "Cannot find node with output {}".format(op.input[0]))
@@ -880,24 +882,18 @@ class Graph(object):
                 value = op.inputs[0].get_tensor_value(as_list=False)
                 tensor = numpy_helper.from_array(value, op.output[0])
                 initializers.append(tensor)
-                const_ops.remove(op.inputs[0])
-                ops.remove(op.inputs[0])
+                placeholder_default_const_ops.append(op.inputs[0])
 
         # create initializers for constant nodes
+        const_ops = [op for op in const_ops if op not in placeholder_default_const_ops]
         for op in const_ops:
-            # Constant support more dtypes after opset 9
-            if self.opset < 9:
-                # not to use numpy_helper.from_array to create a new tensor
-                # because sometimes onnx will have a bug that only check the tensor data in specific field
-                # such as at upsample it only checks the float_data field.
-                t = op.get_attr("value")
-                tensor = helper.get_attribute_value(t)
-                tensor.name = op.output[0]
-                initializers.append(tensor)
-                ops.remove(op)
-            else:
-                op.type = "Constant"
-                op.update_proto()
+            # not to use numpy_helper.from_array to create a new tensor
+            # because sometimes onnx will have a bug that only check the tensor data in specific field
+            # such as at upsample it only checks the float_data field.
+            t = op.get_attr("value")
+            tensor = helper.get_attribute_value(t)
+            tensor.name = op.output[0]
+            initializers.append(tensor)
 
         # create input_tensor_values
         input_ids = [op.output[0] for op in placeholder_ops]

--- a/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
+++ b/tf2onnx/optimizer/merge_duplicated_nodes_optimizer.py
@@ -51,6 +51,9 @@ class MergeDuplicatedNodesOptimizer(GraphOptimizerBase):
     def _group_nodes_by_type_inputs(graph):
         res = defaultdict(list)
         for node in graph.get_nodes():
+            # default const of graph input cannot be merged
+            if node.is_graph_input_default_const():
+                continue
             res[_KeyToGroupNodes(node.type, tuple(node.input))].append(node)
         return res
 
@@ -72,6 +75,7 @@ class MergeDuplicatedNodesOptimizer(GraphOptimizerBase):
     def _have_equal_attr(self, node_1, node_2, graph):
         if node_1.attr == node_2.attr:
             return True
+        # above check guarantees consts here are able to be merged
         if node_1.is_const() and node_2.is_const():
             # get_tensor_value is costly so that we check their shape first
             shape_1 = graph.get_shape(node_1.output[0])


### PR DESCRIPTION
1. Revert the change of mapping Const to Constant op. 
2. Merge Const ops that are not the default value of graph inputs.
3. Fix GraphUtil's bug: map the tensor in both initializer and input to Const --> PlaceholderWithDefault.