### PR TITLE
Faster insertion of operator cast

### DIFF
--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -545,9 +545,9 @@ class BitShift:
                              shapes=shapes, dtypes=dtypes, domain=constants.ONNX_DOMAIN, attr={'direction': direction})
 
         if node.maybe_cast_input([supported, supported], type_map):
-            cast_back_node = ctx.insert_new_node_on_output("Cast", node.output[0],
-                                                           name=utils.make_name(node.name) + "_castback")
-            cast_back_node.set_attr("to", dtypes[0])
+            cast_back_node = ctx.insert_new_node_on_output(
+                "Cast", node.output[0], name=utils.make_name(node.name) + "_castback",
+                to=dtypes[0])
             ctx.set_dtype(cast_back_node.output[0], dtypes[0])
             ctx.copy_shape(node.name, cast_back_node.output[0])
 

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -637,14 +637,13 @@ class Pad:
         origin_dtype = ctx.get_dtype(node.output[0])
         if origin_dtype not in [onnx_pb.TensorProto.FLOAT16, onnx_pb.TensorProto.FLOAT,
                                 onnx_pb.TensorProto.DOUBLE]:
-            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0])
-            cast_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
+            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0], to=onnx_pb.TensorProto.FLOAT)
             ctx.set_dtype(cast_node.output[0], onnx_pb.TensorProto.FLOAT)
             ctx.copy_shape(node.name, cast_node.output[0])
 
             cast_back_node = ctx.insert_new_node_on_output("Cast", node.output[0],
-                                                           name=utils.make_name(node.name) + "_castback")
-            cast_back_node.set_attr("to", origin_dtype)
+                                                           name=utils.make_name(node.name) + "_castback",
+                                                           to=origin_dtype)
             ctx.set_dtype(cast_back_node.output[0], origin_dtype)
             ctx.copy_shape(node.name, cast_back_node.output[0])
 
@@ -667,14 +666,13 @@ class Pad:
         origin_dtype = ctx.get_dtype(node.output[0])
         if origin_dtype not in [TensorProto.FLOAT, TensorProto.DOUBLE,
                                 TensorProto.INT32, TensorProto.INT64]:
-            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0])
-            cast_node.set_attr("to", TensorProto.FLOAT)
+            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0], to=TensorProto.FLOAT)
             ctx.set_dtype(cast_node.output[0], TensorProto.FLOAT)
             ctx.copy_shape(node.name, cast_node.output[0])
 
             cast_back_node = ctx.insert_new_node_on_output("Cast", node.output[0],
-                                                           name=utils.make_name(node.name) + "_castback")
-            cast_back_node.set_attr("to", origin_dtype)
+                                                           name=utils.make_name(node.name) + "_castback",
+                                                           to=origin_dtype)
             ctx.set_dtype(cast_back_node.output[0], origin_dtype)
             ctx.copy_shape(node.name, cast_back_node.output[0])
 

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -31,8 +31,7 @@ def _convert_shapenode_to_int64(ctx, node, input_number):
     """cast int32 shape into int64 shape."""
     name = node.input[input_number]
 
-    cast_node = ctx.insert_new_node_on_input(node, "Cast", name)
-    cast_node.set_attr("to", onnx_pb.TensorProto.INT64)
+    cast_node = ctx.insert_new_node_on_input(node, "Cast", name, to=onnx_pb.TensorProto.INT64)
     ctx.set_dtype(cast_node.output[0], onnx_pb.TensorProto.INT64)
     ctx.copy_shape(name, cast_node.output[0])
 
@@ -46,14 +45,14 @@ def _wrap_concat_with_cast(ctx, node):
         output_name = node.output[0]
         # cast each inputs to float
         for i, inp in enumerate(node.inputs):
-            input_cast = ctx.insert_new_node_on_input(node, "Cast", node.input[i])
-            input_cast.set_attr("to", onnx_pb.TensorProto.FLOAT)
+            input_cast = ctx.insert_new_node_on_input(node, "Cast", node.input[i],
+                                                      to=onnx_pb.TensorProto.FLOAT)
             ctx.set_dtype(input_cast.output[0], onnx_pb.TensorProto.FLOAT)
         next_nodes = ctx.find_output_consumers(node.output[0])
         # cast output back to dtype unless the next op is a cast
         if next_nodes[0].type != "Cast":
-            output_cast = ctx.insert_new_node_on_output("Cast", output_name, name=node.child_name())
-            output_cast.set_attr("to", dtype)
+            output_cast = ctx.insert_new_node_on_output("Cast", output_name, name=node.child_name(),
+                                                        to=dtype)
             ctx.set_dtype(output_cast.output[0], dtype)
             ctx.copy_shape(output_name, output_cast.output[0])
 
@@ -157,15 +156,14 @@ class Reshape:
             return
 
         # onnx < opset 8 does not know reshape for other types than float*, wrap the reshape in casts
-        input_cast = ctx.insert_new_node_on_input(node, "Cast", node.input[0])
-        input_cast.set_attr("to", onnx_pb.TensorProto.FLOAT)
+        input_cast = ctx.insert_new_node_on_input(node, "Cast", node.input[0], to=onnx_pb.TensorProto.FLOAT)
         ctx.copy_shape(node.output[0], input_cast.output[0])
 
         # if the next node is already a cast we don't need to insert another one
         next_nodes = ctx.find_output_consumers(node.output[0])
         if len(next_nodes) != 1 or next_nodes[0].type != "Cast":
