### PR TITLE
Use the 'sizes' parameters of Resize op instead of 'scales'

### DIFF
--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -695,7 +695,13 @@ class Resize:
             final_target_size = build_dynamic_target_size(ctx, input_nchw, node.inputs[1])
             roi = ctx.make_const(utils.make_name("roi"), np.array([]).astype(np.float32))
             const_empty_float = ctx.make_const(utils.make_name("const_empty_float"), np.array([], dtype=np.float32))
-            upsample = ctx.make_node("Resize", [input_nchw.output[0], roi.output[0], const_empty_float.output[0], final_target_size.output[0]],
+            resize_inputs = [
+                input_nchw.output[0],
+                roi.output[0],
+                const_empty_float.output[0],
+                final_target_size.output[0]
+            ]
+            upsample = ctx.make_node("Resize", resize_inputs,
                                      attr={"mode": mode, "nearest_mode": "floor",
                                            "coordinate_transformation_mode": "asymmetric"})
         else:
@@ -707,7 +713,8 @@ class Resize:
                 n, h, w, c = shape
                 nh, nw = target_shape
                 # scales is nchw
-                # the reason not storing data at raw field is because of the bug: https://github.com/onnx/onnx/issues/1852
+                # the reason not storing data at raw field is because of the bug:
+                # https://github.com/onnx/onnx/issues/1852
                 scale_val = np.array([1.0, 1.0, float(nh) / h, float(nw) / w]).astype(np.float32)
                 scales = ctx.make_const(utils.make_name("scales"), scale_val, raw=False)
             else:


### PR DESCRIPTION
I  recently tried to convert a TF model via tensorflow-onnx and run it using onnx-tensorrt (https://github.com/onnx/onnx-tensorrt). 

I had some upscaling (ResizeBilinear) operations with a dynamic target size parameter (i.e. dynamic computation of the resize shape). The constructed graph for this ResizeBilinear TF op went through the "else" branch [here](https://github.com/onnx/tensorflow-onnx/blob/84cfa03d35846ddaf524f42890ffc1576ee95134/tf2onnx/onnx_opset/nn.py#L686) because of this dynamic shape. The `scales` parameter was thus the output of the `Concat` op [here](https://github.com/onnx/tensorflow-onnx/blob/84cfa03d35846ddaf524f42890ffc1576ee95134/tf2onnx/onnx_opset/nn.py#L699).

It then failed in Tensort runtime [at this line](https://github.com/onnx/onnx-tensorrt/blob/457f2c34918e12a4a951c7d320ef7c6cf096f6ee/builtin_op_importers.cpp#L2466) because `scales.is_weights()` is false as `scales` if the output of the `Concat` op as discussed above and not a parameter of the model.

Fortunately, ONNX 11 opset introduced the `sizes` parameter for the Resize op, which is well handled by TensorRT (see [those lines](https://github.com/onnx/onnx-tensorrt/blob/457f2c34918e12a4a951c7d320ef7c6cf096f6ee/builtin_op_importers.cpp#L2454-L2460)) and which is actually already used by tf2onnx to handle the CropAndResize TF op. 

This PR:
- uses this `sizes` parameter for the ResizeBilinear/ResizeNearestNeighbor TF ops
- factorize the introduced code with the CropAndResize op

Questions:
- I renamed `roi_required` into `use_target_size` because it seemed to not be used elsewhere and because I felt the naming was more relevant. But it could be great to confirm this from people who know the codebase.