### PR TITLE
switch ci pipeline to include opset 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ tf2onnx - Convert TensorFlow models to ONNX.
 # Supported ONNX version
 tensorflow-onnx will use the ONNX version installed on your system and installs the latest ONNX version if none is found.
 
-We support opset 6 to 10. By default we use opset 7 for the resulting ONNX graph since most runtimes will support opset 7. Support for future opsets add added as they are released.
+We support opset 6 to 11. By default we use opset 8 for the resulting ONNX graph since most runtimes will support opset 8.
+Support for future opsets add added as they are released.
 
-If you want the graph to be generated with a specific opset, use ```--opset``` in the command line, for example ```--opset 10```.
+If you want the graph to be generated with a specific opset, use ```--opset``` in the command line, for example ```--opset 11```.
 
 # Status
 We support many TensorFlow models. Support for Fully Connected, Convolutional and dynamic LSTM networks is mature.

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -7,7 +7,7 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.6', '3.5']
-        tf_versions: ['1.13.1','1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+        tf_versions: ['1.13','1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -3,8 +3,8 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    python_versions: ['3.7', '3.6', '3.5']
-    tf_versions: ['1.14.0']
+    python_versions: ['3.7', '3.5']
+    tf_versions: ['1.14']
     job:
       steps:
       - template: 'pretrained_model_test.yml'
@@ -12,7 +12,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['windows']
-    tf_versions: ['1.14.0']
+    tf_versions: ['1.14']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -5,8 +5,8 @@ parameters:
   python_versions: ['3.6']
   tf_versions: ['']
   onnx_versions: ['']
-  onnx_opsets: ['10', '9', '8', '7']
-  onnx_backends: {onnxruntime: ['0.4.0']}
+  onnx_opsets: ['11', '10', '9', '8', '7']
+  onnx_backends: {onnxruntime: ['1.0.0']}
   job: {}
   run_setup: 'True'
   report_coverage: 'False'

--- a/ci_build/azure_pipelines/templates/unit_test.yml
+++ b/ci_build/azure_pipelines/templates/unit_test.yml
@@ -1,7 +1,7 @@
 # Run unit test
 
 parameters:
-    onnx_opsets: ['10', '9', '8', '7']
+    onnx_opsets: ['11', '10', '9', '8', '7']
 
 steps:
 - ${{ each onnx_opset in parameters.onnx_opsets }}:

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -7,7 +7,7 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.6', '3.5']
-        tf_versions: ['1.13.1','1.12', '1.11', '1.10', '1.9', '1.8', '1.7', '1.6', '1.5']
+        tf_versions: ['1.13', '1.11', '1.10', '1.9', 1.7', '1.5']
         onnx_opsets: ['']
         job:
           steps:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -15,7 +15,7 @@ stages:
     
     - template: 'templates/job_generator.yml'
       parameters:
-        tf_versions: ['1.14', '1.12', '1.11', '1.10', '1.9', '1.8', '1.7']
+        tf_versions: ['1.14', '1.12', '1.11', '1.10', '1.9', '1.7']
         onnx_opsets: ['']
         job:
           steps:
@@ -27,18 +27,6 @@ stages:
         platforms: ['windows']
         tf_versions: ['1.14']
         onnx_opsets: ['']
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-
-    # test opset-11 and tf-1.15
-    - template: 'templates/job_generator.yml'
-      parameters:
-        platforms: ['linux']
-        tf_versions: ['1.14']
-        onnx_opsets: ['11']
-        onnx_backends: {onnxruntime: ['nightly']}
         job:
           steps:
           - template: 'unit_test.yml'

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -15,7 +15,7 @@ AI_ONNX_ML_DOMAIN = "ai.onnx.ml"
 MICROSOFT_DOMAIN = "com.microsoft"
 
 # Default opset version for onnx domain
-PREFERRED_OPSET = 7
+PREFERRED_OPSET = 8
 
 # Default opset for custom ops
 TENSORFLOW_OPSET = helper.make_opsetid("ai.onnx.converters.tensorflow", 1)


### PR DESCRIPTION
include opset 11 and onnxruntime-1.0.
To keep build times reasonable skip some tensorflow versions (we have never seen failure on those anyway).