### PR TITLE
Add stacked LSTM support

### DIFF
--- a/tests/test_stacked_lstm.py
+++ b/tests/test_stacked_lstm.py
@@ -5,9 +5,13 @@ import tensorflow as tf
 
 from tensorflow.python.ops import init_ops
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main, check_lstm_count, skip_tf2
+from common import unittest_main, check_lstm_count
 
 from tf2onnx.tf_loader import is_tf2
+
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,cell-var-from-loop
+# pylint: disable=invalid-name
 
 if is_tf2():
     LSTMCell = tf.compat.v1.nn.rnn_cell.LSTMCell
@@ -18,6 +22,7 @@ else:
     LSTMBlockCell = tf.contrib.rnn.LSTMBlockCell
     MultiRNNCell = tf.contrib.rnn.MultiRNNCell
     dynamic_rnn = tf.nn.dynamic_rnn
+
 
 class LSTMLayeredTests(Tf2OnnxBackendTestBase):
     def test_layered_lstm(self):
@@ -51,6 +56,7 @@ class LSTMLayeredTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output:0", "cell_state:0"]
         self.run_test_case(func, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06,
                            graph_validator=lambda g: check_lstm_count(g, 2))
+
 
 if __name__ == '__main__':
     unittest_main()

--- a/tests/test_stacked_lstm.py
+++ b/tests/test_stacked_lstm.py
@@ -1,0 +1,56 @@
+"""Unit Tests for layered lstm"""
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.python.ops import init_ops
+from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main, check_lstm_count, skip_tf2
+
+from tf2onnx.tf_loader import is_tf2
+
+if is_tf2():
+    LSTMCell = tf.compat.v1.nn.rnn_cell.LSTMCell
+    MultiRNNCell = tf.compat.v1.nn.rnn_cell.MultiRNNCell
+    dynamic_rnn = tf.compat.v1.nn.dynamic_rnn
+else:
+    LSTMCell = tf.contrib.rnn.LSTMCell
+    LSTMBlockCell = tf.contrib.rnn.LSTMBlockCell
+    MultiRNNCell = tf.contrib.rnn.MultiRNNCell
+    dynamic_rnn = tf.nn.dynamic_rnn
+
+class LSTMLayeredTests(Tf2OnnxBackendTestBase):
+    def test_layered_lstm(self):
+        units = 5
+        batch_size = 6
+        x_val = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]], dtype=np.float32)
+        x_val = np.stack([x_val] * batch_size)
+
+        def func(x):
+            initializer = init_ops.constant_initializer(0.5)
+            num_layers = 2
+
+            # no scope
+            def lstm_cell():
+                return LSTMCell(
+                    units,
+                    initializer=initializer,
+                    state_is_tuple=True)
+
+            stacked_lstm = MultiRNNCell(
+                [lstm_cell() for _ in range(num_layers)])
+            outputs, cell_state = dynamic_rnn(
+                stacked_lstm,
+                x,
+                dtype=tf.float32)
+            return tf.identity(outputs, name="output"), tf.identity(cell_state, name="cell_state")
+
+        input_names_with_port = ["input_1:0"]
+        feed_dict = {"input_1:0": x_val}
+
+        output_names_with_port = ["output:0", "cell_state:0"]
+        self.run_test_case(func, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06,
+                           graph_validator=lambda g: check_lstm_count(g, 2))
+
+if __name__ == '__main__':
+    unittest_main()

--- a/tests/test_stacked_lstm.py
+++ b/tests/test_stacked_lstm.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 from tensorflow.python.ops import init_ops
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main, check_lstm_count
+from common import unittest_main, check_lstm_count, check_opset_after_tf_version, skip_tf2
 
 from tf2onnx.tf_loader import is_tf2
 
@@ -25,6 +25,8 @@ else:
 
 
 class LSTMLayeredTests(Tf2OnnxBackendTestBase):
+    @check_opset_after_tf_version("1.15", 8, "might need Scan")
+    @skip_tf2()
     def test_layered_lstm(self):
         units = 5
         batch_size = 6

--- a/tf2onnx/rewriter/lstm_rewriter.py
+++ b/tf2onnx/rewriter/lstm_rewriter.py
@@ -40,14 +40,14 @@ class LSTMRewriter(LSTMRewriterBase):
             cell_match = self._match_cell(context, cell_type)
             if cell_match and len(cell_match) >= 1:
                 self.num_lstm_layers = len(cell_match)
