### PR TITLE
prevent multi-transpose on pad

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -136,7 +136,7 @@ class Node(object):
     def data_format(self):
         """Return data_format."""
         attr_str = self.get_attr_value("data_format")
-        return "unkown" if attr_str == None else attr_str.decode("utf-8")
+        return "unkown" if attr_str is None else attr_str.decode("utf-8")
 
     @data_format.setter
     def data_format(self, val):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -135,7 +135,8 @@ class Node(object):
     @property
     def data_format(self):
         """Return data_format."""
-        return self.get_attr_str("data_format")
+        attr_str = self.get_attr_value("data_format")
+        return "unkown" if attr_str == None else attr_str.decode("utf-8")
 
     @data_format.setter
     def data_format(self, val):

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -556,12 +556,14 @@ class TransposeOptimizer(GraphOptimizerBase):
             new_pads = [pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]]
             node.set_attr("pads", new_pads)
             return self._switch_transpose_and_node(node, trans)
-        if node.inputs[1].is_const() and self._nodes_has_single_consumer_node([node.inputs[1]]):
-            pads = node.inputs[1].get_tensor_value()
-            # NHWC->NCHW
-            new_pads = np.array([pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]],
-                                dtype=np.int64)
-            node.inputs[1].set_tensor_value(new_pads)
+        if node.inputs[1].is_const():
+            if node.inputs[1].data_format in ["NHWC", "unkown"]:
+                pads = node.inputs[1].get_tensor_value()
+                # NHWC->NCHW
+                new_pads = np.array([pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]],
+                                    dtype=np.int64)
+                node.inputs[1].set_tensor_value(new_pads)
+                node.inputs[1].data_format = "NCHW"
             return self._switch_transpose_and_node(node, trans)
         return False
 

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -556,7 +556,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             new_pads = [pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]]
             node.set_attr("pads", new_pads)
             return self._switch_transpose_and_node(node, trans)
-        if node.inputs[1].is_const():
+        if node.inputs[1].is_const() and self._nodes_has_single_consumer_node([node.inputs[1]]):
             pads = node.inputs[1].get_tensor_value()
             # NHWC->NCHW
             new_pads = np.array([pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]],


### PR DESCRIPTION
Fixing issue:
https://github.com/onnx/tensorflow-onnx/issues/824
When const perm tensor getting consumed by multiple pad op, it gets transposed over and over again, finally go back to its starting value. 