### PR TITLE
Feature: Added optimization step to remove upsample layers with all ones in scale

### DIFF
--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1203,6 +1203,37 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             "Upsample",
             0)
 
+    @check_opset_min_version(9, ">= 9 scales is in input[1]")
+    def test_upsample_all_ones_removed_in_input(self):
+        shape = (1, 1, 32, 32)
+        const_tensor = helper.make_tensor(
+            name="S",
+            data_type=TensorProto.FLOAT,
+            dims=(1,4),
+            vals=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32))
+        node0 = helper.make_node("Constant", [], ["S"], value=const_tensor)
+        node1 = helper.make_node(
+            op_type="Upsample",
+            inputs=["X", "S"],
+            outputs=["Y"],
+            name="upsample1")
+
+        graph = helper.make_graph(
+            [node0, node1],
+            "test_upsample_all_ones",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+
+        self.run_and_compare(
+            ["Y"],
+            {"X": np.random.randn(*shape).astype(np.float32)},
+            model_proto,
+            "Upsample",
+            0)
+
 
 if __name__ == "__main__":
     unittest_main()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1204,6 +1204,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             0)
 
     @check_opset_min_version(9, ">= 9 scales is in input[1]")
+    @check_opset_max_version(9, "Upscale is deprecated in opsets >= 10")
     def test_upsample_all_ones_removed_in_input(self):
         shape = (1, 1, 32, 32)
         const_tensor = helper.make_tensor(

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1209,7 +1209,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         const_tensor = helper.make_tensor(
             name="S",
             data_type=TensorProto.FLOAT,
-            dims=(1,4),
+            dims=(1, 4),
             vals=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32))
         node0 = helper.make_node("Constant", [], ["S"], value=const_tensor)
         node1 = helper.make_node(

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1177,6 +1177,25 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["res", "res2", "res3"], {"u": np.random.randn(1, 2, 3).astype(np.float32)}, model_proto,
                              "Cast", 5)
 
+    def test_upsample_all_ones_removed(self):
+        node1 = helper.make_node("Upsample", ["X"], ["Y"], scales=[1, 1, 1, 1], name="upsample1")
+
+        graph = helper.make_graph(
+            [node1],
+            "test_upsample_all_ones",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (32, 16))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (32, 16))],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+
+        self.run_and_compare(
+            ["Y"],
+            {"X": np.random.randn(32, 16).astype(np.float32)},
+            model_proto,
+            "Upsample",
+            0)
+
 
 if __name__ == "__main__":
     unittest_main()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1177,26 +1177,28 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["res", "res2", "res3"], {"u": np.random.randn(1, 2, 3).astype(np.float32)}, model_proto,
                              "Cast", 5)
 
+    @check_opset_max_version(8, "until opset 8 scales is in attributes")
     def test_upsample_all_ones_removed(self):
+        shape = (1, 1, 32, 32)
         node1 = helper.make_node(
-            "Upsample",
-            ["X"],
-            ["Y"],
+            op_type="Upsample",
+            inputs=["X"],
+            outputs=["Y"],
             scales=[1., 1., 1., 1.],
             name="upsample1")
 
         graph = helper.make_graph(
             [node1],
             "test_upsample_all_ones",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 32, 32, 1))],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1, 32, 32, 1))],
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)],
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
 
         self.run_and_compare(
             ["Y"],
-            {"X": np.random.randn(1, 32, 32, 1).astype(np.float32)},
+            {"X": np.random.randn(*shape).astype(np.float32)},
             model_proto,
             "Upsample",
             0)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1178,20 +1178,25 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
                              "Cast", 5)
 
     def test_upsample_all_ones_removed(self):
-        node1 = helper.make_node("Upsample", ["X"], ["Y"], scales=[1, 1, 1, 1], name="upsample1")
+        node1 = helper.make_node(
+            "Upsample",
+            ["X"],
+            ["Y"],
+            scales=[1., 1., 1., 1.],
+            name="upsample1")
 
         graph = helper.make_graph(
             [node1],
             "test_upsample_all_ones",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (32, 16))],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (32, 16))],
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 32, 32, 1))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1, 32, 32, 1))],
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
 
         self.run_and_compare(
             ["Y"],
-            {"X": np.random.randn(32, 16).astype(np.float32)},
+            {"X": np.random.randn(1, 32, 32, 1).astype(np.float32)},
             model_proto,
             "Upsample",
             0)

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -15,11 +15,13 @@ from .merge_duplicated_nodes_optimizer import MergeDuplicatedNodesOptimizer
 from .transpose_optimizer import TransposeOptimizer
 from .loop_optimizer import LoopOptimizer
 from .back_to_back_optimizer import BackToBackOptimizer