-                logger.debug("number of lstm layers: " + str(self.num_lstm_layers))
+                logger.debug("number of LSTM layers: %s", self.num_lstm_layers)
                 for i in range(self.num_lstm_layers):
                     self.state_variable_handlers.append({
                         "ct" + str(i): (self._ct_variable_finder, self._connect_lstm_yc_to_graph, i),
                         "ht" + str(i): (self._ht_variable_finder, self._connect_lstm_yh_to_graph, i)
                     })
                     self.state_variable_handlers.append({
-                         "ct_ht" + str(i): (self._ct_ht_shared_variable_finder, self._connect_lstm_ych_to_graph, i)
+                        "ct_ht" + str(i): (self._ct_ht_shared_variable_finder, self._connect_lstm_ych_to_graph, i)
                     })
                 logger.debug("parsing unit is %s, num layers is %d", cell_type, self.num_lstm_layers)
             if cell_match:
@@ -287,9 +287,9 @@ class LSTMRewriter(LSTMRewriterBase):
     def process_var_init_nodes_per_layer(self, context, i):
         init_h_id = None
         init_c_id = None
-        if ("ct_ht" + str(i)) in context.state_variables:
+        if "ct_ht" + str(i) in context.state_variables:
             init_h_id, init_c_id = self._process_non_tuple_ch_init_nodes(context, i)
-        elif ("ct" + str(i)) in context.state_variables and ("ht" + str(i)) in context.state_variables:
+        elif "ct" + str(i) in context.state_variables and ("ht" + str(i)) in context.state_variables:
             init_h_id, init_c_id = self._process_tuple_ch_init_nodes(context, i)
         else:
             raise ValueError("no initializers, unexpected")
@@ -363,11 +363,10 @@ class LSTMRewriter(LSTMRewriterBase):
     def create_rnn_node(self, context):
         rnn_nodes = list()
         outputs = context.loop_properties.scan_outputs_exits
-        logger.debug("number of rnn node outputs:" + str(len(outputs)))
-        for i in range(len(outputs)):
-            logger.debug("output " + str(i) + " with id=" + outputs[i].id)
+        logger.debug("number of rnn node outputs: %s", len(outputs))
+
         for i in range(self.num_lstm_layers):
-            logger.debug("creating rnn node for layer: " + str(i))
+            logger.debug("creating rnn node for layer: %s", i)
             rnn_nodes.append(self.create_single_rnn_node(context, i))
             output_id = rnn_nodes[i].output[0]
             rnn_output_shape = self.g.get_shape(output_id)
@@ -376,7 +375,7 @@ class LSTMRewriter(LSTMRewriterBase):
                                             shapes=[squeeze_output_shape],
                                             dtypes=[self.g.get_dtype(output_id)])
             if i + 1 < self.num_lstm_layers:
-                logger.debug("setting input for layer: " + str(i + 1))
+                logger.debug("setting input for layer: %s", i + 1)
                 context.onnx_input_ids[i + 1]["X"] = squeeze_node.output[0]
         return rnn_nodes
 

--- a/tf2onnx/rewriter/lstm_rewriter_base.py
+++ b/tf2onnx/rewriter/lstm_rewriter_base.py
@@ -21,7 +21,7 @@ from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase, UnitRnn
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access,W0223
 
 class LSTMContext(UnitRnnContext):
     def __init__(self):
