### PR TITLE
use same opset->ir mapping as in r1.5 branch

### DIFF
--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -6,7 +6,7 @@ parameters:
   tf_versions: ['']
   onnx_versions: ['']
   onnx_opsets: ['11', '10', '9', '8', '7']
-  onnx_backends: {onnxruntime: ['1.1.0']}
+  onnx_backends: {onnxruntime: ['1.2.0']}
   job: {}
   run_setup: 'True'
   report_coverage: 'False'

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 from onnx import helper, TensorProto, OperatorSetIdProto
-from tf2onnx import utils
+from tf2onnx import utils, constants
 from tf2onnx.graph import GraphUtil
 from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main, group_nodes_by_type, check_opset_min_version, check_opset_max_version
@@ -69,8 +69,11 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
     def make_model(self, graph, producer_name="onnx-tests"):
         imp = OperatorSetIdProto()
         imp.version = self.config.opset
-
         model_proto = helper.make_model(graph, producer_name=producer_name, opset_imports=[imp])
+        try:
+            model_proto.ir_version = constants.OPSET_TO_IR_VERSION.get(self.config.opset, model_proto.ir_version)
+        except:  # pylint: disable=bare-except
+            pass
         return model_proto
 
     # Tranpose Optimizer Tests Start

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -39,7 +39,7 @@ NCHW_TO_HWCN = [2, 3, 1, 0]
 ENV_TF2ONNX_DEBUG_MODE = "TF2ONNX_DEBUG_MODE"
 
 # Mapping opset to IR version.
-# When adding here, make sure that the IR changes don't impact that we do.
+# Note: opset 7 and opset 8 came out with IR3 but we need IR4 because of PlaceholderWithDefault
 OPSET_TO_IR_VERSION = {
-    1: 3, 2: 3, 3: 3, 4: 4, 5: 3, 6: 3, 7: 3, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7
+    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7
 }


### PR DESCRIPTION
- use same opset->ir mapping as in r1.5 branch
- fix optimizer ut (they call helper.make_model directly and need to know about  opset->ir
- use onnxruntime-1.2