-            output_cast = ctx.insert_new_node_on_output("Cast", node.output[0], name=node.child_name())
-            output_cast.set_attr("to", dtype)
+            output_cast = ctx.insert_new_node_on_output("Cast", node.output[0], name=node.child_name(),
+                                                        to=dtype)
             ctx.set_dtype(output_cast.output[0], dtype)
             ctx.copy_shape(node.output[0], output_cast.output[0])
 
@@ -739,16 +737,17 @@ class StridedSlice:
                 if node.inputs[0].type == "Cast" and len(ctx.find_output_consumers(node.inputs[0].output[0])) == 1:
                     # override the previous cast
                     cast_node = node.inputs[0]
+                    cast_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
                 else:
-                    cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0])
+                    cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[0],
+                                                             to=onnx_pb.TensorProto.FLOAT)
                     nodes.insert(0, cast_node)
-                cast_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
                 ctx.set_dtype(cast_node.output[0], onnx_pb.TensorProto.FLOAT)
                 ctx.copy_shape(node.input[0], cast_node.output[0])
                 # undo the cast afer slice
                 name = utils.make_name(node.name)
-                cast_node = ctx.insert_new_node_on_output("Cast", nodes[-1].output[0], name)
-                cast_node.set_attr("to", input_dtype)
+                cast_node = ctx.insert_new_node_on_output("Cast", nodes[-1].output[0], name,
+                                                          to=input_dtype)
                 ctx.set_dtype(cast_node.output[0], input_dtype)
                 ctx.copy_shape(node.output[0], cast_node.output[0])
                 nodes.append(cast_node)
@@ -1180,8 +1179,7 @@ class Shape:
         if dtype == onnx_pb.TensorProto.INT64:
             return
         op_name = utils.make_name(node.name)
-        output_cast = ctx.insert_new_node_on_output("Cast", node.output[0], name=op_name)
-        output_cast.set_attr("to", dtype)
+        output_cast = ctx.insert_new_node_on_output("Cast", node.output[0], name=op_name, to=dtype)
         ctx.set_dtype(output_cast.output[0], dtype)
         ctx.copy_shape(node.output[0], output_cast.output[0])
 
@@ -1555,8 +1553,7 @@ class ReverseSequence:
 
         seq_len_dtype = ctx.get_dtype(node.input[1])
         if seq_len_dtype != onnx_pb.TensorProto.INT64:
-            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[1])
-            cast_node.set_attr("to", onnx_pb.TensorProto.INT64)
+            cast_node = ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=onnx_pb.TensorProto.INT64)
             ctx.set_dtype(cast_node.output[0], onnx_pb.TensorProto.INT64)
             ctx.copy_shape(node.input[1], cast_node.output[0])
 
@@ -1762,8 +1759,8 @@ class Unique:
             # cast to int64 if needed
             if dtypes[1] != onnx_pb.TensorProto.UINT64:
                 cast_node = ctx.insert_new_node_on_output("Cast", node.output[1],
-                                                          name=utils.make_name(node.name) + "_cast")
-                cast_node.set_attr("to", dtypes[1])
+                                                          name=utils.make_name(node.name) + "_cast",
+                                                          to=dtypes[1])
                 ctx.set_dtype(cast_node.output[0], dtypes[1])
                 ctx.copy_shape(node.output[1], cast_node.output[0])
             # FIXME: the indices in onnx are not the same as in tensorflow.

--- a/tf2onnx/tfonnx.py
+++ b/tf2onnx/tfonnx.py
@@ -160,8 +160,8 @@ def rewrite_incomplete_type_support(g, ops, impacted_ops):
                         input_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
                         g.set_dtype(input_name, onnx_pb.TensorProto.FLOAT)
                     else:
-                        cast_node = g.insert_new_node_on_input(op, "Cast", input_name)
-                        cast_node.set_attr("to", onnx_pb.TensorProto.FLOAT)
+                        cast_node = g.insert_new_node_on_input(op, "Cast", input_name,
+                                                               to=onnx_pb.TensorProto.FLOAT)
                         g.set_dtype(cast_node.output[0], onnx_pb.TensorProto.FLOAT)
                         g.copy_shape(input_name, cast_node.output[0])
                         cast_inserted.append(cast_node)
@@ -171,8 +171,8 @@ def rewrite_incomplete_type_support(g, ops, impacted_ops):
                     name = utils.make_name(op.name)
                     logger.debug("insert cast back for node %s on output %s [dtype=%s]", op.name, output_name,
                                  output_dtype)
-                    output_cast = g.insert_new_node_on_output("Cast", output_name, name=name)
-                    output_cast.set_attr("to", output_dtype)
+                    output_cast = g.insert_new_node_on_output("Cast", output_name, name=name,
+                                                              to=output_dtype)
                     g.set_dtype(output_cast.output[0], output_dtype)
                     g.copy_shape(output_name, output_cast.output[0])
                     cast_inserted.append(output_cast)


### PR DESCRIPTION
The PR avoids one type inference because type is specified while inserting the node cast and not after.