### PR TITLE
Adjust spatial shape to meet rank requirements for Conv*D

### DIFF
--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -204,6 +204,11 @@ def add_padding(ctx, node, kernel_shape, strides, dilations=None, spatial=2):
         input_shape = ctx.get_shape(node.input[0])
         output_shape = ctx.get_shape(node.output[0])
 
+        # prefix with batch dim of [1] to satisfy rank requirements
+        if len(input_shape) == spatial + 1:
+            input_shape = [1] + input_shape
+            ctx.set_shape(node.input[0], input_shape)
+
         if len(input_shape) != spatial + 2:
             raise ValueError(
                 "node {} output needs to be rank {}, is {}".format(


### PR DESCRIPTION
Fixes #997.

The input shape into  Conv*D operators is sometimes "off by 1", and can be adjusted (broadcasted) to satisfy the spatial rank requirements for the 'add_padding()' function to work correctly and proceed with converting the TF ops.