### PR TITLE
Use the same syntax to replace an node input

### DIFF
--- a/tf2onnx/custom_opsets/ms.py
+++ b/tf2onnx/custom_opsets/ms.py
@@ -85,8 +85,8 @@ class ConvTransposeWithDynamicPads:
         # set node's attrs, Note: output_padding, group are left default.
         conv_dims_attr(node, "dilations")
         # set node's inputs from (output_shape, filter, input_tensor) to (input_tensor, filter, pads, Bias)
-        node.input[0] = node.input[2]
-        node.input[2] = pads.output[0]
+        ctx.replace_input(node, node.input[0], node.input[2], 0)
+        ctx.replace_input(node, node.input[2], pads.output[0], 2)
         conv_convert_inputs(ctx, node, with_kernel=True)
         node.attr.pop("data_format")
         node.attr.pop("padding")

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1262,18 +1262,6 @@ class Graph(object):
     def replace_inputs(self, node, new_inputs):
         """Replace node inputs."""
         assert isinstance(node, Node) and isinstance(new_inputs, list)
-
-        for old_input in node.input:
-            to_ops = self._input_to_node_name.get(old_input, None)
-            if to_ops is not None and old_input in to_ops:
-                # To avoid issues when a node
-                # takes twice the same entry.
-                to_ops.remove(old_input)
-
-        for input_name in new_inputs:
-            assert isinstance(input_name, six.text_type)
-            self._register_input_name(input_name, node)
-
         node.input = new_inputs
         return True
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1139,22 +1139,24 @@ class Graph(object):
         return op_cnt
 
     @staticmethod
-    def remove_input(node, to_be_removed, i=None):
+    def remove_input(node, to_be_removed, input_index=None):
         """Remove input from Node.
         Args:
             node: the node we expect the input on
             to_be_removed: the node name we want to remove
-            i: if not None, index of the input to be removed
+            input_index: if not None, index of the input to be removed,
+                the method is more efficient if *input_index* is specified,
+                otherwise, it has to look for every input named *old_input*.
         """
         assert isinstance(node, Node) and isinstance(to_be_removed, six.text_type)
-        if i is not None:
-            assert node.input[i] == to_be_removed
-            del node.input[i]
+        if input_index is not None:
+            assert node.input[input_index] == to_be_removed
+            del node.input[input_index]
             return True
 
-        for i2, name in enumerate(node.input):
+        for i, name in enumerate(node.input):
             if name == to_be_removed:
-                del node.input[i2]
+                del node.input[i]
                 break
         # don't remove output from parent since others might depend on it
         return True
@@ -1243,17 +1245,21 @@ class Graph(object):
                 for g in body_graphs.values():
                     g.replace_all_inputs(g.get_nodes(), old_input, new_input)
 
-    def replace_input(self, node, old_input, new_input, i=None):
-        """Replace one input in a node."""
+    def replace_input(self, node, old_input, new_input, input_index=None):
+        """
+        Replace one input in a node.
+        The method is more efficient if *input_index* is specified.
+        Otherwise, it renames every output named *old_input*.
+        """
         assert isinstance(node, Node) and isinstance(old_input, six.text_type) and isinstance(new_input, six.text_type)
         is_replaced = False
-        if i is None:
-            for i2, input_name in enumerate(node.input):
+        if input_index is None:
+            for i, input_name in enumerate(node.input):
                 if input_name == old_input:
-                    node.input[i2] = new_input
+                    node.input[i] = new_input
                     is_replaced = True
-        elif node.input[i] == old_input:
-            node.input[i] = new_input
+        elif node.input[input_index] == old_input:
+            node.input[input_index] = new_input
             is_replaced = True
         else:
             raise RuntimeError("Unable to replace input %r into %r for node %r." % (old_input, new_input, node.name))

