### PR TITLE
Add half pixel transformation to resize bilinear op

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -64,6 +64,7 @@ if is_tf2():
     resize_nearest_neighbor = tf.compat.v1.image.resize_nearest_neighbor
     quantize_and_dequantize = tf.quantization.quantize_and_dequantize
     resize_bilinear = tf.compat.v1.image.resize_bilinear
+    resize_bilinear_v2 = tf.compat.v2.image.resize
     is_nan = tf.math.is_nan
     is_inf = tf.math.is_inf
     floormod = tf.math.floormod
@@ -81,6 +82,7 @@ elif LooseVersion(tf.__version__) >= "1.13":
     quantize_and_dequantize = tf.compat.v1.quantization.quantize_and_dequantize
     resize_nearest_neighbor = tf.compat.v1.image.resize_nearest_neighbor
     resize_bilinear = tf.compat.v1.image.resize_bilinear
+    resize_bilinear_v2 = tf.compat.v2.image.resize
     is_nan = tf.math.is_nan
     is_inf = tf.math.is_inf
     floormod = tf.floormod
@@ -1990,6 +1992,16 @@ class BackendTests(Tf2OnnxBackendTestBase):
         x_new_size = np.array([20, 16]).astype(np.int32)
         def func(x, x_new_size_):
             x_ = resize_bilinear(x, x_new_size_)
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: x_new_size})
+
+    @check_opset_min_version(11, "resize_bilinear_v2")
+    def test_resize_bilinear_v2_with_non_const(self):
+        x_shape = [3, 10, 8, 5]
+        x_val = np.arange(1, 1 + np.prod(x_shape), dtype=np.float32).reshape(x_shape)
+        x_new_size = np.array([20, 16]).astype(np.int32)
+        def func(x, x_new_size_):
+            x_ = resize_bilinear_v2(x, x_new_size_)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: x_new_size})
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1995,6 +1995,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: x_new_size})
 
+    @check_tf_min_version("1.14")
     @check_opset_min_version(11, "resize_bilinear_v2")
     def test_resize_bilinear_v2_with_non_const(self):
         x_shape = [3, 10, 8, 5]

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -736,9 +736,12 @@ class Resize:
             const_empty_float.output[0],
             concat_shape.output[0]
         ]
+        transformation_mode = "asymmetric"
+        if "half_pixel_centers" in node.attr and node.attr["half_pixel_centers"].i:
+            transformation_mode = "half_pixel"
         resize = ctx.make_node("Resize", resize_inputs,
                                attr={"mode": mode, "nearest_mode": "floor",
-                                     "coordinate_transformation_mode": "asymmetric"})
+                                     "coordinate_transformation_mode": transformation_mode})
         shapes = node.output_shapes
         dtypes = node.output_dtypes
         ctx.remove_node(node.name)


### PR DESCRIPTION
resize bilinear defaults to half_pixel_centers=True in TF 2.X. This PR sets the transformation mode of resize accordingly.