### PR TITLE
Add support for crop_and_resize for opset 10.

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,3 +1,4 @@
+
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
@@ -2453,6 +2454,19 @@ class BackendTests(Tf2OnnxBackendTestBase):
                     y = tf.constant(dtype=y_type, value=y_val, shape=y_val.shape, name=_TFINPUT1)
                     return space_to_batch_nd(x, y, z, name=_TFOUTPUT)
                 self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT2: z_val})
+
+    @check_opset_min_version(10, "CropAndResize")
+    def test_crop_and_resize(self):
+        boxes_val = [[0.5, 0.7, 0.7, 0.9], [0.2, 0.4, 0.4, 0.6]]
+        def func(input_x, box_ind):
+            boxes = tf.constant(boxes_val, dtype=tf.float32)
+            corp_size = tf.constant(np.array([20, 20]).astype(np.int32))
+            return tf.image.crop_and_resize(input_x, boxes, box_ind, corp_size, name=_TFOUTPUT, method='bilinear')
+
+        input_x_val = np.random.randint(low=0, high=256, size=[2, 36, 36, 3]).astype(np.float32)  # NHWC
+        box_ind_val = np.array([1, 0]).astype(np.int32)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: input_x_val, _INPUT2: box_ind_val},
+                            rtol=1e-04, atol=1e-03)
 
     @check_opset_min_version(11, "CropAndResize")
     def test_crop_and_resize_linear(self):


### PR DESCRIPTION
Support for Crop and resize for opset 10 is implemented if its inputs boxes and crop_size are Constant. 
Currently only opset 11 is supported. If this version is also added to master, it will be helpful. 
Thanks.