### PR TITLE
dont look at fold_constant

### DIFF
--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -216,7 +216,6 @@ class LoopTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["i:0", "output_ta:0"]
         self.run_test_case(func, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-06)
 
-    @skip_tf2()
     def test_map_fn_1(self):
         x_val = 100 * np.random.random_sample([2, 10]).astype(np.float32)
 
@@ -234,7 +233,6 @@ class LoopTests(Tf2OnnxBackendTestBase):
         output_names_with_port = ["output_0:0"]
         self.run_test_case(func, feed_dict, input_names_with_port, output_names_with_port, rtol=1e-5)
 
-    @skip_tf2()
     def test_map_fn_2(self):
         x_val = 100 * np.random.random_sample([2, 10]).astype(np.float32)
         y_val = 100 * np.random.random_sample([2, 10]).astype(np.float32)

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -12,7 +12,7 @@ import numpy as np
 import tensorflow as tf
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main, check_tf_min_version, check_tf_max_version, check_onnxruntime_min_version, skip_tf2
+from common import unittest_main, check_tf_min_version, check_tf_max_version, check_onnxruntime_min_version
 from tf2onnx.tf_loader import is_tf2
 
 

--- a/tf2onnx/tf_loader.py
+++ b/tf2onnx/tf_loader.py
@@ -433,24 +433,19 @@ def tf_optimize(input_names, output_names, graph_def, fold_constant=True):
                    [utils.node_name(i) for i in output_names]
     graph_def = extract_sub_graph(graph_def, needed_names)
 
-    if fold_constant:
-        want_grappler = is_tf2() or LooseVersion(tf.__version__) >= "1.15"
-        if want_grappler:
-            graph_def = tf_optimize_grappler(input_names, output_names, graph_def, fold_constant)
-        else:
-            # the older transform path
-            from tensorflow.tools.graph_transforms import TransformGraph  # pylint: disable=redefined-outer-name
-            transforms = []
-            if fold_constant:
-                transforms.extend([
-                    "fold_constants(ignore_errors=true)",
-                    "remove_attribute(attribute_name=_class)",  # remove node colocation attributes
-                ])
-            transforms.extend([
-                "fold_batch_norms",
-                "fold_old_batch_norms",
-            ])
-            graph_def = TransformGraph(graph_def, input_names, output_names, transforms)
+    want_grappler = is_tf2() or LooseVersion(tf.__version__) >= "1.15"
+    if want_grappler:
+        graph_def = tf_optimize_grappler(input_names, output_names, graph_def, fold_constant)
+    else:
+        # the older transform path
+        from tensorflow.tools.graph_transforms import TransformGraph  # pylint: disable=redefined-outer-name
+        transforms = [
+            "fold_constants(ignore_errors=true)",
+            "remove_attribute(attribute_name=_class)",  # remove node colocation attributes
+            "fold_batch_norms",
+            "fold_old_batch_norms",
+        ]
+        graph_def = TransformGraph(graph_def, input_names, output_names, transforms)
 
     return graph_def
 


### PR DESCRIPTION
Signed-off-by: Guenther Schmuelling <guschmue@microsoft.com>

#1166

never act on fold_constants - we'll always fold.
We keep the function for tf_loader signatures so we don't break somebody that is calling it with a fold_constants.