--- a/tf2onnx/onnx_opset/common.py
+++ b/tf2onnx/onnx_opset/common.py
@@ -40,8 +40,8 @@ class BroadcastOp:
                         shape1 = node.inputs[1].scalar_to_dim1()
             if shape0 and shape1 and len(shape0) < len(shape1) and node.type in ["Mul", "Add"]:
                 tmp = node.input[0]
-                node.input[0] = node.input[1]
-                node.input[1] = tmp
+                ctx.replace_input(node, node.input[0], node.input[1], 0)
+                ctx.replace_input(node, node.input[1], tmp, 1)
         else:
             node.set_attr("broadcast", 0)
 
@@ -65,5 +65,5 @@ class BroadcastOp:
                         shape1 = node.inputs[1].scalar_to_dim1()
             if shape0 and shape1 and len(shape0) < len(shape1) and node.type in ["Mul", "Add"]:
                 tmp = node.input[0]
-                node.input[0] = node.input[1]
-                node.input[1] = tmp
+                ctx.replace_input(node, node.input[0], node.input[1], 0)
+                ctx.replace_input(node, node.input[1], tmp, 1)

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -40,7 +40,7 @@ class RandomOp:
         node.set_attr("seed", float(seed.f))
         if len(node.input) > 0:
             shape = node.inputs[0].get_tensor_value()
-            ctx.remove_input(node, node.input[0])
+            ctx.remove_input(node, node.input[0], 0)
             node.set_attr("shape", shape)
             ctx.set_shape(node.output[0], shape)
 
@@ -53,7 +53,7 @@ class RandomOp:
             node.set_attr("seed", float(seed.f))
             cast_node = ctx.make_node("Cast", node.input, attr={'to': onnx_pb.TensorProto.INT64})
             const_node = ctx.make_node("ConstantOfShape", cast_node.output)
-            node.input = const_node.output
+            ctx.replace_inputs(node, const_node.output.copy())
             node.type = node.type + 'Like'
 
 
@@ -103,8 +103,8 @@ class Fill:
         ctx.set_shape(tile_shape_int64.output[0], fill_shape)
 
         tmp = node.input[0]
-        node.input[0] = node.input[1]
-        node.input[1] = tmp
+        ctx.replace_input(node, node.input[0], node.input[1], 0)
+        ctx.replace_input(node, node.input[1], tmp, 1)
         node.type = "Tile"
         ctx.set_dtype(node.output[0], new_dtype)
 
@@ -128,13 +128,13 @@ class Fill:
         value = np.array([node.inputs[1].get_tensor_value()]).astype(utils.map_onnx_to_numpy_type(dtype))
         value_proto = numpy_helper.from_array(value)
         node.set_attr("value", value_proto)
-        del node.input[1]
+        ctx.remove_input(node, node.input[1], 1)
 
     @classmethod
     def version_11(cls, ctx, node, **kwargs):
         # cls.version_7(ctx, node, **kwargs)
         node.type = "Expand"
-        node.input = [node.input[1], node.input[0]]
+        ctx.replace_inputs(node, [node.input[1], node.input[0]])
         # cast shape to int64 if needed
         if ctx.get_dtype(node.input[1]) != onnx_pb.TensorProto.INT64:
             ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=onnx_pb.TensorProto.INT64)
