### PR TITLE
Added graph methods for saving using the external data storage format

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -226,7 +226,7 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         n1 = g.get_node_by_name("n1")
         self.assertTrue("my_attr" in n1.attr)
-        self.assertTrue("my_attr" not in n1.attr_onnx)
+        self.assertTrue("my_attr" not in n1.get_onnx_attrs())
 
         n1 = helper.make_node("Conv", ["X", "W"], ["Y"], name="n1", domain="my_domain", my_attr="my_attr")
         graph_proto = helper.make_graph(
@@ -240,7 +240,7 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         g = GraphUtil.create_graph_from_onnx_graph(graph_proto)
         n1 = g.get_node_by_name("n1")
         self.assertTrue("my_attr" in n1.attr)
-        self.assertTrue("my_attr" in n1.attr_onnx)
+        self.assertTrue("my_attr" in n1.get_onnx_attrs())
 
     def test_tensor_data(self):
         tensors = {

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -282,7 +282,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             return False
         # move transpose into branches to let Transposes can be "handled" in each branch
         for n in out_nodes:
-            branch_trans = n.graph.make_node("Transpose", [trans.input[0]], attr=trans.attr_onnx)
+            branch_trans = n.graph.make_node("Transpose", [trans.input[0]], attr=trans.get_onnx_attrs())
             n.graph.replace_input(n, trans.output[0], branch_trans.output[0])
 
         self._g.remove_node(trans.name)
@@ -407,7 +407,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                 target_node.set_tensor_value(target_val)
 
                 conv_inputs = [t_p.input[0], t_p.input[1], node.input[1]]
-                conv_node = self._g.make_node(t_p.type, conv_inputs, attr=t_p.attr_onnx)
+                conv_node = self._g.make_node(t_p.type, conv_inputs, attr=t_p.get_onnx_attrs())
                 ops = self._g.get_nodes()
                 trans.input[0] = utils.port_name(conv_node.name)
                 self._g.replace_all_inputs(ops, node.output[0], trans.output[0])

--- a/tf2onnx/schemas.py
+++ b/tf2onnx/schemas.py
@@ -136,7 +136,7 @@ def infer_onnx_shape_dtype(node, opset_version, input_shapes, input_dtypes, init
                 copied_sub_graph = copy.deepcopy(sub_graph)
                 graph_proto = copied_sub_graph.make_graph("graph for " + node.name + " " + attr_name)
                 attr.append(helper.make_attribute(attr_name, graph_proto))
-        attr.extend(node.attr_onnx.values())
+        attr.extend(node.get_onnx_attrs().values())
         if attr:
             onnx_node.attribute.extend(attr)
         return onnx_node

--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -405,9 +405,9 @@ def have_same_inference_value(g, output_1, output_2):
         if node_1.type != node_2.type:
             return False
         # check onnx attributes
-        if node_1.attr_onnx.keys() != node_2.attr_onnx.keys():
+        if node_1.get_onnx_attrs().keys() != node_2.get_onnx_attrs().keys():
             return False
-        for name in node_1.attr_onnx.keys(): # pylint: disable=consider-iterating-dictionary
+        for name in node_1.get_onnx_attrs().keys(): # pylint: disable=consider-iterating-dictionary
             if node_1.get_attr_value(name) != node_2.get_attr_value(name):
                 return False
         return True


### PR DESCRIPTION
Renamed the node attr_onnx property into a function get_onnx_attrs that takes an optional external_tensor_storage object.  If passed in, the returned attributes will refer to an externally stored tensor, which will be stored in the object.  The update_proto methods pass in ExternalTensorStorage to capture the data to store externally.  