### PR TITLE
Fix BatchToSpaceND and SpaceToBatchND operators

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2472,7 +2472,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.batch_to_space_nd(input_x, block_size, crop, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: input_val})
 
-    @check_opset_min_version(11, "BatchToSpaceND")
+    @check_opset_min_version(10, "BatchToSpaceND")
     def test_batch_to_spacend_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors
@@ -2493,7 +2493,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
                 _ = tf.batch_to_space_nd(x, y, z, name=_TFOUTPUT)
                 self._run_test_case([_OUTPUT], {_INPUT: x_val, _INPUT2: z_val})
 
-    @check_opset_min_version(11, "SpaceToBatchND")
+    @check_opset_min_version(10, "SpaceToBatchND")
     def test_space_to_batchnd_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2472,7 +2472,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         _ = tf.batch_to_space_nd(input_x, block_size, crop, name=_TFOUTPUT)
         self._run_test_case([_OUTPUT], {_INPUT: input_val})
 
-    @check_opset_min_version(10, "BatchToSpaceND")
+    @check_opset_min_version(11, "BatchToSpaceND")
     def test_batch_to_spacend_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors
@@ -2493,7 +2493,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
                 _ = tf.batch_to_space_nd(x, y, z, name=_TFOUTPUT)
                 self._run_test_case([_OUTPUT], {_INPUT: x_val, _INPUT2: z_val})
 
-    @check_opset_min_version(10, "SpaceToBatchND")
+    @check_opset_min_version(11, "SpaceToBatchND")
     def test_space_to_batchnd_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2473,26 +2473,46 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case([_OUTPUT], {_INPUT: input_val})
 
     @check_opset_min_version(11, "BatchToSpaceND")
-    def test_batch_to_spacend_non_const(self):
-        input_x_val = np.random.random_sample([40, 3, 5, 100]).astype(np.float32)  # NHWC
-        block_shape_val = np.array([2, 2]).astype(np.int64)
-        crops_val = np.array([[1, 0], [2, 1]]).astype(np.int64)
-        input_x = tf.placeholder(dtype=tf.float32, shape=input_x_val.shape, name=_TFINPUT)
-        block_shape = tf.placeholder(dtype=tf.int64, shape=block_shape_val.shape, name=_TFINPUT1)
-        crops = tf.placeholder(dtype=tf.int64, shape=crops_val.shape, name=_TFINPUT2)
-        _ = tf.batch_to_space_nd(input_x, block_shape, crops, name=_TFOUTPUT)
-        self._run_test_case([_OUTPUT], {_INPUT: input_x_val, _INPUT1: block_shape_val, _INPUT2: crops_val})
+    def test_batch_to_spacend_non_const_7d(self):
+        x_type, y_type, z_type = np.int64, np.int64, np.int64
+        # test 3D upto 6D input tensors
+        for x_shape in [[12, 4, 4], [12, 4, 8, 3], [12, 4, 8, 3, 2], [12, 4, 8, 3, 2, 3], [12, 4, 8, 3, 2, 1, 3]]:
+            # test 1D upto 7D block shapes
+            for block_shape in [[2, 3], [2]]:
+                tf.reset_default_graph()
+                # crop 1 layer at end of each dim
+                crops = [[0, 1] for dim in block_shape]
+                y_val = np.array(block_shape).astype(y_type)
+                x_val = np.array([x + 1 for x in range(0, np.prod(x_shape))], dtype=x_type).reshape(x_shape)
+                z_val = np.array(crops).astype(z_type)
+                # x and z can be dynamic.
+                # y = block_shape cannot be dynamic without change to Transpose op spec
+                x = tf.placeholder(dtype=x_type, shape=x_val.shape, name=_TFINPUT)
+                y = tf.constant(dtype=y_type, value=y_val, shape=y_val.shape, name=_TFINPUT1)
+                z = tf.placeholder(dtype=z_type, shape=z_val.shape, name=_TFINPUT2)
+                _ = tf.batch_to_space_nd(x, y, z, name=_TFOUTPUT)
+                self._run_test_case([_OUTPUT], {_INPUT: x_val, _INPUT2: z_val})
 
     @check_opset_min_version(11, "SpaceToBatchND")
