### PR TITLE
cherry pick fix to set IR based on opset

### DIFF
--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -40,5 +40,5 @@ ENV_TF2ONNX_DEBUG_MODE = "TF2ONNX_DEBUG_MODE"
 
 # Mapping opset to IR version.
 OPSET_TO_IR_VERSION = {
-    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 3, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7
+    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7
 }

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -37,3 +37,8 @@ NCHW_TO_HWCN = [2, 3, 1, 0]
 
 # Environment variables
 ENV_TF2ONNX_DEBUG_MODE = "TF2ONNX_DEBUG_MODE"
+
+# Mapping opset to IR version.
+OPSET_TO_IR_VERSION = {
+    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 3, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7
+}

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -990,6 +990,12 @@ class Graph(object):
             kwargs["opset_imports"] = opsets
         model_proto = helper.make_model(graph, **kwargs)
 
+        # set the IR version based on opset
+        try:
+            model_proto.ir_version = constants.OPSET_TO_IR_VERSION.get(self.opset, model_proto.ir_version)
+        except: # pylint: disable=bare-except
+            logger.error("ir_version override failed - install the latest onnx version")
+
         # optimize the model proto.
         # TODO: this is disabled by default because of bugs in fuse_consecutive_transposes
         if optimize:


### PR DESCRIPTION
this prevents that the converter will write onnx files with IR7 when onnx-1.7 comes out. Same change is in master.