### PR TITLE
Fix Pad op for dynamic input (opset 11).

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1079,7 +1079,7 @@ class Graph(object):
         if name is None:
             name = utils.make_name(node.name)
         new_output = port_name(name)
-        if type(input_name) is not list:
+        if not isinstance(input_name, list):
             input_name = [input_name]
 
         new_node = self.make_node(op_type, input_name, attr=kwargs, outputs=[new_output], name=name, domain=domain)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1067,7 +1067,9 @@ class Graph(object):
         Args:
             node: we want to replace the input for this node
             op_type: type for new operation
-            input_name: the names of the outputs above us
+            input_name: the name(s) of the outputs above us
+                if scalar, new node placed above input_name
+                if list, new node placed above input_name[0]. list is inputs into new node
             name: the name of the new op
             kwargs: attributes of the new node
 
@@ -1077,9 +1079,12 @@ class Graph(object):
         if name is None:
             name = utils.make_name(node.name)
         new_output = port_name(name)
-        new_node = self.make_node(op_type, [input_name], attr=kwargs, outputs=[new_output], name=name, domain=domain)
+        if type(input_name) is not list:
+            input_name = [input_name]
+
+        new_node = self.make_node(op_type, input_name, attr=kwargs, outputs=[new_output], name=name, domain=domain)
         for i, n in enumerate(node.input):
-            if n == input_name:
+            if n == input_name[0]:
                 node.input[i] = new_output
                 break
         return new_node

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -16,8 +16,8 @@ from onnx import onnx_pb, numpy_helper
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 
-
 logger = logging.getLogger(__name__)
+
 
 # pylint: disable=unused-argument,missing-docstring
 
@@ -101,6 +101,15 @@ class Fill:
         value_proto = numpy_helper.from_array(value)
         node.set_attr("value", value_proto)
         del node.input[1]
+
+    @classmethod
+    def version_11(cls, ctx, node, **kwargs):
+        # cls.version_7(ctx, node, **kwargs)
+        node.type = "Expand"
+        node.input = [node.input[1], node.input[0]]
+        # cast shape to int64 if needed
+        if ctx.get_dtype(node.input[1]) != onnx_pb.TensorProto.INT64:
+            ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=onnx_pb.TensorProto.INT64)
 
 
 @tf_op("Multinomial")

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -286,7 +286,7 @@ class DepthwiseConv2d:
         k_h, k_w, k_input_channels, k_channel_multiplier = kernel_shape
         if k_input_channels < 1:
             raise ValueError("input channel must be positive")
-        k_output_channels = k_input_channels  * k_channel_multiplier
+        k_output_channels = k_input_channels * k_channel_multiplier
 
         node.set_attr("kernel_shape", [k_h, k_w])
         strides = conv_dims_attr(node, "strides")
@@ -448,13 +448,17 @@ class Pad:
         if mode not in [None, "constant", "reflect"]:
             raise ValueError(mode + " pad mode is not supported")
 
-        pads = node.inputs[1].get_tensor_value()
-        pads = np.array(pads).transpose().flatten().astype(np.int64)
-        node.inputs[1].set_tensor_value(pads)
+        # pads must be int64
+        if ctx.get_dtype(node.input[1]) != onnx_pb.TensorProto.INT64:
+            ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=onnx_pb.TensorProto.INT64)
+        ctx.insert_new_node_on_input(node, "Transpose", node.input[1])
+        reshape = ctx.insert_new_node_on_input(node, "Reshape", node.input[1])
+        shape_const = ctx.make_const(utils.make_name(node.name), np.array([-1]).astype(np.int64))
+        reshape.input = [reshape.input[0], shape_const.name]
 
         origin_dtype = ctx.get_dtype(node.output[0])
-        if origin_dtype not in [TensorProto.FLOAT16, TensorProto.FLOAT,
-                                TensorProto.DOUBLE]:
+        if origin_dtype not in [TensorProto.FLOAT, TensorProto.DOUBLE,
+                                TensorProto.INT32, TensorProto.INT64]:
             cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0])
             cast_node.set_attr("to", TensorProto.FLOAT)
             ctx.set_dtype(cast_node.output[0], TensorProto.FLOAT)


### PR DESCRIPTION
Fixes #739 

`Pad` needs to handle dynamic padding values as of opset 11.  