-    def test_space_to_batchnd_non_const(self):
-        input_x_val = np.random.random_sample([40, 5, 7, 66]).astype(np.float32)  # NHWC
-        block_size_val = np.array([2, 2]).astype(np.int64)
-        pad_val = np.array([[0, 1], [2, 1]]).astype(np.int64)
-        input_x = tf.placeholder(dtype=tf.float32, shape=input_x_val.shape, name=_TFINPUT)
-        block_size = tf.placeholder(dtype=tf.int64, shape=block_size_val.shape, name=_TFINPUT1)
-        pad = tf.placeholder(dtype=tf.int64, shape=pad_val.shape, name=_TFINPUT2)
-        _ = tf.space_to_batch_nd(input_x, block_size, pad, name=_TFOUTPUT)
-        self._run_test_case([_OUTPUT], {_INPUT: input_x_val, _INPUT1: block_size_val, _INPUT2: pad_val})
+    def test_space_to_batchnd_non_const_7d(self):
+        x_type, y_type, z_type = np.int64, np.int64, np.int64
+        # test 3D upto 6D input tensors
+        for x_shape in [[2, 4, 4], [1, 4, 8, 3], [1, 4, 8, 3, 2], [1, 4, 8, 3, 2, 3], [1, 4, 8, 3, 2, 1, 3]]:
+            # test 1D upto 7D block shapes
+            for block_shape in [[2], [2, 2]]:
+                tf.reset_default_graph()
+                # pad 1 layer at begin and end of each dim
+                pads = [[1, 1] for dim in block_shape]
+                y_val = np.array(block_shape).astype(y_type)
+                x_val = np.array([x + 1 for x in range(0, np.prod(x_shape))], dtype=x_type).reshape(x_shape)
+                z_val = np.array(pads).astype(z_type)
+                # x and z can be dynamic.
+                # y = block_shape cannot be dynamic without change to Transpose op spec
+                x = tf.placeholder(dtype=x_type, shape=x_val.shape, name=_TFINPUT)
+                y = tf.constant(dtype=y_type, value=y_val, shape=y_val.shape, name=_TFINPUT1)
+                z = tf.placeholder(dtype=z_type, shape=z_val.shape, name=_TFINPUT2)
+                _ = tf.space_to_batch_nd(x, y, z, name=_TFOUTPUT)
+                self._run_test_case([_OUTPUT], {_INPUT: x_val, _INPUT2: z_val})
 
     @check_opset_min_version(11, "CropAndResize")
     def test_crop_and_resize_linear(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2475,7 +2475,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_opset_min_version(11, "BatchToSpaceND")
     def test_batch_to_spacend_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
-        # test 3D upto 6D input tensors
+        # test 3D upto 7D input tensors
         for x_shape in [[12, 4, 4], [12, 4, 8, 3], [12, 4, 8, 3, 2], [12, 4, 8, 3, 2, 3], [12, 4, 8, 3, 2, 1, 3]]:
             # test 1D upto 7D block shapes
             for block_shape in [[2, 3], [2]]:
@@ -2496,7 +2496,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_opset_min_version(11, "SpaceToBatchND")
     def test_space_to_batchnd_non_const_7d(self):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
-        # test 3D upto 6D input tensors
+        # test 3D upto 7D input tensors
         for x_shape in [[2, 4, 4], [1, 4, 8, 3], [1, 4, 8, 3, 2], [1, 4, 8, 3, 2, 3], [1, 4, 8, 3, 2, 1, 3]]:
             # test 1D upto 7D block shapes
             for block_shape in [[2], [2, 2]]:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2477,7 +2477,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors
         for x_shape in [[12, 4, 4], [12, 4, 8, 3], [12, 4, 8, 3, 2], [12, 4, 8, 3, 2, 3], [12, 4, 8, 3, 2, 1, 3]]:
-            # test 1D upto 7D block shapes
+            # test 1D upto 2D block shapes
             for block_shape in [[2, 3], [2]]:
                 tf.reset_default_graph()
                 # crop 1 layer at end of each dim
@@ -2498,7 +2498,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_type, y_type, z_type = np.int64, np.int64, np.int64
         # test 3D upto 7D input tensors
         for x_shape in [[2, 4, 4], [1, 4, 8, 3], [1, 4, 8, 3, 2], [1, 4, 8, 3, 2, 3], [1, 4, 8, 3, 2, 1, 3]]:
-            # test 1D upto 7D block shapes
+            # test 1D upto 2D block shapes
             for block_shape in [[2], [2, 2]]:
                 tf.reset_default_graph()
                 # pad 1 layer at begin and end of each dim

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -1275,9 +1275,9 @@ class BatchToSpace:
             indices = mkconst('_indicies_const', np.asarray(g))
             gather = mknode('Gather', [shape1.output[0], indices])
             x2 = mknode('Reshape', [input0, gather.output[0]])
-            trans2 = mknode('Transpose', [x2.output[0]], {'perm': np.array(p)})
+            tr2 = mknode('Transpose', [x2.output[0]], {'perm': np.array(p)})
             shape2 = mknode('Concat', [minus1_const, target_spatial.output[0], depth.output[0]], {'axis': 0})
-            x3 = mknode('Reshape', [trans2.output[0], shape2.output[0]])
+            x3 = mknode('Reshape', [tr2.output[0], shape2.output[0]])
 
             # crop axes
             slice_starts_const1 = mkconst('_slicestart1_const', np.asarray([0, 0]))

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -1230,7 +1230,7 @@ class BatchToSpace:
 
             # support non 3D/4D tensors and dynamic crop vals
             # dynamic slice starts at opset 10
-            utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const crops require opset 10+')
+            utils.make_sure(ctx.opset >= 11, 'non-4D tensor or non-const crops require opset 11')
 
             input0 = node.input[0]
             input2 = node.input[2]
@@ -1358,7 +1358,7 @@ class SpaceToBatch:
 
             # support non 3D/4D tensors and dynamic pad vals
             # dynamic slice starts at opset 10
-            utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const pads require opset 10+')
+            utils.make_sure(ctx.opset >= 11, 'non-4D tensor or non-const pads require opset 11')
 
             input0 = node.input[0]
             input2 = node.input[2]

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -1165,8 +1165,8 @@ class BatchToSpace:
         blocklen = len(block_shape)
         xlen = len(ctx.get_shape(node.input[0]))
 
-        # if 4d tensor & square 2d block_shape , can optimize
-        cond1 = xlen == 4
+        # if 3d or 4d tensor & square 2d block_shape , can optimize
+        cond1 = xlen in [3, 4]
         cond2 = node.inputs[2].is_const()
         cond3 = blocklen == 2 and block_shape[0] == block_shape[1]
         if cond1 and cond2 and cond3:
@@ -1228,7 +1228,7 @@ class BatchToSpace:
                 const_node = ctx.make_const(utils.make_name(nodename), val.astype(dtype))
                 return const_node.output[0]
 
-            # support non 4D tensors and dynamic crop vals
+            # support non 3D/4D tensors and dynamic crop vals
             # dynamic slice starts at opset 10
             utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const crops require opset 10+')
 
@@ -1311,8 +1311,8 @@ class SpaceToBatch:
         blocklen = len(block_shape)
         xlen = len(ctx.get_shape(node.input[0]))
 
-        # if 4d tensor & square 2d block_shape , can optimize
-        cond1 = xlen == 4
+        # if 3d or 4d tensor & square 2d block_shape , can optimize
+        cond1 = xlen in [3, 4]
         cond2 = node.inputs[2].is_const()
         cond3 = blocklen == 2 and block_shape[0] == block_shape[1]
         if cond1 and cond2 and cond3:
@@ -1356,7 +1356,7 @@ class SpaceToBatch:
                 const_node = ctx.make_const(utils.make_name(nodename), val.astype(dtype))
                 return const_node.output[0]
 
-            # support non 4D tensors and dynamic pad vals
+            # support non 3D/4D tensors and dynamic pad vals
             # dynamic slice starts at opset 10
             utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const pads require opset 10+')
 

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -1230,15 +1230,16 @@ class BatchToSpace:
 
             # support non 4D tensors and dynamic crop vals
             # dynamic slice starts at opset 10
-            utils.make_sure(ctx.opset >= 10, 'not-4D tensor or non-const pads require opset 10+')
+            utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const crops require opset 10+')
 
             input0 = node.input[0]
             input2 = node.input[2]
+
+            # const vals
             int_max_const = mkconst('int_max', np.array([utils.get_max_value(np.int64)]))
             one_const = mkconst('_const_one', np.array([1]))
             minus1_const = mkconst('_const_minus1', np.array([-1]))
             blocklen_resize_const = mkconst('_const_blocklen_resize', np.array([-1, blocklen]))
-
             blocklenplus1_const = mkconst('_const_blocklenplus1', np.array([blocklen + 1]))
             block_shape_const = mkconst('_const_block_shape', block_shape)
 
@@ -1357,17 +1358,17 @@ class SpaceToBatch:
 
             # support non 4D tensors and dynamic pad vals
             # dynamic slice starts at opset 10
-            utils.make_sure(ctx.opset >= 10, 'not-4D tensor or non-const pads require opset 10+')
+            utils.make_sure(ctx.opset >= 10, 'non-4D tensor or non-const pads require opset 10+')
 
             input0 = node.input[0]
             input2 = node.input[2]
+
             # const vals
             int_max_const = mkconst('int_max', np.array([utils.get_max_value(np.int64)]))
             zero_const = mkconst('_zero_const', np.array([0]))
             one_const = mkconst('_one_const', np.array([1]))
             minus1_const = mkconst('_minus1_const', np.array([-1]))
             blocklen_resize_const = mkconst('_blocklen_resize_const', np.array([-1, blocklen]))
-
             blocklenplus1_const = mkconst('_blocklenplus1_const', np.array([blocklen + 1]))
             filltop_const = mkconst('_filltop_const', np.array([1, 0, 0, 0]))
             fillbottom_const = mkconst('_bottom_const', np.array([0, 0, 1, 0]))

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -1157,22 +1157,28 @@ class IsNan:
 class BatchToSpace:
     @classmethod
     def version_1(cls, ctx, node, **kwargs):
-        # https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/batch-to-space-n-d.html
-        # the above link says the data format of input tensor should be (batch, spatial_shape, remaining_shape)
-        # and we only support 3D and 4D here, and the data format is NHC and NHWC
-        # onnx op "DepthToSpace" does the same work on input tensor except that it works on "C",
-        # and it only supports NCHW
-        # T out = BatchToSpaceND(T input, int32 block_shape, int32 crops)
-        if ctx.opset <= 10 or (node.inputs[1].is_const() and node.inputs[2].is_const()):
+        # block_shape impacts Transpose 'perm' attribute values.
+        # must be available at compile time
+        utils.make_sure(node.inputs[1].is_const(), 'only support constant block_shape value.')
+
+        block_shape = node.inputs[1].get_tensor_value(False)
+        blocklen = len(block_shape)
+        xlen = len(ctx.get_shape(node.input[0]))
+
+        # if 4d tensor & square 2d block_shape , can optimize
+        cond1 = xlen == 4
+        cond2 = node.inputs[2].is_const()
+        cond3 = blocklen == 2 and block_shape[0] == block_shape[1]
+        if cond1 and cond2 and cond3:
+            # https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/batch-to-space-n-d.html
+            # the above link says the data format of input tensor should be (batch, spatial_shape, remaining_shape)
+            # and we only support 3D and 4D here, and the data format is NHC and NHWC
+            # onnx op "DepthToSpace" does the same work on input tensor except that it works on "C",
+            # and it only supports NCHW
+            # T out = BatchToSpaceND(T input, int32 block_shape, int32 crops)
             input_tensor = node.inputs[0]
             input_shape = ctx.get_shape(input_tensor.output[0])
-            blocksize = node.inputs[1].get_tensor_value()
             crops = node.inputs[2].get_tensor_value()
-
-            utils.make_sure(len(input_shape) in (4, 3),
-                            "only supports 3D and 4D for now")
-            utils.make_sure(len(blocksize) == 2 and blocksize[0] == blocksize[1],
-                            "only support same blocksize at different dims")
 
             # NHWC TO CNHW, so onnx op will work on "N" which is the same as tensorflow
             if len(input_shape) == 3:
@@ -1181,7 +1187,7 @@ class BatchToSpace:
                 trans1 = ctx.make_node("Transpose", unsqz1.output, {"perm": [3, 0, 1, 2]})
             else:
                 trans1 = ctx.make_node("Transpose", input_tensor.output, {"perm": [3, 0, 1, 2]})
-            reorganize_node = ctx.make_node(node.type, trans1.output, attr={"blocksize": blocksize[0]})
+            reorganize_node = ctx.make_node(node.type, trans1.output, attr={"blocksize": block_shape[0]})
             trans2 = ctx.make_node("Transpose", reorganize_node.output, {"perm": [1, 2, 3, 0]})
 
             # implement crop logic, the data format is NHWC
@@ -1213,87 +1219,109 @@ class BatchToSpace:
                 ctx.remove_node(node.name)
                 GraphBuilder(ctx).make_slice(kwargs, name=node.name, dtypes=dtypes, shapes=shapes)
         else:
-            """
-            1. Reshape input to reshaped of shape:
-                [block_shape[0], ...,
-                block_shape[M-1], batch / prod(block_shape),
-                input_shape[1], ..., input_shape[N-1]]
-            2. Permute dimensions of reshaped to produce permuted of shape:
-                [batch / prod(block_shape),input_shape[1],
-                block_shape[0], ..., input_shape[M],
-                block_shape[M-1],input_shape[M+1], ...,
-                input_shape[N-1]]
-            3. Reshape permuted to produce reshaped_permuted of shape:
-                [batch / prod(block_shape),
-                input_shape[1] * block_shape[0], ...,
-                input_shape[M] * block_shape[M-1],
-                input_shape[M+1], ..., input_shape[N-1]]
-            4. Crop the start and end of dimensions [1, ..., M] of reshaped_permuted
-                according to crops to produce the output of shape:
-                [batch / prod(block_shape),
-                input_shape[1] * block_shape[0] - crops[0,0] - crops[0,1], ...,
-                input_shape[M] * block_shape[M-1] - crops[M-1,0] - crops[M-1,1],
-                input_shape[M+1], ..., input_shape[N-1]]
-            """
-            input_x = node.inputs[0]
-            block_shape = ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=TensorProto.INT64)
-            crop = ctx.insert_new_node_on_input(node, "Cast", node.input[2], to=TensorProto.INT64)
-            shape_x = ctx.make_node("Shape", [input_x.output[0]])
-            block_size = GraphBuilder(ctx).make_slice({"data": block_shape.output[0], "ends": [1], "starts": [0]})
-            block_prod = ctx.make_node("Mul", [block_size, block_size])
-            const_one = ctx.make_const(utils.make_name(node.name + "_const_one"), np.array([1], dtype=np.int64))
-            const_zero_three = ctx.make_const(utils.make_name(node.name + "_const_zero_three"),
-                                              np.array([0, 3], dtype=np.int64))
-            padded_block_prod = ctx.make_node("Pad",
-                                              [block_prod.output[0], const_zero_three.output[0], const_one.output[0]])
-            new_shape_x = ctx.make_node("Div", [shape_x.output[0], padded_block_prod.output[0]])
-            concat_new_shape_x = ctx.make_node("Concat", [block_shape.output[0], new_shape_x.output[0]], {"axis": 0})
-            reshaped_x = ctx.make_node("Reshape", [input_x.output[0], concat_new_shape_x.output[0]])
-            transposed_x = ctx.make_node("Transpose", [reshaped_x.output[0]], {"perm": [2, 3, 0, 4, 1, 5]})
-            const_one_one = ctx.make_const(utils.make_name(node.name + "_const_one_one"),
-                                           np.array([1, 1], dtype=np.int64))
-            padded_block_shape = ctx.make_node("Pad",
-                                               [block_shape.output[0], const_one_one.output[0], const_one.output[0]])
-            new_shape_x_v2 = ctx.make_node("Mul", [new_shape_x.output[0], padded_block_shape.output[0]])
-            reshaped_x_v2 = ctx.make_node("Reshape", [transposed_x.output[0], new_shape_x_v2.output[0]])
-            transposed_crop = ctx.make_node("Transpose", [crop.output[0]], {"perm": [1, 0]})
-            const_two = ctx.make_const(utils.make_name(node.name + "_const_two"), np.array([2], dtype=np.int64))
-            const_one_two = ctx.make_const(utils.make_name(node.name + "const_one_two"),
-                                           np.array([1, 2], dtype=np.int64))
-            slice_crop_starts = GraphBuilder(ctx).make_slice(
-                {"data": transposed_crop.output[0], "ends": [1, 2], "starts": [0, 0]})
-            reshaped_slice_crop_starts = ctx.make_node("Reshape", [slice_crop_starts, const_two.output[0]])
-            slice_crop_ends = GraphBuilder(ctx).make_slice(
-                {"data": transposed_crop.output[0], "ends": [2, 2], "starts": [1, 0]})
-            reshaped_slice_crop_ends = ctx.make_node("Reshape", [slice_crop_ends, const_two.output[0]])
-            sliced_new_shape_x_v2 = GraphBuilder(ctx).make_slice(
-                {"data": new_shape_x_v2.output[0], "ends": [3], "starts": [1]})
-            neged_reshaped_slice_crop_ends = ctx.make_node("Sub",
-                                                           [sliced_new_shape_x_v2, reshaped_slice_crop_ends.output[0]])
+            def mknode(optype, inputs, attrs=None):
+                nodename = utils.make_name(node.name + '_' + optype.lower())
+                return ctx.make_node(optype, inputs, attrs, name=nodename)
+
+            def mkconst(desc, val, dtype=np.int64):
+                nodename = utils.make_name(node.name + '_' + desc)
+                const_node = ctx.make_const(utils.make_name(nodename), val.astype(dtype))
+                return const_node.output[0]
+
+            # support non 4D tensors and dynamic crop vals
+            # dynamic slice starts at opset 10
+            utils.make_sure(ctx.opset >= 10, 'not-4D tensor or non-const pads require opset 10+')
+
+            input0 = node.input[0]
+            input2 = node.input[2]
+            int_max_const = mkconst('int_max', np.array([utils.get_max_value(np.int64)]))
+            one_const = mkconst('_const_one', np.array([1]))
+            minus1_const = mkconst('_const_minus1', np.array([-1]))
+            blocklen_resize_const = mkconst('_const_blocklen_resize', np.array([-1, blocklen]))
+
+            blocklenplus1_const = mkconst('_const_blocklenplus1', np.array([blocklen + 1]))
+            block_shape_const = mkconst('_const_block_shape', block_shape)
+
+            x_shape = ctx.insert_new_node_on_input(node, 'Shape', node.input[0])
+
+            # get the spatial and depth (i.e remaining) dimensions
+            # compute target spatial dimensions by multiplying block_shape
+            spatial = mknode('Slice', [x_shape.output[0], one_const, blocklenplus1_const])
+            depth = mknode('Slice', [x_shape.output[0], blocklenplus1_const, int_max_const])
+            target_spatial = mknode('Mul', [spatial.output[0], block_shape_const])
+
+            # shape to use before shuffle  (part 1)
+            ccat1 = mknode('Concat', [spatial.output[0], block_shape_const], {'axis': 0})
+            re1 = mknode('Reshape', [ccat1.output[0], blocklen_resize_const])
+            tr1 = mknode('Transpose', [re1.output[0]])
+            interleave = mknode('Reshape', [tr1.output[0], minus1_const])
+            shape1 = mknode('Concat', [minus1_const, interleave.output[0], depth.output[0]], {'axis': 0})
+
+            # shape to use before shuffle (part 2)
+            g1 = list(range(2, 2 * blocklen + 1, 2))
+            g2 = list(range(1, 2 * blocklen + 1, 2))
+            g = g1 + [0] + g2 + list(range(0, xlen + blocklen)[1 + 2 * blocklen:])
+
+            # permutation values for shuffling
+            p = np.asarray(range(0, xlen + blocklen))
+            p[0] = blocklen
+            p[1] = blocklen + 1
+            p[2] = 0
+            for i in range(3, blocklen * 2 + 1):
+                p[i] = p[i - 2] + 1
+
+            # reshape to create moving blocks, shuffle, and reshape to target_spatial
+            indices = mkconst('_indicies_const', np.asarray(g))
+            gather = mknode('Gather', [shape1.output[0], indices])
+            x2 = mknode('Reshape', [input0, gather.output[0]])
+            trans2 = mknode('Transpose', [x2.output[0]], {'perm': np.array(p)})
+            shape2 = mknode('Concat', [minus1_const, target_spatial.output[0], depth.output[0]], {'axis': 0})
+            x3 = mknode('Reshape', [trans2.output[0], shape2.output[0]])
+
+            # crop axes
+            slice_starts_const1 = mkconst('_slicestart1_const', np.asarray([0, 0]))
+            slice_starts_const2 = mkconst('_slicestart2_const', np.asarray([1, utils.get_max_value(np.int64)]))
+            slice_ends_const1 = mkconst('_sliceend1_const', np.asarray([1, 0]))
+            slice_ends_const2 = mkconst('_sliceend2_const', np.asarray([2, utils.get_max_value(np.int64)]))
+            axes_const = mkconst('_sliceaxes_const', np.asarray(range(1, blocklen + 1)))
+            crop = mknode('Cast', [input2], {'to': TensorProto.INT64})
+            crop_transposed = mknode('Transpose', [crop.output[0]])
+            crop_starts = mknode('Slice', [crop_transposed.output[0], slice_starts_const1, slice_starts_const2])
+            crop_ends = mknode('Slice', [crop_transposed.output[0], slice_ends_const1, slice_ends_const2])
+            crop_starts_squeeze = mknode('Squeeze', [crop_starts.output[0]], {'axes': [0]})
+            crop_ends_squeeze = mknode('Squeeze', [crop_ends.output[0]], {'axes': [0]})
+            end_range = mknode('Sub', [target_spatial.output[0], crop_ends_squeeze.output[0]])
+            orig_shape = node.output_shapes
+            orig_dtypes = node.output_dtypes
             ctx.remove_node(node.name)
