### PR TITLE
Fix onehot operator opset 9 for all data types

### DIFF
--- a/tf2onnx/version.py
+++ b/tf2onnx/version.py
@@ -1,2 +1,3 @@
+
 version = '1.6.0'
-git_version = '82f805f8fe7d2fa91e6ca9d39e153712f6887fec'
+git_version = 'fdabeea6600f5c793a439ae54d138e7d325b5bf2'


### PR DESCRIPTION
Onehot operator in opset version 9 supports data types other than int