### PR TITLE
Fix Transpose + Pad handler, for Keras app MobilenetV2 model

### DIFF
--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -20,7 +20,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['windows']
-    tf_versions: ['1.14.0']
+    tf_versions: ['1.14.0', '2.1.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -20,7 +20,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['windows']
-    tf_versions: ['1.14.0', '2.1.0']
+    tf_versions: ['1.14.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/tests/run_pretrained_models.yaml
+++ b/tests/run_pretrained_models.yaml
@@ -403,3 +403,15 @@ keras_resnet50:
     "input_1:0": [1, 224, 224, 3]
   outputs:
     - Identity:0
+
+keras_mobilenet_v2:
+  tf_min_version: 2.1
+  disabled: false
+  url: module://tensorflow.keras.applications.mobilenet_v2/MobileNetV2
+  model: MobileNetV2
+  model_type: keras
+  input_get: get_ramp
+  inputs:
+    "input_1:0": [1, 224, 224, 3]
+  outputs:
+    - Identity:0

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -505,7 +505,7 @@ class Graph(object):
         return node
 
     def copy_const(self, node, name=None):
-        """Copy a const node, using name is specified"""
+        """Copy a const node, using name if specified"""
         # TODO: support attr copy starting opset 12
         if name is None:
             name = utils.make_name(node.name)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -504,6 +504,13 @@ class Graph(object):
         self.set_dtype(name, utils.map_numpy_to_onnx_dtype(np_val.dtype))
         return node
 
+    def copy_const(self, node, name=None):
+        """Copy a const node, using name is specified"""
+        # TODO: support attr copy starting opset 12
+        if name is None:
+            name = utils.make_name(node.name)
+        return self.make_const(name, node.get_tensor_value(as_list=False))
+
     def make_node(self, op_type, inputs, attr=None, output_count=1, outputs=None, skip_conversion=True,
                   op_name_scope=None, name=None, shapes=None, dtypes=None, domain=constants.ONNX_DOMAIN,
                   infer_shape_dtype=True):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -506,7 +506,7 @@ class Graph(object):
 
     def copy_const(self, node, name=None):
         """Copy a const node, using name if specified"""
-        # TODO: support attr copy starting opset 12
+        # TODO: support attr copy starting at opset 12
         if name is None:
             name = utils.make_name(node.name)
         return self.make_const(name, node.get_tensor_value(as_list=False))

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -607,8 +607,8 @@ class TransposeOptimizer(GraphOptimizerBase):
         if input1.is_const():
             if input1.data_format in ["NHWC", "unkown"]:
                 if not self._nodes_has_single_consumer_node([input1]):
-                    input1 = self.g.copy_const(input1)
-                    self.input[1] = input1.output[0]
+                    input1 = self._g.copy_const(input1)
+                    node.input[1] = input1.output[0]
                 pads = input1.get_tensor_value()
                 # NHWC->NCHW
                 new_pads = np.array([pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]],

--- a/tf2onnx/tf_loader.py
+++ b/tf2onnx/tf_loader.py
@@ -260,6 +260,7 @@ def from_keras(model_path, input_names, output_names):
     # Handles Keras when Eager mode is enabled.
     custom_objects = None
     if context.executing_eagerly():
+        _keras.backend.clear_session()
         _keras.backend.set_learning_phase(False)
         keras_model = _keras.models.load_model(model_path, custom_objects)
 


### PR DESCRIPTION
Fix pad handler to create a copy of input Const node before modifying padding values.

Const nodes may be shared with several other downstream ops, and if so, we cannot modify pad values in that node -- we should create a copy of the node first.