-            ctx.make_node("Slice", [reshaped_x_v2.output[0], reshaped_slice_crop_starts.output[0],
-                                    neged_reshaped_slice_crop_ends.output[0], const_one_two.output[0]],
-                          name=node.name, outputs=node.output)
+            ctx.make_node('Slice', [x3.output[0], crop_starts_squeeze.output[0], end_range.output[0], axes_const],
+                          name=node.name, outputs=node.output, shapes=orig_shape, dtypes=orig_dtypes)
 
 
 @tf_op("SpaceToBatchND", onnx_op="SpaceToDepth")
 class SpaceToBatch:
     @classmethod
     def version_1(cls, ctx, node, **kwargs):
-        # https://www.tensorflow.org/api_docs/python/tf/space_to_batch_nd
-        # the above link says the data format of input tensor should be (batch, spatial_shape, remaining_shape)
-        # and we only support 4D here, so the data format is NHWC
-        # onnx op "SpaceToDepth" does the same work on input tensor except that it works on "C",
-        # and it only supports NCHW
-        # T out = SpaceToBatchND(T input, int32 block_shape, int32 crops)
-        if ctx.opset <= 10 or (node.inputs[1].is_const() and node.inputs[2].is_const()):
+        # block_shape impacts Transpose 'perm' attribute values.
+        # must be available at compile time
+        utils.make_sure(node.inputs[1].is_const(), 'only support constant block_shape value.')
+
+        block_shape = node.inputs[1].get_tensor_value(False)
+        blocklen = len(block_shape)
+        xlen = len(ctx.get_shape(node.input[0]))
+
+        # if 4d tensor & square 2d block_shape , can optimize
+        cond1 = xlen == 4
+        cond2 = node.inputs[2].is_const()
+        cond3 = blocklen == 2 and block_shape[0] == block_shape[1]
+        if cond1 and cond2 and cond3:
+            # https://www.tensorflow.org/api_docs/python/tf/space_to_batch_nd
+            # the above link says the data format of input tensor should be (batch, spatial_shape, remaining_shape)
+            # and we only support 4D here, so the data format is NHWC
+            # onnx op "SpaceToDepth" does the same work on input tensor except that it works on "C",
+            # and it only supports NCHW
+            # T out = SpaceToBatchND(T input, int32 block_shape, int32 crops)
             input_tensor = node.inputs[0]
