### PR TITLE
Add functionality for QDQ per channel

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2043,7 +2043,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = quantize_and_dequantize(x, -6.0, 6.0, signed_input=True, narrow_range=False, range_given=True)
             return tf.identity(x_, name=_TFOUTPUT)
         _ = self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
-        
+
     @check_tf_min_version("2.0")
     @check_opset_min_version(13, "quantize_and_dequantize")
     def test_qdq_per_channel_signed_input(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2043,6 +2043,19 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = quantize_and_dequantize(x, -6.0, 6.0, signed_input=True, narrow_range=False, range_given=True)
             return tf.identity(x_, name=_TFOUTPUT)
         _ = self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
+        
+    @check_tf_min_version("2.0")
+    @check_opset_min_version(13, "quantize_and_dequantize")
+    def test_qdq_per_channel_signed_input(self):
+        x_shape = [3, 3, 2]
+        x_val = np.arange(-np.prod(x_shape)/2, np.prod(x_shape)/2).astype("float32").reshape(x_shape)
+        def func(x):
+            x_ = quantize_and_dequantize(x, np.array([-1.72, -3.89]).astype(np.float32), \
+                                         np.array([5.12, 2.36]).astype(np.float32), \
+                                         signed_input=True, narrow_range=False, \
+                                         range_given=True, axis=-1)
+            return tf.identity(x_, name=_TFOUTPUT)
+        _ = self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
 
     @skip_caffe2_backend()
     @check_opset_min_version(7, "resize_nearest_neighbor")

--- a/tf2onnx/rewriter/quantization_ops_rewriter.py
+++ b/tf2onnx/rewriter/quantization_ops_rewriter.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 """
-tf2onnx.rewriter - rewrite tensorflow QuantizeAndDequantizeV3 op
+tf2onnx.rewriter - rewrite tensorflow QuantizeAndDequantizeV2|QuantizeAndDequantizeV3 op
 """
 
 import numpy as np
@@ -32,33 +32,46 @@ def create_qdq_nodes(g, match_results):
         if not signed_input:
             min_quantized, max_quantized = [0, 255]
 
+        # Get axis attribute for per channel implementation.
+        axis = qdq_node.attr['axis'].i
+
         # Get the min and max value of the inputs to QDQ op
         min_value = extract_numpy_array(qdq_node.inputs[1])
         max_value = extract_numpy_array(qdq_node.inputs[2])
 
-        # Calculate scales from the min and max values
-        scale_from_min_side = min_quantized/min_value if min_quantized*min_value > 0 else max_quantized
-        scale_from_max_side = max_quantized/max_value if max_quantized*max_value > 0 else max_quantized
+        num_channels = min_value.shape[0]
+        scales = np.zeros(num_channels, dtype=np.float32)
+        zero_point_dtype = np.int8 if signed_input else np.uint8
+        zero_point = np.zeros(num_channels, dtype=zero_point_dtype)
 
-        if scale_from_min_side < scale_from_max_side:
-            scale = scale_from_min_side
-        else:
-            scale = scale_from_max_side
+        for i in range(num_channels):
+            # Calculate scales from the min and max values
+            scale_from_min_side = min_quantized/min_value[i] if min_quantized*min_value[i] > 0 else max_quantized
+            scale_from_max_side = max_quantized/max_value[i] if max_quantized*max_value[i] > 0 else max_quantized
 
-        utils.make_sure(scale > 0, "Quantize/Dequantize scale must be greater than zero")
+            if scale_from_min_side < scale_from_max_side:
+                scale = scale_from_min_side
+            else:
+                scale = scale_from_max_side
 
-        if signed_input:
-            zero_point = np.int8(0)
-        else:
-            zero_point = np.uint8(0)
+            utils.make_sure(scale > 0, "Quantize/Dequantize scale must be greater than zero")
+            scales[i] = np.float32(scale)
+
+        # Set scalars for scale and zero point for per layer quantization
+        if num_channels == 1:
+            scales = scales[0]
+            zero_point = zero_point[0]
+            axis = np.int64(1) # Default value of axis
 
         # Split it into QuantizeLinear and DequantizeLinear and remove the QDQ node reference
-        y_quant_scale = g.make_const(name=utils.make_name("y_quant_scale"), np_val=1/scale)
+        inverse_scale = (1/scales).astype(np.float32)
+        y_quant_scale = g.make_const(name=utils.make_name("y_quant_scale"), np_val=inverse_scale)
         y_zero_point = g.make_const(name=utils.make_name("y_zero_point"), np_val=zero_point)
         quant_node = g.make_node(op_type="QuantizeLinear",
                                  inputs=[qdq_node.input[0], y_quant_scale.output[0],
                                          y_zero_point.output[0]],
                                  shapes=[qdq_node_output_shape],
+                                 attr={'axis': axis},
                                  dtypes=[qdq_node_output_dtype],
                                  name=utils.make_name("QuantLinearNode"))
 
@@ -66,13 +79,14 @@ def create_qdq_nodes(g, match_results):
 
         g.remove_node(qdq_node.name)
 
-        y_dequant_scale = g.make_const(name=utils.make_name("y_dequant_scale"), np_val=1/scale)
+        y_dequant_scale = g.make_const(name=utils.make_name("y_dequant_scale"), np_val=inverse_scale)
         y_inv_zero_point = g.make_const(name=utils.make_name("y_inv_zero_point"), np_val=zero_point)
         dequant_node = g.make_node(op_type="DequantizeLinear",
                                    inputs=[quant_node.output[0], y_dequant_scale.output[0],
                                            y_inv_zero_point.output[0]],
                                    outputs=[qdq_node.output[0]],
                                    shapes=[qdq_node_output_shape],
+                                   attr={'axis': axis},
                                    dtypes=[qdq_node_output_dtype],
                                    name=utils.make_name("DequantLinearNode"))
         g.set_shape(dequant_node.output[0], qdq_node_output_shape)


### PR DESCRIPTION
- Opset 13 introduces per channel support for QuantizeLinear and DequantizeLinear
- This PR implements conversion of TF QDQ per channel layer (through axis argument) to its ONNX counterpart.
- Verified the test case by building onnxruntime from master (with  [https://github.com/microsoft/onnxruntime/pull/4759](https://github.com/microsoft/onnxruntime/pull/4759))