@@ -156,7 +156,7 @@ class Multinomial:
             output_dtype = onnx_pb.TensorProto.INT32
         node.set_attr("dtype", output_dtype)
         node.set_attr("sample_size", sample_size)
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
 
 
 @tf_op("ZerosLike")

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -123,7 +123,7 @@ def make_min_or_max_op(ctx, op_type, inputs, outputs,
             # use add as 'broadcast' op
             add_node = ctx.make_node("Add", [input_node.output[0], sub_node.output[0]],
                                      op_name_scope=input_node.name)
-            node.input[i] = add_node.output[0]
+            ctx.replace_input(node, node.input[i], add_node.output[0], i)
     return final_node
 
 
@@ -293,7 +293,7 @@ class Pow:
             # workaround a bug in caffe2 pre Feb2018, pow(a, b) becomes np.exp(np.log(a) * b)
             node.type = "Log"
             b = node.input[1]
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[1], 1)
             op_name = utils.make_name(node.name)
             mul_op = ctx.insert_new_node_on_output("Mul", node.output[0], name=op_name)
             mul_op.input.append(b)

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -130,7 +130,7 @@ def conv_convert_inputs(ctx, node, with_kernel=False, new_kernel_shape=None,
                 ctx.make_const(shape_name, np.array(new_kernel_shape, dtype=np.int64))
 
                 reshape = ctx.make_node("Reshape", [kernel_name, shape_name])
-                ctx.replace_input(node, kernel_name, reshape.output[0])
+                ctx.replace_input(node, kernel_name, reshape.output[0], 1)
 
                 reshape.skip_conversion = True
 
@@ -453,11 +453,11 @@ class ConvTranspose:
         conv_dims_attr(node, "dilations", spatial=spatial)
 
         # remove output_shapes input
-        ctx.remove_input(node, node.input[0])
+        ctx.remove_input(node, node.input[0], 0)
         # swap data and kernel
         t = node.input[0]
-        node.input[0] = node.input[1]
-        node.input[1] = t
+        ctx.replace_input(node, node.input[0], node.input[1], 0)
+        ctx.replace_input(node, node.input[1], t, 1)
 
         conv_convert_inputs(ctx, node, with_kernel=True, spatial=spatial)
 
@@ -539,8 +539,8 @@ class PoolOp:
         else:
             kernel_shape_tf = node.inputs[1].get_tensor_value()
             strides_tf = node.inputs[2].get_tensor_value()
-            ctx.remove_input(node, node.input[2])
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[2], 2)
+            ctx.remove_input(node, node.input[1], 1)
 
         kernel_shape_hw = parse_dims_attr(node, kernel_shape_tf, spatial)
         strides_hw = parse_dims_attr(node, strides_tf, spatial)
@@ -605,7 +605,7 @@ class BiasAdd:
                 ctx.make_const(shape_name, np.array(new_broadcast_shape, dtype=np.int64))
                 op_name = node.input[1]
                 reshape_node = ctx.make_node("Reshape", [op_name, shape_name])
-                ctx.replace_input(node, op_name, reshape_node.output[0])
+                ctx.replace_input(node, op_name, reshape_node.output[0], 1)
                 ctx.set_shape(reshape_node.output[0], new_broadcast_shape)
 
 
@@ -629,9 +629,9 @@ class Pad:
         if mode in [None, "constant"] and len(node.input) == 3:
             const_val = node.inputs[2].get_tensor_value()
             node.set_attr("value", const_val)
-            ctx.remove_input(node, node.input[2])
+            ctx.remove_input(node, node.input[2], 2)
 
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
         node.set_attr("pads", paddings)
 
         origin_dtype = ctx.get_dtype(node.output[0])
@@ -709,14 +709,14 @@ class BatchNorm:
                                       dtype=val_type)
             new_mean_node_name = utils.make_name(node.name)
             ctx.make_const(new_mean_node_name, new_mean_value)
-            node.input[3] = new_mean_node_name
+            ctx.replace_input(node, node.input[3], new_mean_node_name, 3)
 
         if var_shape != scale_shape:
             new_var_value = np.array(np.resize(node.inputs[4].get_tensor_value(as_list=False), scale_shape),
                                      dtype=val_type)
             new_val_node_name = utils.make_name(node.name)
             ctx.make_const(new_val_node_name, new_var_value)
-            node.input[4] = new_val_node_name
+            ctx.replace_input(node, node.input[4], new_val_node_name, 4)
 
     @classmethod
     def version_9(cls, ctx, node, **kwargs):
@@ -867,7 +867,7 @@ class Resize:
         scaler = [1., 1., float(nh) / h, float(nw) / w]
         node.set_attr("scales", scaler)
         node.set_attr("mode", mode)
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
         node.data_format = "NHWC"
         conv_convert_inputs(ctx, node, with_kernel=False)
 