-            blocksize = node.inputs[1].get_tensor_value()
-
-            utils.make_sure(len(ctx.get_shape(input_tensor.output[0])) == 4, "only supports 4D for now")
-            utils.make_sure(len(blocksize) == 2 and blocksize[0] == blocksize[1],
-                            "only support same blocksize at different dims")
-
             shapes = [ctx.get_shape(node.output[0])]
             dtypes = [ctx.get_dtype(node.output[0])]
 
@@ -1314,72 +1342,81 @@ class SpaceToBatch:
 
             # NHWC TO CNHW, so onnx op will work on "N" which is the same as tensorflow
             trans1 = ctx.make_node("Transpose", pad_op.output, {"perm": [3, 0, 1, 2]})
-            reorganize_node = ctx.make_node(node.type, trans1.output, attr={"blocksize": blocksize[0]})
+            reorganize_node = ctx.make_node(node.type, trans1.output, attr={"blocksize": block_shape[0]})
             ctx.make_node("Transpose", reorganize_node.output, {"perm": [1, 2, 3, 0]},
                           name=node.name, outputs=node.output, shapes=shapes, dtypes=dtypes)
         else:
-            """
-            1. Zero-pad the start and end of dimensions [1, ..., M] of the input
-                according to paddings to produce padded of shape padded_shape.
-            2. Reshape padded to reshaped_padded of shape:
-                [batch] + [padded_shape[1] / block_shape[0],
-                block_shape[0], ..., padded_shape[M] / block_shape[M-1],
-                block_shape[M-1]] + remaining_shape
-            3. Permute dimensions of reshaped_padded to produce permuted_reshaped_padded of shape:
-                block_shape + [batch] + [padded_shape[1] / block_shape[0], ...,
-                padded_shape[M] / block_shape[M-1]] + remaining_shape
-            4. Reshape permuted_reshaped_padded to flatten block_shape into the batch dimension,
-                producing an output tensor of shape:
-                [batch * prod(block_shape)] + [padded_shape[1] / block_shape[0], ...,
-                padded_shape[M] / block_shape[M-1]] + remaining_shape
-            """
-            input_x = node.inputs[0]
-            block_shape = ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=TensorProto.INT64)
-            pad_x = ctx.insert_new_node_on_input(node, "Cast", node.input[2], to=TensorProto.INT64)
-            const_zero_zero = ctx.make_const(utils.make_name(node.name + "_const_zero_zero"),
-                                             np.array([[0, 0]], dtype=np.int64))
-            concated_pad_x = ctx.make_node("Concat", [const_zero_zero.output[0], pad_x.output[0]], {"axis": 0})
-            concated_pad_x_v2 = ctx.make_node("Concat", [concated_pad_x.output[0], const_zero_zero.output[0]],
-                                              {"axis": 0})
-            transposed_concated_pad_x_v2 = ctx.make_node("Transpose", [concated_pad_x_v2.output[0]], {"perm": [1, 0]})
-            const_eight = ctx.make_const(utils.make_name(node.name + "_const_eight"), np.array([8], dtype=np.int64))
-            reshaped_transposed_pad_x = ctx.make_node("Reshape",
-                                                      [transposed_concated_pad_x_v2.output[0], const_eight.output[0]])
-            padded_input_x = ctx.make_node("Pad", [input_x.output[0], reshaped_transposed_pad_x.output[0]])
-            const_one = ctx.make_const(utils.make_name(node.name + "_const_one"), np.array([1], dtype=np.int64))
-            const_one_one = ctx.make_const(utils.make_name(node.name + "_const_one_one"),
-                                           np.array([1, 1], dtype=np.int64))
-            padded_block_shape = ctx.make_node("Pad",
-                                               [block_shape.output[0], const_one_one.output[0], const_one.output[0]])
-            shape_x = ctx.make_node("Shape", [padded_input_x.output[0]])
-            new_shape_x = ctx.make_node("Div", [shape_x.output[0], padded_block_shape.output[0]])
-            first_row_new_shape_x = GraphBuilder(ctx).make_slice(
-                {"data": new_shape_x.output[0], "ends": [2], "starts": [0]})
-            block_size = GraphBuilder(ctx).make_slice({"data": block_shape.output[0], "ends": [1], "starts": [0]})
-            new_fisrt_row_new_shape_x = ctx.make_node("Concat", [first_row_new_shape_x, block_size], {"axis": 0})
-            second_row_new_shape_x_first_half = GraphBuilder(ctx).make_slice(
-                {"data": new_shape_x.output[0], "ends": [3], "starts": [2]})
-            second_row_new_shape_x_second_half = GraphBuilder(ctx).make_slice(
-                {"data": new_shape_x.output[0], "ends": [4], "starts": [3]})
-            new_second_row_new_shape_x_first_half = ctx.make_node("Concat",
-                                                                  [second_row_new_shape_x_first_half, block_size],
-                                                                  {"axis": 0})
-            new_second_row_new_shape_x = ctx.make_node("Concat", [new_second_row_new_shape_x_first_half.output[0],
-                                                                  second_row_new_shape_x_second_half], {"axis": 0})
-            new_shape_x_v2 = ctx.make_node("Concat",
-                                           [new_fisrt_row_new_shape_x.output[0], new_second_row_new_shape_x.output[0]],
-                                           {"axis": 0})
-            new_x = ctx.make_node("Reshape", [padded_input_x.output[0], new_shape_x_v2.output[0]])
-            transposed_new_x = ctx.make_node("Transpose", [new_x.output[0]], {"perm": [2, 4, 0, 1, 3, 5]})
-            block_size_prod = ctx.make_node("Mul", [block_size, block_size])
-            const_zero_three = ctx.make_const(utils.make_name(node.name + "_const_zero_three"),
-                                              np.array([0, 3], dtype=np.int64))
-            padded_block_size_prod = ctx.make_node("Pad", [block_size_prod.output[0], const_zero_three.output[0],
-                                                           const_one.output[0]])
-            new_shape_x_v3 = ctx.make_node("Mul", [new_shape_x.output[0], padded_block_size_prod.output[0]])
+            def mknode(optype, inputs, attrs=None):
+                nodename = utils.make_name(node.name + '_' + optype.lower())
+                return ctx.make_node(optype, inputs, attrs, name=nodename)
+
+            def mkconst(desc, val, dtype=np.int64):
+                nodename = utils.make_name(node.name + '_' + desc)
+                const_node = ctx.make_const(utils.make_name(nodename), val.astype(dtype))
+                return const_node.output[0]
+
+            # support non 4D tensors and dynamic pad vals
+            # dynamic slice starts at opset 10
+            utils.make_sure(ctx.opset >= 10, 'not-4D tensor or non-const pads require opset 10+')
+
+            input0 = node.input[0]
+            input2 = node.input[2]
+            # const vals
+            int_max_const = mkconst('int_max', np.array([utils.get_max_value(np.int64)]))
+            zero_const = mkconst('_zero_const', np.array([0]))
+            one_const = mkconst('_one_const', np.array([1]))
+            minus1_const = mkconst('_minus1_const', np.array([-1]))
+            blocklen_resize_const = mkconst('_blocklen_resize_const', np.array([-1, blocklen]))
+
+            blocklenplus1_const = mkconst('_blocklenplus1_const', np.array([blocklen + 1]))
+            filltop_const = mkconst('_filltop_const', np.array([1, 0, 0, 0]))
+            fillbottom_const = mkconst('_bottom_const', np.array([0, 0, 1, 0]))
+            block_shape_const = mkconst('_block_shape_const', block_shape)
+
+            x_shape = ctx.insert_new_node_on_input(node, 'Shape', node.input[0])
+            x_rank = mknode('Size', [x_shape.output[0]])
+
+            # pad x prior to compute
+            pad = mknode('Cast', [input2], {'to': TensorProto.INT64})
+            pad_shape = mknode('Shape', [pad.output[0]])
+            pad_rank = mknode('Slice', [pad_shape.output[0], zero_const, one_const])
+            pad_gap = mknode('Sub', [x_rank.output[0], pad_rank.output[0]])
+            gapminus1 = mknode('Sub', [pad_gap.output[0], one_const])
+            gapminus1fillbot = mknode('Mul', [fillbottom_const, gapminus1.output[0]])
+            padfilltop = mknode('Pad', [pad.output[0], filltop_const])
+            padfilltopbottom = mknode('Pad', [padfilltop.output[0], gapminus1fillbot.output[0]])
+            pad_t = mknode('Transpose', [padfilltopbottom.output[0]])
+            pad1d = mknode('Reshape', [pad_t.output[0], minus1_const])
+
+            # get the spatial and depth (i.e remaining) dimensions
+            # compute reduced spatial dimensions by dividing block_shape
+            x1 = mknode('Pad', [input0, pad1d.output[0]])
+            x1_shape = mknode('Shape', [x1.output[0]])
+            spatial = mknode('Slice', [x1_shape.output[0], one_const, blocklenplus1_const])
+            depth = mknode('Slice', [x1_shape.output[0], blocklenplus1_const, int_max_const])
+            reduced = mknode('Div', [spatial.output[0], block_shape_const])
+
+            # reshape x into smaller blocks before shuffle
+            ccat1 = mknode('Concat', [reduced.output[0], block_shape_const], {'axis': 0})
+            reshape1 = mknode('Reshape', [ccat1.output[0], blocklen_resize_const])
+            tr1 = mknode('Transpose', [reshape1.output[0]])
+            interleave = mknode('Reshape', [tr1.output[0], minus1_const])
+            shape1 = mknode('Concat', [minus1_const, interleave.output[0], depth.output[0]], {'axis': 0})
+            x2 = mknode('Reshape', [x1.output[0], shape1.output[0]])
+
+            # permutation values for shuffling
+            p1 = list(range(2, 2 * blocklen + 1, 2))
+            p2 = list(range(1, 2 * blocklen + 1, 2))
+            perm = p1 + [0] + p2 + list(range(0, xlen + blocklen)[1 + 2 * blocklen:])
+
+            tr2 = mknode('Transpose', [x2.output[0]], {'perm': perm})
+            shape2 = mknode('Concat', [minus1_const, reduced.output[0], depth.output[0]], {'axis': 0})
+            orig_shape = node.output_shapes
+            orig_dtypes = node.output_dtypes
             ctx.remove_node(node.name)
