### PR TITLE
Fix transpose optimizer when handling "if" operator subgraphs

### DIFF
--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -282,8 +282,8 @@ class TransposeOptimizer(GraphOptimizerBase):
             return False
         # move transpose into branches to let Transposes can be "handled" in each branch
         for n in out_nodes:
-            branch_trans = self._g.make_node("Transpose", [trans.input[0]], attr=trans.attr_onnx)
-            self._g.replace_input(n, trans.output[0], branch_trans.output[0])
+            branch_trans = n.graph.make_node("Transpose", [trans.input[0]], attr=trans.attr_onnx)
+            n.graph.replace_input(n, trans.output[0], branch_trans.output[0])
 
         self._g.remove_node(trans.name)
         return False


### PR DESCRIPTION
Fixes #994 

When a `Transpose` operator is replicated (i.e. branched-out), once for each downstream consumer, the replicated `Transpose` ops should be created in the same sub-graph the consumer node resides in, which may or may not be the main graph.