--- a/tf2onnx/onnx_opset/quantize.py
+++ b/tf2onnx/onnx_opset/quantize.py
@@ -70,7 +70,7 @@ class FakeQuantWithMinMaxArgs:
             op_name_scope=node.name, attr={"axis": axis},
             shapes=[shape], dtypes=[idtype])
         output_name = new_node.output[0]
-        node.input[0] = output_name
+        ctx.replace_input(node, node.input[0], output_name, 0)
 
         ctx.remove_node(node.name)
 

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -43,7 +43,7 @@ class ReduceOpBase:
             axes = [val + input_rank if val < 0 else val for val in axes]
 
         node.set_attr("axes", axes)
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
         keep_dims = node.get_attr("keep_dims")
         if keep_dims:
             del node.attr['keep_dims']
@@ -82,7 +82,7 @@ class ArgMax:
 
         node.set_attr("axis", axis)
         node.set_attr("keepdims", 0)
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
 
     @classmethod
     def version_11(cls, ctx, node, **kwargs):

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -264,7 +264,7 @@ class ConcatV2:
         for i, inp in enumerate(node.inputs):
             if inp.is_const() and inp.get_tensor_value(as_list=False).size == 0:
                 removed_indices.append(i)
-        for i in reverse(dremoved_indices):
+        for i in reverse(removed_indices):
             ctx.remove_input(node, node.input[i], i)
                 ctx.remove_input(node, node.input[i], i)
         # all inputs are deleted

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -140,7 +140,7 @@ class Reshape:
         if shape is None:
             logger.error("Reshape on node %s does not have a const shape", node.name)
             return
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[1], 1)
         node.set_attr("shape", shape)
         ctx.set_shape(node.output[0], shape)
 
@@ -216,7 +216,7 @@ class Transpose:
             if perm.is_const():
                 # perms is passed as const
                 dims = perm.get_tensor_value()
-                ctx.remove_input(node, node.input[1])
+                ctx.remove_input(node, node.input[1], 1)
                 node.set_attr("perm", dims)
             else:
                 utils.make_sure(False, "perm can't be dynamic in ONNX")
@@ -233,7 +233,7 @@ class Concat:
         node.type = "Concat"
         axis_node = node.inputs[0]
         axis_val = axis_node.get_tensor_value()
-        ctx.remove_input(node, node.input[0])
+        ctx.remove_input(node, node.input[0], 0)
 
         if axis_val < 0:  # onnxruntime does not support -1 axis, but TF supports.
             input_shape = ctx.get_shape(node.input[0])
@@ -260,9 +260,13 @@ class ConcatV2:
         # if any input is empty, remove the input and concat the others
         # NOTE: workaround for https://github.com/Microsoft/onnxruntime/issues/681
         node.type = "Concat"
+        removed_indices = []
         for i, inp in enumerate(node.inputs):
             if inp.is_const() and inp.get_tensor_value(as_list=False).size == 0:
-                ctx.remove_input(node, node.input[i])
+                removed_indices.append(i)
+        for i in reverse(dremoved_indices):
+            ctx.remove_input(node, node.input[i], i)
+                ctx.remove_input(node, node.input[i], i)
         # all inputs are deleted
         if not node.input:
             raise RuntimeError("all inputs of {} are empty".format(node.name))
@@ -270,7 +274,7 @@ class ConcatV2:
         axis_node = node.inputs[-1]
         utils.make_sure(axis_node.is_const(), "{} needs to be const".format(axis_node.name))
         axis_val = axis_node.get_tensor_value()
-        ctx.remove_input(node, node.input[-1])
+        ctx.remove_input(node, node.input[-1], len(node.input) - 1)
 
         if axis_val < 0:  # onnxruntime does not support -1 axis, but TF supports.
             input_shape = ctx.get_shape(node.input[0])
@@ -358,7 +362,7 @@ class GatherV2:
         # for GatherV2 axis come as input
         node.type = "Gather"
         axis = node.inputs[2].get_tensor_value()
