### PR TITLE
fix deepcopy

### DIFF
--- a/tf2onnx/loader.py
+++ b/tf2onnx/loader.py
@@ -125,4 +125,4 @@ def from_saved_model(model_path, input_names, output_names, signatures=None):
     input_names = remove_redundant_inputs(frozen_graph, input_names)
     # clean up
     tf.reset_default_graph()
-    return frozen_graph, input_names, outputs.keys()
+    return frozen_graph, input_names, list(outputs.keys())


### PR DESCRIPTION
deepcopy error caused by dict_item: https://stackoverflow.com/questions/54658048/typeerror-cant-pickle-dict-items-objects