@@ -45,6 +45,7 @@ class LSTMRewriterBase(UnitRnnRewriterBase):
         2 find needed info from tensorflow graph
     3 process found info according to ONNX requirement
     """
+
     def __init__(self, g):
         super(LSTMRewriterBase, self).__init__(g)
         # {var_name: (finder, connector)}
@@ -100,7 +101,8 @@ class LSTMRewriterBase(UnitRnnRewriterBase):
             context.input_size.append(None)
             context.hidden_size.append(None)
             context.attributes.append({})
-            context.onnx_input_ids[i]["sequence_lens"] = seq_len_node.output[0] if seq_len_node else utils.ONNX_EMPTY_INPUT
+            context.onnx_input_ids[i]["sequence_lens"] = \
+                seq_len_node.output[0] if seq_len_node else utils.ONNX_EMPTY_INPUT
 
         context.onnx_input_ids[0]["X"] = inputs[0]
         if not self.parse_attributes(context):
@@ -126,10 +128,9 @@ class LSTMRewriterBase(UnitRnnRewriterBase):
             )
 
             match_results = list(matcher.match_ops(body_graph_ops))
-            logger.debug("number of match results: " + str(len(match_results)))
-            if len(match_results) < 1:
-                return None
-            return match_results
+            logger.debug("number of match results: %s", len(match_results))
+            if len(match_results) > 0:
+                return match_results
         return None
 
     def get_state_variables(self, context):

--- a/tf2onnx/rewriter/lstm_rewriter_base.py
+++ b/tf2onnx/rewriter/lstm_rewriter_base.py
@@ -1,0 +1,189 @@
+# Licensed under the MIT license.
+
+# Temporary base class exclusive for LSTMs for stacked LSTM layer support.
+# Once GRU, BiLSTM, BiGRU re-writers will also be enhanced for stacked layer support
+# this will be combined with unit rnn base class.
+
+"""
+tf2onnx.rewriter.lstm_rewriter_base
+"""
+
+from __future__ import division
+from __future__ import print_function
+import logging
+
+from tf2onnx import utils
+from tf2onnx.rewriter.loop_rewriter_base import LoopRewriterBase
+from tf2onnx.rewriter.rnn_utils import get_pattern
+from tf2onnx.graph_matcher import GraphMatcher
+from tf2onnx.rewriter.unit_rnn_rewriter_base import UnitRnnRewriterBase, UnitRnnContext
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test,broad-except,protected-access
+
+class LSTMContext(UnitRnnContext):
+    def __init__(self):
+        super(LSTMContext, self).__init__()
+        self.cell_match = list()  # matched cell
+
+        self.weights = list({})
+        self.input_size = list()
+        self.hidden_size = list()
+
+        self.attributes = list({})  # onnx attributes
+        # onnx inputs: List of [X, W, R, B, sequence_lens, initial_h, initial_c, P]
+        self.onnx_input_ids = list({})
+
+
+class LSTMRewriterBase(UnitRnnRewriterBase):
+    """
+    main procedures:
+    1 check whether extracted loop is a unit LSTM, fall back in necessity:
+        1 parse LSTM
+        2 find needed info from tensorflow graph
+    3 process found info according to ONNX requirement
+    """
+    def __init__(self, g):
+        super(LSTMRewriterBase, self).__init__(g)
+        # {var_name: (finder, connector)}
+        self.state_variable_handler = list()
+        self.state_variable_handlers = list()
+
+    def create_context(self):
+        return LSTMContext()
+
+    def parse_unit_rnn(self, context):
+        """
+        parse needed info from tensorflow graph:
+        1 weight
+        2 state variables used in rnn unit, such as c_t, h_t
+        3 sequence node
+        4 input_x
+        5 attributes, e.g., activation_alpha, activation_beta... optional
+        """
+        logger.debug("parse unit rnn")
+
+        logger.debug("match unit cell against loop body graph")
+        cell_match = self.find_cell(context)
+        if not cell_match:
+            logger.debug('failed to match cell pattern')
+            return False
+        cell_match.sort(key=lambda cmt: cmt.get_op("cell_kernel").name)
+        context.cell_match = cell_match
+
+        logger.debug("get_weight_and_bias starts")
+        weights = self.get_weight_and_bias(context)
+        if not weights:
+            logger.debug("rnn weights check failed, SKIP")
+            return False
+        context.weights = weights
+
+        if not self.get_state_variables(context):
+            logger.debug("no cell variable initializers found, SKIP")
+            return False
+
+        seq_len_node = self.find_sequence_length_node(context)
+        if seq_len_node:
+            logger.debug("find sequence node: %s", seq_len_node.name)
+
+        # require exact one input
+        inputs = context.loop_properties.scan_inputs_initial_values
+        if len(inputs) != 1:
+            logger.debug("found %d inputs for the unit rnn: %s",
+                         len(inputs), inputs)
+            return False
+
+        for i in range(len(context.cell_match)):
+            context.onnx_input_ids.append({})
+            context.input_size.append(None)
+            context.hidden_size.append(None)
+            context.attributes.append({})
+            context.onnx_input_ids[i]["sequence_lens"] = seq_len_node.output[0] if seq_len_node else utils.ONNX_EMPTY_INPUT
+
+        context.onnx_input_ids[0]["X"] = inputs[0]
+        if not self.parse_attributes(context):
+            logger.debug("wrong attributes found")
+            return False
+
+        return True
+
+    def _match_cell(self, context, unittype):
+        """match unit cell"""
+        for cell_pattern in get_pattern(unittype):
+            matcher = GraphMatcher(cell_pattern, allow_reorder=True)
+
+            loop_props = context.loop_properties
+            inputs = loop_props.state_inputs + loop_props.scan_inputs
+            input_ids = [input_tensor_value_info.id for input_tensor_value_info in inputs]
+            outputs = loop_props.state_outputs + loop_props.scan_outputs
+            output_ids = [out_tensor_value_info.id for out_tensor_value_info in outputs]
+            body_graph_ops, _, _ = LoopRewriterBase.find_subgraph(
+                set(input_ids),
+                set(output_ids),
+                self.g, merge_as_end=True
+            )
+
+            match_results = list(matcher.match_ops(body_graph_ops))
+            logger.debug("number of match results: " + str(len(match_results)))
+            if len(match_results) < 1:
+                return None
+            return match_results
+        return None
+
+    def get_state_variables(self, context):
+        """
+        Get state variables by provided handlers. There maybe several handlers corresponding to
+        different patterns of state variables.
+        The commone method is to find state variables from loop property according to its
+        next_iteration_input and switch_true_identity_output, see lstm_rewriter_v2
+        """
+        contains_handler = False
+        for handler in self.state_variable_handlers:
+            can_handle = True
+            for var_name, funcs in handler.items():
+                finder = funcs[0]
+                state_variable = finder(context, funcs[2])
+                if state_variable:
+                    logger.debug("found state variable %s", var_name)
+                    context.state_variables[var_name] = state_variable
+                else:
+                    logger.debug("failed to get state variable %s", var_name)
+                    can_handle = False
+                    break
+            if can_handle:
+                self.state_variable_handler.append(handler)
+                contains_handler = True
+        return contains_handler
+
+    def process_outputs(self, context):
+        for handler in self.state_variable_handler:
+            for var_name, funcs in handler.items():
+                output_connector = funcs[1]
+                output_connector(context, funcs[2])
+                logger.debug("connect output of %s to graph", var_name)
+        logger.debug("done handling all state variables, now focusing on final output")
+        self.connect_unit_rnn_output_to_graph(context)
+
+    def connect_unit_rnn_output_to_graph(self, context):
+        outputs = context.loop_properties.scan_outputs_exits
+        if not outputs:
+            logger.debug("no one consume output")
+            return
+
+        gather_output_id = outputs[0].id
+        logger.debug("found output for rnn: %s", gather_output_id)
+
+        # in tf batch major mode, output shape is : [batch, time, hidden]
+        # in time major mode, output shape is: [time, batch, hidden]
+        # in onnx, output shape is : [time, num_directions, batch, hidden]
+
+        rnn_node = context.rnn_node[len(context.rnn_node) - 1]
+        output_id = rnn_node.output[0]
+        rnn_output_shape = self.g.get_shape(output_id)
+        squeeze_output_shape = [rnn_output_shape[0], rnn_output_shape[2], rnn_output_shape[3]]
+        squeeze_node = self.g.make_node("Squeeze", [output_id], attr={"axes": [1]},
+                                        shapes=[squeeze_output_shape],
+                                        dtypes=[self.g.get_dtype(output_id)])
+        self.g.replace_all_inputs(self.g.get_nodes(), gather_output_id, squeeze_node.output[0])

--- a/tf2onnx/rewriter/rnn.py
+++ b/tf2onnx/rewriter/rnn.py
@@ -15,7 +15,7 @@ from tf2onnx.rewriter.bilstm_rewriter import rewrite_bidirectional_lstms
 from tf2onnx.rewriter.bigru_rewriter import rewrite_bidirectional_grus
 from tf2onnx.rewriter.custom_rnn_rewriter import CustomRnnRewriter
 from tf2onnx.rewriter.loop_rewriter import LoopRewriter
-from tf2onnx.rewriter.lstm_rewriter import LSTMUnitRewriter
+from tf2onnx.rewriter.lstm_rewriter import LSTMRewriter
 from tf2onnx.rewriter.gru_rewriter import GRUUnitRewriter
 
 # pylint: disable=invalid-name,unused-argument,missing-docstring
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def rewrite_single_direction_lstm(g, ops):
-    r = LSTMUnitRewriter(g)
+    r = LSTMRewriter(g)
     return r.run()
 
 


### PR DESCRIPTION
- added new base class exclusive for LSTM which supports stacked LSTMs
- this base class can be combined with unit_rnn_rewriter_base once we add support for stacked layers in other RNN types like GRU
- modified LSTM rewriter such that it allows multiple cell matches and for all the variable finder and weight-bias methods we pass the LSTM index
- added new test for the same