-        ctx.remove_input(node, node.input[2])
+        ctx.remove_input(node, node.input[2], 2)
         node.set_attr("axis", axis)
 
     @classmethod
@@ -526,7 +530,7 @@ class ScatterND:
         ctx.insert_new_node_on_input(node, "Cast", node.input[0], to=TensorProto.INT64)
         ctx.insert_new_node_on_input(node, "Cast", node.input[2], to=onnxdtype)
         # reorder inputs to match onnx
-        node.input = [node.input[2], node.input[0], node.input[1]]
+        ctx.replace_inputs(node, [node.input[2], node.input[0], node.input[1]])
 
 
 @tf_op("Split")
@@ -536,7 +540,7 @@ class Split:
         # T output = Split(int32 split_dim, T value, @int num_split)
         # T outputs = Split(T input, @INT axis, @INTS split)
         split_dims = node.inputs[0].get_tensor_value()
-        ctx.remove_input(node, node.input[0])
+        ctx.remove_input(node, node.input[0], 0)
         node.set_attr("axis", split_dims)
 
     @classmethod
@@ -566,8 +570,8 @@ class SplitV:
             for i, v in enumerate(split):
                 if v == -1:
                     split[i] = final_sum - sums
-        ctx.remove_input(node, node.input[2])
-        ctx.remove_input(node, node.input[1])
+        ctx.remove_input(node, node.input[2], 2)
+        ctx.remove_input(node, node.input[1], 1)
         node.set_attr("split", split)
         node.set_attr("axis", split_dims)
 
@@ -588,7 +592,7 @@ class ExpandDims:
             # tensorflow already infers the output shape so we can just take it
             shape = ctx.get_shape(node.output[0])
             node.type = "Reshape"
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[1], 1)
             node.set_attr("shape", shape)
             return
 
@@ -601,7 +605,7 @@ class ExpandDims:
                 input_rank = len(ctx.get_shape(node.input[0]))
                 dim = dim + input_rank + 1
             node.set_attr("axes", [dim])
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[1], 1)
             return
         raise ValueError("non-const dim is not supported")
 
@@ -620,7 +624,7 @@ class ExpandDims:
                 input_rank = len(ctx.get_shape(node.input[0]))
                 dim = dim + input_rank + 1
             node.set_attr("axes", [dim])
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[1], 1)
             return
         raise ValueError("non-const dim is not supported")
 
@@ -634,7 +638,7 @@ class ExpandDims:
                 # tf.expanddims() wants a scalar per doc but quietly accepts a list too.
                 dim = dim[0]
             node.set_attr("axes", [dim])
-            ctx.remove_input(node, node.input[1])
+            ctx.remove_input(node, node.input[1], 1)
             return
         raise ValueError("non-const dim is not supported")
 
@@ -1000,7 +1004,7 @@ class TopKV2:
         k_0d = node.input[1]
         cast = ctx.make_node("Cast", [k_0d], attr={"to": onnx_pb.TensorProto.INT64})
         k_1d = ctx.make_node("Unsqueeze", cast.output, attr={"axes": [0]})
-        ctx.replace_input(node, k_0d, k_1d.output[0])
+        ctx.replace_input(node, k_0d, k_1d.output[0], 1)
         # cast the index output to int32
         cast_out = ctx.insert_new_node_on_output("Cast", node.output[1], name=utils.make_name(node.name), to=dtypes[1])
         ctx.set_dtype(cast_out.output[0], dtypes[1])
@@ -1039,7 +1043,7 @@ class Pack:
             new_node = ctx.make_node("Unsqueeze", [node.input[i]], op_name_scope=node.name, attr={"axes": [axis]},
                                      shapes=[shape], dtypes=[dtype])
             output_name = new_node.output[0]
-            node.input[i] = output_name
+            ctx.replace_input(node, node.input[i], output_name, i)
             inputs.append(output_name)
 
         shapes = node.output_shapes