-            ctx.make_node("Reshape", [transposed_new_x.output[0], new_shape_x_v3.output[0]], name=node.name,
-                          outputs=node.output)
+            ctx.make_node('Reshape', [tr2.output[0], shape2.output[0]],
+                          name=node.name, outputs=node.output, shapes=orig_shape,
+                          dtypes=orig_dtypes)
 
 
 @tf_op("IsInf", onnx_op="IsInf")

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -174,6 +174,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             "Cast": self._simple_through_handler,
             "Clip": self._simple_through_handler,
             "Concat": self._concat_handler,
+            "Elu": self._simple_through_handler,
             "Identity": self._identity_handler,
             "LeakyRelu": self._simple_through_handler,
             "Max": self._maxmin_handler,
@@ -247,14 +248,6 @@ class TransposeOptimizer(GraphOptimizerBase):
         shape = self._g.get_shape(node.output[0])
         if shape:
             # only nhwc transpose can reach here
-            # if slicing results in non 4-D shape, we cannot infer the outputshape
-            # JRP
-            # new_shape = shape
-            # if len(shape) == len(NHWC_TO_NCHW):
-            #     new_shape = [shape[i] for i in NHWC_TO_NCHW]
-            # else:
-            #     new_shape = [-1]*len(shape)
-            #     self.logger.warning("%s's shape is unknown, which may interfere further optimization", node.output[0])
             new_shape = [shape[i] for i in NHWC_TO_NCHW]
             self._g.set_shape(node.output[0], new_shape)
         return True
@@ -526,7 +519,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             squeeze_shape = self._g.get_shape(node.output[0])
             self._g.set_shape(trans.output[0], squeeze_shape)
             input_shape = self._g.get_shape(node.input[0])
-            if input_shape is not None: # JRP and len(input_shape) == 4:
+            if input_shape is not None:
                 new_squeeze_output_shape = [input_shape[i] for i in range(4) if i not in new_squeeze_axes]
             else:
                 new_squeeze_output_shape = [-1] * 4
@@ -576,9 +569,6 @@ class TransposeOptimizer(GraphOptimizerBase):
         else:  # in opset 10, axes is input instead of an attribute.
             if len(node.inputs) >= 4 and node.inputs[3].is_const():
                 axes = node.inputs[3].get_tensor_value(as_list=True)
-                # JRP
-                #shape = self._g.get_shape(node.output[0])
-                #if axes == [0, 1, 2, 3] and len(shape) == 4:
                 if axes == [0, 1, 2, 3]:
                     # axes node might be shared
                     new_axes = np.array(NCHW_TO_NHWC, dtype=np.int64)


### PR DESCRIPTION
Fix BatchToSpaceND and SpaceToBatchND to support >4D tensors, as well as dynamic block_shape values and dynamic paddings/crop values.