### PR TITLE
Add opset 11 ops with minimal changes

### DIFF
--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -187,6 +187,11 @@ class Softmax:
         logits_rank = len(ctx.get_shape(node.input[0]))
         node.set_attr("axis", logits_rank - 1)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # opset 11 supports -ve axis
+        pass
+
 
 @tf_op("Square")
 class Square:

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -304,6 +304,11 @@ class PoolOp:
         cls._convert(ctx, node, **kwargs)
 
     @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # no change
+        cls._convert(ctx, node, **kwargs)
+
+    @classmethod
     def _convert(cls, ctx, node, **kwargs):
         # T output = MaxPool(T input, @list(int) ksize, @list(int) strides, @string padding, @string data_format)
         # T Y = MaxPool(T X, @AttrType.STRING auto_pad, @AttrType.INTS kernel_shape, @AttrType.INTS pads,

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -207,6 +207,11 @@ class ConvOp:
         add_padding(ctx, node, kernel_shape, strides, dilations=dilations, spatial=2)
         conv_convert_inputs(ctx, node, with_kernel=True)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # no change
+        cls.version_1(ctx, node, **kwargs)
+
 
 @tf_op("Conv2DBackpropInput")
 class ConvTranspose:

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -17,8 +17,8 @@ from onnx import onnx_pb, helper
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-
 logger = logging.getLogger(__name__)
+
 
 # pylint: disable=unused-argument,missing-docstring
 
@@ -49,6 +49,11 @@ class ReduceOpBase:
             del node.attr['keep_dims']
             node.set_attr("keepdims", keep_dims.i)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # Opset 11 supports negative axis, but core logic is same
+        cls.version_1(ctx, node, **kwargs)
+
 
 @tf_op(["ArgMax", "ArgMin"])
 class ArgMax:
@@ -78,6 +83,11 @@ class ArgMax:
         node.set_attr("axis", axis)
         node.set_attr("keepdims", 0)
         ctx.remove_input(node, node.input[1])
+
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # Opset 11 supports negative axis, but core logic same
+        cls.version_1(ctx, node, **kwargs)
 
 
 @tf_op(["All", "Any"])

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -536,7 +536,7 @@ class Split:
         cls.version_1(ctx, node, **kwargs)
 
     @classmethod
-    def version_1(cls, ctx, node, **kwargs):
+    def version_11(cls, ctx, node, **kwargs):
         # no change
         cls.version_1(ctx, node, **kwargs)
 

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -79,6 +79,10 @@ class Flatten:
         # no change for us
         cls.version_1(ctx, node, **kwargs)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # no change
+        cls.version_1(ctx, node, **kwargs)
 
 @tf_op("Dropout")
 class Dropout:
@@ -184,6 +188,10 @@ class Squeeze:
             axis = [i for i, j in enumerate(shape) if j == 1]
         node.set_attr("axes", axis)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # Opset 11 supports negative axis, but core logic is same
+        cls.version_1(ctx, node, **kwargs)
 
 @tf_op("Transpose")
 class Transpose:
@@ -225,6 +233,10 @@ class Concat:
             _wrap_concat_with_cast(ctx, node)
             return
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # Opset 11 supports negative axis, but core logic is same
+        cls.version_1(ctx, node, **kwargs)
 
 @tf_op("ConcatV2")
 class ConcatV2:
@@ -316,6 +328,10 @@ class Gather:
     def version_1(cls, ctx, node, **kwargs):
         node.type = "Gather"
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # no change
+        cls.version_1(ctx, node, **kwargs)
 
 @tf_op("GatherV2")
 class GatherV2:
@@ -327,6 +343,10 @@ class GatherV2:
         ctx.remove_input(node, node.input[2])
         node.set_attr("axis", axis)
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # no change
+        cls.version_1(ctx, node, **kwargs)
 
 def _make_gathernd_inner_loop(ctx, params, index, dtype):
     """create the inner loop for GatherNd."""
@@ -515,6 +535,10 @@ class Split:
     def version_2(cls, ctx, node, **kwargs):
         cls.version_1(ctx, node, **kwargs)
 
+    @classmethod
+    def version_1(cls, ctx, node, **kwargs):
+        # no change
+        cls.version_1(ctx, node, **kwargs)
 
 @tf_op("SplitV")
 class SplitV:
