### PR TITLE
Fix flatten_rewriter -- check to see if nodes are safe to rewrite

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1231,6 +1231,18 @@ class Graph(object):
                     body_graph.delete_unused_nodes(body_graph.outputs)
         self.reset_nodes(related_nodes)
 
+    def safe_to_remove_nodes(self, to_delete):
+        """ List of nodes that safe to delete (i.e. outputs not consumed by other nodes.)"""
+        safe_to_remove = []
+        delete_set = set(to_delete)
+        for n in delete_set:
+            out_consumers = set()
+            for out in n.output:
+                out_consumers |= set(self.find_output_consumers(out))
+            if out_consumers.issubset(delete_set):
+                safe_to_remove.append(n)
+        return safe_to_remove
+
     def safe_remove_nodes(self, to_delete):
         """Delete nodes in `to_delete` without third-party node consuming it."""
         delete_set = set(to_delete)

--- a/tf2onnx/rewriter/flatten_rewriter.py
+++ b/tf2onnx/rewriter/flatten_rewriter.py
@@ -74,6 +74,13 @@ def rewrite_flatten(g, ops):
             if not need_rewrite:
                 continue
 
+            to_remove = [n for n in match.get_nodes() if n != input_node]
+            safe = g.safe_to_remove_nodes(to_remove)
+
+            # Ok if reshape_node is not safe. Will make it safe later.
+            if len(to_remove) - len(safe) > 1:
+                continue
+
             op_name = utils.make_name("Flatten")
             out_name = utils.port_name(op_name)
             g.make_node("Flatten", [reshape_node.input[0]], outputs=[out_name], name=op_name)
@@ -88,7 +95,6 @@ def rewrite_flatten(g, ops):
 
             g.set_shape(out_name, input_shape[:-2] + [new_dim])
             g.replace_all_inputs(ops, reshape_node.output[0], out_name)
-            to_delete = [n for n in match.get_nodes() if n != input_node]
-            g.safe_remove_nodes(to_delete)
+            g.safe_remove_nodes(to_remove)
 
     return ops

--- a/tf2onnx/rewriter/flatten_rewriter.py
+++ b/tf2onnx/rewriter/flatten_rewriter.py
@@ -95,6 +95,7 @@ def rewrite_flatten(g, ops):
 
             g.set_shape(out_name, input_shape[:-2] + [new_dim])
             g.replace_all_inputs(ops, reshape_node.output[0], out_name)
-            g.safe_remove_nodes(to_remove)
+            for n in to_remove:
+                g.remove_node(n.name)
 
     return ops


### PR DESCRIPTION
The nodes to be rewritten (i.e. matched-set) need to be checked if they can be safely deleted, and that they are not used by any other nodes outside the matched set.