@@ -1107,9 +1111,7 @@ class OneHot:
         const_name = utils.make_name(node.name)
         ctx.make_const(const_name, eye)
         # setup gather inputs
-        del node.input[:]
-        node.input.append(const_name)
-        node.input.append(indices_name)
+        ctx.replace_inputs(node, [const_name, indices_name])
         node.type = "Gather"
         if axis.i == 0:
             # TODO: revisit for rank > 1
@@ -1143,19 +1145,18 @@ class OneHot:
         if ctx.is_target(constants.TARGET_RS6) \
                 and ctx.get_dtype(indices) != onnx_pb.TensorProto.INT64:
             indices = ctx.make_node("Cast", [indices], attr={"to": onnx_pb.TensorProto.INT64}).output[0]
-        node.input[0] = indices
+        ctx.replace_input(node, node.input[0], indices, 0)
 
         if ctx.is_target(constants.TARGET_RS6) \
                 and ctx.get_dtype(depth) != onnx_pb.TensorProto.INT64:
             depth = ctx.make_node("Cast", [depth], attr={"to": onnx_pb.TensorProto.INT64}).output[0]
-        node.input[1] = depth
+        ctx.replace_input(node, node.input[1], depth, 1)
 
         if ctx.is_target(constants.TARGET_RS6) \
                 and output_dtype != onnx_pb.TensorProto.INT64:
             off_on_value = ctx.make_node("Cast", [off_on_value], attr={"to": onnx_pb.TensorProto.INT64}).output[0]
-        node.input[2] = off_on_value
-
-        del node.input[3]
+        ctx.replace_input(node, node.input[2], off_on_value, 2)
+        ctx.remove_input(node, node.input[3], 3)
 
         if ctx.is_target(constants.TARGET_RS6) \
                 and output_dtype != onnx_pb.TensorProto.INT64:
@@ -1568,8 +1569,8 @@ class ReverseSequence:
             ctx.copy_dtype(node.output[0], trans_back_node.output[0])
 
         tmp = node.input[0]
-        node.input[0] = node.input[1]
-        node.input[1] = tmp
+        ctx.replace_input(node, node.input[0], node.input[1], 0)
+        ctx.replace_input(node, node.input[1], tmp, 1)
 
     @classmethod
     def version_9(cls, ctx, node, **kwargs):

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -266,7 +266,6 @@ class ConcatV2:
                 removed_indices.append(i)
         for i in reverse(removed_indices):
             ctx.remove_input(node, node.input[i], i)
-                ctx.remove_input(node, node.input[i], i)
         # all inputs are deleted
         if not node.input:
             raise RuntimeError("all inputs of {} are empty".format(node.name))

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -264,7 +264,7 @@ class ConcatV2:
         for i, inp in enumerate(node.inputs):
             if inp.is_const() and inp.get_tensor_value(as_list=False).size == 0:
                 removed_indices.append(i)
-        for i in reverse(removed_indices):
+        for i in reversed(removed_indices):
             ctx.remove_input(node, node.input[i], i)
         # all inputs are deleted
         if not node.input:

--- a/tf2onnx/optimizer/back_to_back_optimizer.py
+++ b/tf2onnx/optimizer/back_to_back_optimizer.py
@@ -83,7 +83,7 @@ class BackToBackOptimizer(GraphOptimizerBase):
             type2 = pnode.get_attr('to').i
             if type1 == type2:
                 for node2 in consumer_nodes:
-                    node2.input[0] = node.input[0]
+                    g.replace_input(node2, node2.input[0], node.input[0], 0)
                     q2.append(node2.output[0])
                 g.remove_node(node.name)
                 return q2
@@ -118,7 +118,7 @@ class BackToBackOptimizer(GraphOptimizerBase):
 
         if can_reduce:
             for node2 in consumer_nodes:
-                node2.input[0] = node.input[0]
+                g.replace_input(node2, node2.input[0], node.input[0], 0)
             g.remove_node(node.name)
         return q2
 