@@ -924,6 +948,12 @@ class TopKV2:
                                       shapes=[shapes[1]], dtypes=[onnx_pb.TensorProto.INT32])
 
     @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # opset 11 supports negative axis, and new attrs 'largest' and 'sorted'
+        # the core logic doesn't change, using defaults for new attrs
+        cls.version_1(ctx, node, **kwargs)
+
+    @classmethod
     def version_10(cls, ctx, node, **kwargs):
         # onnx only supports input K as a 1D tesor with dtype int64
         # while in tf, K is a 0D tensor with dtype int32
@@ -1083,6 +1113,10 @@ class OneHot:
             ctx.set_dtype(new_node.output[0], output_dtype)
             ctx.set_shape(new_node.output[0], ctx.get_shape(node.output[0]))
 
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # Opset 11 supports negative axis, but core logic is same
+        cls.version_9(ctx, node, **kwargs)
 
 @tf_op("Shape")
 class Shape:

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -84,6 +84,7 @@ class Flatten:
         # no change
         cls.version_1(ctx, node, **kwargs)
 
+
 @tf_op("Dropout")
 class Dropout:
     @classmethod
@@ -193,6 +194,7 @@ class Squeeze:
         # Opset 11 supports negative axis, but core logic is same
         cls.version_1(ctx, node, **kwargs)
 
+
 @tf_op("Transpose")
 class Transpose:
     @classmethod
@@ -237,6 +239,7 @@ class Concat:
     def version_11(cls, ctx, node, **kwargs):
         # Opset 11 supports negative axis, but core logic is same
         cls.version_1(ctx, node, **kwargs)
+
 
 @tf_op("ConcatV2")
 class ConcatV2:
@@ -333,6 +336,7 @@ class Gather:
         # no change
         cls.version_1(ctx, node, **kwargs)
 
+
 @tf_op("GatherV2")
 class GatherV2:
     @classmethod
@@ -347,6 +351,7 @@ class GatherV2:
     def version_11(cls, ctx, node, **kwargs):
         # no change
         cls.version_1(ctx, node, **kwargs)
+
 
 def _make_gathernd_inner_loop(ctx, params, index, dtype):
     """create the inner loop for GatherNd."""
@@ -539,6 +544,7 @@ class Split:
     def version_11(cls, ctx, node, **kwargs):
         # no change
         cls.version_1(ctx, node, **kwargs)
+
 
 @tf_op("SplitV")
 class SplitV:
@@ -948,12 +954,6 @@ class TopKV2:
                                       shapes=[shapes[1]], dtypes=[onnx_pb.TensorProto.INT32])
 
     @classmethod
-    def version_11(cls, ctx, node, **kwargs):
-        # opset 11 supports negative axis, and new attrs 'largest' and 'sorted'
-        # the core logic doesn't change, using defaults for new attrs
-        cls.version_1(ctx, node, **kwargs)
-
-    @classmethod
     def version_10(cls, ctx, node, **kwargs):
         # onnx only supports input K as a 1D tesor with dtype int64
         # while in tf, K is a 0D tensor with dtype int32
@@ -966,6 +966,12 @@ class TopKV2:
         cast_out = ctx.insert_new_node_on_output("Cast", node.output[1], name=utils.make_name(node.name), to=dtypes[1])
         ctx.set_dtype(cast_out.output[0], dtypes[1])
         ctx.copy_shape(node.output[1], cast_out.output[0])
+
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # opset 11 supports negative axis, and new attrs 'largest' and 'sorted'
+        # the core logic doesn't change, using defaults for new attrs
+        cls.version_10(ctx, node, **kwargs)
 
 
 @tf_op("Tile")
@@ -1117,6 +1123,7 @@ class OneHot:
     def version_11(cls, ctx, node, **kwargs):
         # Opset 11 supports negative axis, but core logic is same
         cls.version_9(ctx, node, **kwargs)
+
 
 @tf_op("Shape")
 class Shape:


### PR DESCRIPTION
Add "version_11()" empty method for operators with minimal changes. These include "ArgMax", "ArgMin", "Concat", "Flatten" etc.

Most of the onnx spec changes for these operators are either cosmetic, or else to support axis with negative values.