### PR TITLE
Fix Clip Op for LSTM for opset11

### DIFF
--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -138,10 +138,8 @@ class LSTMBlockCell:
                 cs = cs_clip_node.output[0]
             else:
                 dtype = utils.map_onnx_to_numpy_type(ctx.get_dtype(cs))
-                min_name  = utils.make_name("{}_min".format(node.name))
-                max_name = utils.make_name("{}_max".format(node.name))
-                min_const = ctx.make_const(min_name, np.array(-cell_clip, dtype=dtype))
-                max_const = ctx.make_const(max_name, np.array(cell_clip, dtype=dtype))
+                min_const = ctx.make_const(utils.make_name(f'{node.name}_min'), np.array(-cell_clip, dtype=dtype))
+                max_const = ctx.make_const(utils.make_name(f"{node.name}_max"), np.array(cell_clip, dtype=dtype))
                 cs_clip_node = ctx.make_node("Clip", [cs, min_const.output[0], max_const.output[0]])
                 nodes.append(cs_clip_node)
                 cs = cs_clip_node.output[0]

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -15,7 +15,6 @@ import numpy as np
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -133,9 +132,18 @@ class LSTMBlockCell:
         cs = cs_node.output[0]
         # cs = clip(cs)
         if cell_clip > 0:
-            cs_clip_node = ctx.make_node("Clip", [cs], attr={"max": cell_clip, "min": -cell_clip})
-            nodes.append(cs_clip_node)
-            cs = cs_clip_node.output[0]
+            if ctx.opset < 11:
+                cs_clip_node = ctx.make_node("Clip", [cs], attr={"max": cell_clip, "min": -cell_clip})
+                nodes.append(cs_clip_node)
+                cs = cs_clip_node.output[0]
+            else:
+                dtype = utils.map_onnx_to_numpy_type(ctx.get_dtype(cs))
+                clip_min = ctx.make_const(node.name + 'min', np.array(-cell_clip, dtype=dtype))
+                clip_max = ctx.make_const(node.name + 'max', np.array(cell_clip, dtype=dtype))
+                cs_clip_node = ctx.make_node("Clip", [cs, clip_min.output[0], clip_max.output[0]])
+                nodes.append(cs_clip_node)
+                cs = cs_clip_node.output[0]
+
         # o = cs * wco + o
         o = make_sigmoid(cs, wco, o)
         # co = Tanh(cs)

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -138,8 +138,10 @@ class LSTMBlockCell:
                 cs = cs_clip_node.output[0]
             else:
                 dtype = utils.map_onnx_to_numpy_type(ctx.get_dtype(cs))
-                min_const = ctx.make_const(utils.make_name(f'{node.name}_min'), np.array(-cell_clip, dtype=dtype))
-                max_const = ctx.make_const(utils.make_name(f'{node.name}_max'), np.array(cell_clip, dtype=dtype))
+                name_min = utils.make_name("{}_min".format(node.name))
+                name_max = utils.make_name("{}_max".format(node.name))
+                min_const = ctx.make_const(name_min, np.array(-cell_clip, dtype=dtype))
+                max_const = ctx.make_const(name_max, np.array(cell_clip, dtype=dtype))
                 cs_clip_node = ctx.make_node('Clip', [cs, min_const.output[0], max_const.output[0]])
                 nodes.append(cs_clip_node)
                 cs = cs_clip_node.output[0]

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -139,8 +139,8 @@ class LSTMBlockCell:
             else:
                 dtype = utils.map_onnx_to_numpy_type(ctx.get_dtype(cs))
                 min_const = ctx.make_const(utils.make_name(f'{node.name}_min'), np.array(-cell_clip, dtype=dtype))
-                max_const = ctx.make_const(utils.make_name(f"{node.name}_max"), np.array(cell_clip, dtype=dtype))
-                cs_clip_node = ctx.make_node("Clip", [cs, min_const.output[0], max_const.output[0]])
+                max_const = ctx.make_const(utils.make_name(f'{node.name}_max'), np.array(cell_clip, dtype=dtype))
+                cs_clip_node = ctx.make_node('Clip', [cs, min_const.output[0], max_const.output[0]])
                 nodes.append(cs_clip_node)
                 cs = cs_clip_node.output[0]
 

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -138,9 +138,11 @@ class LSTMBlockCell:
                 cs = cs_clip_node.output[0]
             else:
                 dtype = utils.map_onnx_to_numpy_type(ctx.get_dtype(cs))
-                clip_min = ctx.make_const(node.name + 'min', np.array(-cell_clip, dtype=dtype))
-                clip_max = ctx.make_const(node.name + 'max', np.array(cell_clip, dtype=dtype))
-                cs_clip_node = ctx.make_node("Clip", [cs, clip_min.output[0], clip_max.output[0]])
+                min_name  = utils.make_name("{}_min".format(node.name))
+                max_name = utils.make_name("{}_max".format(node.name))
+                min_const = ctx.make_const(min_name, np.array(-cell_clip, dtype=dtype))
+                max_const = ctx.make_const(max_name, np.array(cell_clip, dtype=dtype))
+                cs_clip_node = ctx.make_node("Clip", [cs, min_const.output[0], max_const.output[0]])
                 nodes.append(cs_clip_node)
                 cs = cs_clip_node.output[0]
 


### PR DESCRIPTION
Fix Clip operator for LSTM opset11. Attributes have changed to inputs, do the LSTM/RNN logic needs to be updated.