### PR TITLE
Fix graph deepcopy issue

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -301,7 +301,7 @@ class Node(object):
         self.set_attr("value", onnx_tensor)
         # track shapes in _output_shapes
         self._graph_check()
-        self.graph.set_shape(onnx_tensor.name, onnx_tensor.dims)
+        self.graph.set_shape(onnx_tensor.name, list(onnx_tensor.dims))
 
     def get_body_graphs(self):
         self._graph_check()


### PR DESCRIPTION
Fixes the Graph deepcopy() error sometimes seen during conversion. Issue was intermittent and difficult to reproduce systematically, although experienced by by several users,

Verified the patch works with 2 variants of the MobileNet model  that experienced deepcopy() errors. 