### PR TITLE
Fix strided slice, reverse stride with unbounded begin and end

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1788,6 +1788,32 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
 
     @check_opset_min_version(10, "Slice")
+    def test_strided_slice_reverse_1(self):
+        tf.reset_default_graph()
+        x_val = np.arange(16 * 32).astype(np.float32).reshape((1, 16, 32, 1))
+        def func(x):
+            return tf.concat([x[:, :, :10], x[:, :, :21:-1]], axis=0, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
+
+    @check_opset_min_version(10, "Slice")
+    def test_strided_slice_reverse_2(self):
+        tf.reset_default_graph()
+        x_val = np.arange(16 * 32).astype(np.float32).reshape((1, 16, 32, 1))
+        def func(x):
+            return tf.concat([x[:, :, :10], x[:, :, 9::-1]], axis=0, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
+
+    @check_opset_min_version(10, "Slice")
+    def test_strided_slice_reverse_3(self):
+        tf.reset_default_graph()
+        x_val = np.zeros((1, 16, 32, 1)).astype(np.float32)
+        y_val = np.array(9).astype(np.int32)
+        z_val = np.array(-1).astype(np.int32)
+        def func(x, y, z):
+            return tf.concat([x[:, :, :10], x[:, :, y::z]], axis=0, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val, _INPUT2: z_val})
+
+    @check_opset_min_version(10, "Slice")
     def test_new_axis_mask(self):
         def func(x, y):
             x_ = x[tf.newaxis, 0:y, y::2, tf.newaxis, :, tf.newaxis, :y, tf.newaxis, ..., 9]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1789,7 +1789,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @check_opset_min_version(10, "Slice")
     def test_strided_slice_reverse_1(self):
-        tf.reset_default_graph()
         x_val = np.arange(16 * 32).astype(np.float32).reshape((1, 16, 32, 1))
         def func(x):
             return tf.concat([x[:, :, :10], x[:, :, :21:-1]], axis=0, name=_TFOUTPUT)
@@ -1797,7 +1796,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @check_opset_min_version(10, "Slice")
     def test_strided_slice_reverse_2(self):
-        tf.reset_default_graph()
         x_val = np.arange(16 * 32).astype(np.float32).reshape((1, 16, 32, 1))
         def func(x):
             return tf.concat([x[:, :, :10], x[:, :, 9::-1]], axis=0, name=_TFOUTPUT)
@@ -1805,7 +1803,6 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @check_opset_min_version(10, "Slice")
     def test_strided_slice_reverse_3(self):
-        tf.reset_default_graph()
         x_val = np.zeros((1, 16, 32, 1)).astype(np.float32)
         y_val = np.array(9).astype(np.int32)
         z_val = np.array(-1).astype(np.int32)

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -97,8 +97,8 @@ def make_min_or_max_op(ctx, op_type, inputs, outputs,
         ctx.set_dtype(cast_node.output[0], origin_dtype)
         ctx.copy_shape(node.output[0], cast_node.output[0])
         actual_outputs = cast_node.output
-    ctx.make_node("Identity", actual_outputs, outputs=outputs,
-                  shapes=output_shapes, dtypes=output_dtypes)
+    final_node = ctx.make_node("Identity", actual_outputs, outputs=outputs,
+                               shapes=output_shapes, dtypes=output_dtypes)
 
     # tensorflow minimum/maximum does support broadcast, onnx < opset 8 does not.
     # handle this by doing something like:
@@ -124,6 +124,7 @@ def make_min_or_max_op(ctx, op_type, inputs, outputs,
             add_node = ctx.make_node("Add", [input_node.output[0], sub_node.output[0]],
                                      op_name_scope=input_node.name)
             node.input[i] = add_node.output[0]
+    return final_node
 
 
 @tf_op("Minimum", onnx_op="Min")

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -846,10 +846,8 @@ class StridedSlice:
         new_begin_mask = np.array(new_begin_mask, dtype=np_dtype)
         if not np.all(new_begin_mask == 1):
             if begin.is_const() and strides.is_const():
-                begin_vals = begin.get_tensor_value(as_list=False)
-                strides_vals = strides.get_tensor_value(as_list=False)
-                new_begin_vals = np.copy(begin_vals)
-                for i, v in enumerate(strides_vals):
+                new_begin_vals = np.copy(begin.get_tensor_value(as_list=False))
+                for i, v in enumerate(strides.get_tensor_value(as_list=False)):
                     if v < 0 and new_begin_mask[i] == 0:
                         new_begin_vals[i] = max_size
                 begin = ctx.make_const(utils.make_name("begin_masked"), new_begin_vals)


### PR DESCRIPTION
Fixes #810 

The current implementation of strided slice ignored the direction of the slice (i.e. backward or forward) when setting values for unbounded 'begins' or 'ends'. The values need to be reversed if slice direction is backwards.