@@ -129,7 +129,7 @@ class BackToBackOptimizer(GraphOptimizerBase):
         t1 = list(node.get_attr('perm').ints)
         q2 = []
         for node2 in consumer_nodes:
-            node2.input[0] = node.input[0]
+            g.replace_input(node2, node2.input[0], node.input[0], 0)
             t2 = list(node2.get_attr('perm').ints)
             new_perm = [t1[i] for i in t2]
             # check if node2 can be removed. otherwise only update
@@ -230,7 +230,7 @@ class BackToBackOptimizer(GraphOptimizerBase):
         bias_new = (bias - mean) * scale_new + offset
         bias_new_const = g.make_const(node.name + '_bias_fused_bn', bias_new)
         weights_new_const = g.make_const(node.name + '_weights_fused_bn', weights_new)
-        node.input = [node.input[0], weights_new_const.output[0], bias_new_const.output[0]]
+        g.replace_inputs(node, [node.input[0], weights_new_const.output[0], bias_new_const.output[0]])
 
         # fuse conv and bn, delete bn
         node2_output = node2.output[:1]

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -592,8 +592,8 @@ class TransposeOptimizer(GraphOptimizerBase):
             # 1 switch
             ops = self._g.get_nodes()
             self._g.replace_all_inputs(ops, node.output[0], trans.output[0])
-            node.input[0] = trans.input[0]
-            trans.input[0] = node.output[0]
+            self._g.replace_input(node, node.input[0], trans.input[0], 0)
+            self._g.replace_input(trans, trans.input[0], node.output[0], 0)
             # 2 correct attr of nodes
             squeeze_axes = sorted(list(node.get_attr("axes").ints))
             trans_perm = list(trans.get_attr("perm").ints)
@@ -630,7 +630,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             if input1.data_format in ["NHWC", "unkown"]:
                 if not self._nodes_has_single_consumer_node([input1]):
                     input1 = self._g.copy_const(input1)
-                    node.input[1] = input1.output[0]
+                    self._g.replace_input(node, node.input[1], input1.output[0], 1)
                 pads = input1.get_tensor_value()
                 # NHWC->NCHW
                 new_pads = np.array([pads[0], pads[3], pads[1], pads[2], pads[4], pads[7], pads[5], pads[6]],
@@ -670,7 +670,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                         new_axes_const = self._g.make_const(
                             utils.make_name(node.inputs[3].name), new_axes
                         )
-                        self._g.replace_input(node, node.input[3], new_axes_const.output[0])
+                        self._g.replace_input(node, node.input[3], new_axes_const.output[0], 3)
                     return self._switch_transpose_and_node(node, trans)
         return False
 

--- a/tf2onnx/rewriter/conv2d_with_pad_rewriter.py
+++ b/tf2onnx/rewriter/conv2d_with_pad_rewriter.py
@@ -48,7 +48,7 @@ def rewrite_conv2d_with_pad(g, ops):
 
         paddings_val = paddings_val[1:3]
         paddings_val = paddings_val.transpose().flatten()
-        g.replace_input(conv, conv.input[0], pad.input[0])
+        g.replace_input(conv, conv.input[0], pad.input[0], 0)
         # convert Conv2D
         conv.type = "Conv2D"
         func, _ = handler.tf_op.find_effective_op("Conv2D")

--- a/tf2onnx/rewriter/transpose_rewriter.py
+++ b/tf2onnx/rewriter/transpose_rewriter.py
@@ -28,7 +28,7 @@ def rewrite_transpose(g, ops):
         shape = g.get_shape(output.input[0])
         dims = range(len(shape) - 1, -1, -1)
         output.set_attr("perm", dims)
-        g.remove_input(output, output.input[1])
+        g.remove_input(output, output.input[1], 1)
         to_delete = [n for n in match.get_nodes() if n != output]
         g.safe_remove_nodes(to_delete)
     return ops


### PR DESCRIPTION
Preliminary work to build a forward index to keep track of all nodes ingesting a specific input.