### PR TITLE
Update axis handling for SoftMax. TF default axis is rank-1.

### DIFF
--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -189,8 +189,7 @@ class Softmax:
 
     @classmethod
     def version_11(cls, ctx, node, **kwargs):
-        # opset 11 supports -ve axis
-        pass
+        cls.version_1(ctx, node, **kwargs)
 
 
 @tf_op("Square")


### PR DESCRIPTION
Minor fix for SoftMax 11 conversion.