### PR TITLE
allow negative axis

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2376,6 +2376,38 @@ class BackendTests(Tf2OnnxBackendTestBase):
             return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
         self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
 
+    @check_opset_min_version(11, "ReduceMin")
+    def test_reduce_all_negative_axis(self):
+        input_val = np.random.randint(0, 2, (10, 20)).astype(np.bool)
+        def func(x):
+            res = tf.reduce_all(input_tensor=x, keepdims=False)
+            res1 = tf.reduce_all(input_tensor=x, axis=[-1], keepdims=False)
+            return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
+        self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
+
+        input_val = np.random.randint(0, 2, (10, 20)).astype(np.bool)
+        def func(input_x):
+            res = tf.reduce_all(input_tensor=input_x, keepdims=True)
+            res1 = tf.reduce_all(input_tensor=input_x, axis=[-1], keepdims=True)
+            return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
+        self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
+
+    @check_opset_min_version(11, "ReduceSums")
+    def test_reduce_any_negative_axis(self):
+        input_val = np.random.randint(0, 2, (10, 20)).astype(np.bool)
+        def func(x):
+            res = tf.reduce_any(input_tensor=x, keepdims=False)
+            res1 = tf.reduce_any(input_tensor=x, axis=[-1], keepdims=False)
+            return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
+        self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
+
+        input_val = np.random.randint(0, 2, (10, 20)).astype(np.bool)
+        def func(x):
+            res = tf.reduce_any(input_tensor=x, keepdims=True)
+            res1 = tf.reduce_any(input_tensor=x, axis=[-1], keepdims=True)
+            return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
+        self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
+
     @check_opset_min_version(7, "fill")
     def test_zeros_like(self):
         input_val = np.random.random_sample([10, 20]).astype(np.float32)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2392,7 +2392,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             return tf.identity(res, name=_TFOUTPUT), tf.identity(res1, name=_TFOUTPUT1)
         self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: input_val})
 
-    @check_opset_min_version(11, "ReduceSums")
+    @check_opset_min_version(11, "ReduceSum")
     def test_reduce_any_negative_axis(self):
         input_val = np.random.randint(0, 2, (10, 20)).astype(np.bool)
         def func(x):

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -102,7 +102,8 @@ class AllAny:
         if np.isscalar(reduce_dim):
             reduce_dim = [reduce_dim]
 
-        utils.make_sure(all(i >= 0 for i in reduce_dim), "negative reduce axis is not supported in onnx for now")
+        if ctx.opset < 11:
+            utils.make_sure(all(i >= 0 for i in reduce_dim), "negative reduce axis is not supported in onnx for now")
 
         cast = ctx.make_node(op_type="Cast", inputs=[node.input[0]], attr={"to": onnx_pb.TensorProto.FLOAT})
         keepdims = helper.get_attribute_value(node.get_attr("keep_dims"))


### PR DESCRIPTION
Allow negative axis for ReduceSum and ReduceMin.
The fix is required for converting office intent search model.