+from .upsample_optimizer import UpsampleOptimizer
 from .. import logging
 
 # optimizer sequence need to be considered carefully
 _optimizers = OrderedDict([
     ("optimize_transpose", TransposeOptimizer),
+    ("remove_redundant_upsample", UpsampleOptimizer),
     ("fold_constants", ConstFoldOptimizer),
     ("loop_optimizer", LoopOptimizer),
     # merge_duplication should be used after optimize_transpose

--- a/tf2onnx/optimizer/upsample_optimizer.py
+++ b/tf2onnx/optimizer/upsample_optimizer.py
@@ -1,0 +1,32 @@
+"""Resize Optimizer.
+    Replace resize operations with all ones in scale with Identity nodes
+"""
+
+from __future__ import unicode_literals
+
+from .optimizer_base import GraphOptimizerBase
+
+# pylint: disable=logging-not-lazy,unused-argument,missing-docstring,unused-variable,arguments-differ
+
+
+class UpsampleOptimizer(GraphOptimizerBase):
+    """Resize Optimizer."""
+
+    def __init__(self):  # pylint: disable=useless-super-delegation
+        super(UpsampleOptimizer, self).__init__()
+
+    def _optimize(self, graph):
+        return self._apply_optimization(
+            graph,
+            self._optimize_at_current_graph_level)
+
+    def _optimize_at_current_graph_level(self, graph):
+        # replace resize operations with all ones in scale with Identity nodes
+        for n in graph.get_nodes():
+            if n.type == "Upsample":
+                scales = n.get_attr_value("scales")
+                if all([s == 1 for s in scales]):
+                    n.type = "Identity"
+                    self.logger.debug("replacing " + n.name +
+                                      " with Identity operation")
+        return graph

--- a/tf2onnx/optimizer/upsample_optimizer.py
+++ b/tf2onnx/optimizer/upsample_optimizer.py
@@ -3,7 +3,6 @@
 """
 
 from __future__ import unicode_literals
-from onnx import helper
 
 from .optimizer_base import GraphOptimizerBase
 

--- a/tf2onnx/optimizer/upsample_optimizer.py
+++ b/tf2onnx/optimizer/upsample_optimizer.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+import numpy as np
+
 from .optimizer_base import GraphOptimizerBase
 
 # pylint: disable=logging-not-lazy,unused-argument,missing-docstring,unused-variable,arguments-differ
@@ -26,12 +28,24 @@ class UpsampleOptimizer(GraphOptimizerBase):
         # replace upsample node with all ones in scale with identity node
         for n in self._g.get_nodes():
             if n.type == "Upsample":
+                node_changed = False
                 # upsample in opset <=8 has scales in attributes
                 if self._g.opset <= 8:
                     scales = n.get_attr_value("scales")
                     if scales and all([float(s) == 1. for s in scales]):
                         n.type = "Identity"
-                        self.logger.debug("replacing " + n.name +
-                                          " with Identity operation ")
-                # upsample in opset > 8 has scales in input[1]
+                        node_changed = True
+                # upsample in opset >= 9 has scales in input[1]
+                if self._g.opset >= 9 and len(n.input) == 2:
+                    scales_input = n.inputs[1]
+
+                    if scales_input.is_const() and \
+                            np.all(scales_input.get_tensor_value(as_list=False) == 1.):
+                        n.type = "Identity"
+                        n.input = [n.input[0]]
+                        node_changed = True
+                if node_changed:
+                    self.logger.debug("replacing " + n.name +
+                                      " with Identity operation ")
+
         return self._g

--- a/tf2onnx/optimizer/upsample_optimizer.py
+++ b/tf2onnx/optimizer/upsample_optimizer.py
@@ -10,7 +10,7 @@ from .optimizer_base import GraphOptimizerBase
 
 
 class UpsampleOptimizer(GraphOptimizerBase):
-    """Resize Optimizer."""
+    """Upsample Optimizer."""
 
     def __init__(self):  # pylint: disable=useless-super-delegation
         super(UpsampleOptimizer, self).__init__()
@@ -21,12 +21,14 @@ class UpsampleOptimizer(GraphOptimizerBase):
             self._optimize_at_current_graph_level)
 
     def _optimize_at_current_graph_level(self, graph):
-        # replace resize operations with all ones in scale with Identity nodes
+        # replace upsample node with all ones in scale with identity node
         for n in graph.get_nodes():
             if n.type == "Upsample":
                 scales = n.get_attr_value("scales")
                 if all([s == 1 for s in scales]):
                     n.type = "Identity"
+                    if len(n.input) > 0:
+                        n.input = [n.input[0]]
                     self.logger.debug("replacing " + n.name +
                                       " with Identity operation")
         return graph


### PR DESCRIPTION
Upsample operations with all ones in scale are redundant and can be safely removed. In this commit I replace them with an Identity node which is then removed by the Identity optimization step.