### PR TITLE
transpose optimizer wrongly removes a transpose

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -86,12 +86,12 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         ops = g.get_nodes()
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { Placeholder__4 [op_type=Placeholder] ' \
+        expected = 'digraph { Placeholder__5 [op_type=Placeholder] ' \
                    'n1 [op_type=Abs] n7 [op_type=Abs] n2 [op_type=Abs] n3 [op_type=Abs] ' \
                    'n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
-                   'n5_graph_outputs_Identity__3 [op_type=Identity] input -> n1 n1:0 -> n7 ' \
-                   'n7:0 -> n2 n1:0 -> n3 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n6 ' \
-                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
+                   'n5_graph_outputs_Identity__4 [op_type=Identity] input -> n1 n1:0 -> n7 ' \
+                   'n7:0 -> n2 n1:0 -> n3 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 n5_raw_output___3:0 -> n6 ' \
+                   'n5_raw_output___3:0 -> n5_graph_outputs_Identity__4 }'
         self.assertEqual(expected, result)
 
     def test_insert_node2(self):
@@ -101,11 +101,11 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         ops = g.get_nodes()
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n7 [op_type=Abs] ' \
+        expected = 'digraph { Placeholder__5 [op_type=Placeholder] n1 [op_type=Abs] n7 [op_type=Abs] ' \
                    'n3 [op_type=Abs] n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] ' \
-                   'n6 [op_type=Identity] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
+                   'n6 [op_type=Identity] n5_graph_outputs_Identity__4 [op_type=Identity] ' \
                    'input -> n1 n1:0 -> n7 n7:0 -> n3 n7:0 -> n2 n2:0 -> n4 n3:0 -> n4 n4:0 -> n5 ' \
-                   'n5_raw_output___2:0 -> n6 n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
+                   'n5_raw_output___3:0 -> n6 n5_raw_output___3:0 -> n5_graph_outputs_Identity__4 }'
         self.assertEqual(expected, result)
 
     def test_remove_input(self):
@@ -116,11 +116,11 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
         ops = g.get_nodes()
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] n3 [op_type=Abs] ' \
+        expected = 'digraph { Placeholder__5 [op_type=Placeholder] n1 [op_type=Abs] n3 [op_type=Abs] ' \
                    'n2 [op_type=Abs] n4 [op_type=Add] n5 [op_type=Abs] n6 [op_type=Identity] ' \
-                   'n5_graph_outputs_Identity__3 [op_type=Identity] input -> n1 n1:0 -> n3 ' \
-                   'n1:0 -> n2 n2:0 -> n4 n4:0 -> n5 n5_raw_output___2:0 -> n6 ' \
-                   'n5_raw_output___2:0 -> n5_graph_outputs_Identity__3 }'
+                   'n5_graph_outputs_Identity__4 [op_type=Identity] input -> n1 n1:0 -> n3 ' \
+                   'n1:0 -> n2 n2:0 -> n4 n4:0 -> n5 n5_raw_output___3:0 -> n6 ' \
+                   'n5_raw_output___3:0 -> n5_graph_outputs_Identity__4 }'
         self.assertEqual(expected, result)
 
     def test_rewrite_subgraph(self):
@@ -144,11 +144,12 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
                 g.remove_node(n.name)
         g.topological_sort(ops)
         result = onnx_to_graphviz(g)
-        expected = 'digraph { Placeholder__4 [op_type=Placeholder] n1 [op_type=Abs] ' \
-                   'n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__5 [op_type=Sub] ' \
-                   'n6 [op_type=Identity] n5_graph_outputs_Identity__3 [op_type=Identity] ' \
-                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__5 n3:0 -> ReplacedOp__5 ' \
-                   'ReplacedOp__5:0 -> n6 ReplacedOp__5:0 -> n5_graph_outputs_Identity__3 }'
+        expected = 'digraph { Placeholder__5 [op_type=Placeholder] n1 [op_type=Abs] ' \
+                   'n3 [op_type=Abs] n2 [op_type=Abs] ReplacedOp__6 [op_type=Sub] ' \
+                   'n6 [op_type=Identity] n5_graph_outputs_Identity__4 [op_type=Identity] ' \
+                   'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__6 n3:0 -> ReplacedOp__6 ' \
+                   'ReplacedOp__6:0 -> n6 ReplacedOp__6:0 -> n5_graph_outputs_Identity__4 }'
+        self.maxDiff = None
         self.assertEqual(expected, result)
 
     def test_match_flipped(self):

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -149,7 +149,6 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
                    'n6 [op_type=Identity] n5_graph_outputs_Identity__4 [op_type=Identity] ' \
                    'input -> n1 n1:0 -> n3 n1:0 -> n2 n2:0 -> ReplacedOp__6 n3:0 -> ReplacedOp__6 ' \
                    'ReplacedOp__6:0 -> n6 ReplacedOp__6:0 -> n5_graph_outputs_Identity__4 }'
-        self.maxDiff = None
         self.assertEqual(expected, result)
 
     def test_match_flipped(self):

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -462,7 +462,7 @@ class Graph(object):
         self._output_to_consumers = {}
         self._input_to_graph = {}
         self.shapes = {}
-        self.graph_name = graph_name or "tf2onnx"
+        self.graph_name = graph_name or utils.make_name("tf2onnx")
         self._is_subgraph = is_subgraph
         self.ta_reads = []
         self.func_inputs = []
@@ -1006,7 +1006,7 @@ class Graph(object):
             all_input = list(filter(lambda a: a != '', all_input))
             for inp in sorted(all_input):
                 j = self.get_node_by_output(inp)
-                utils.make_sure(j is not None, "Cannot find node with output %r", inp)
+                utils.make_sure(j is not None, "Cannot find node with output %r in graph %r", inp, self.graph_name)
                 if self.parent_graph and j.name not in op_name_to_index:
                     # there might be some outer-scoped inputs for an inner Graph.
                     pass

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -100,6 +100,7 @@ class TransposeOptimizer(GraphOptimizerBase):
         nodes = self.nodes
         # if channel==1 or height==width==1, replace transpose with reshape
         # replacing trans with reshape is because transpose will copy data even if this transpose doesn't nothing
+        need_sort = False
         for op in nodes:
             if op.type == "Transpose":
                 input_shape = self._g.get_shape(op.input[0])
@@ -112,7 +113,9 @@ class TransposeOptimizer(GraphOptimizerBase):
                     # replace transpose with reshape
                     self._g.remove_node(op.name)
                     self._g.make_node("Reshape", [op.input[0], new_shape], name=op.name, outputs=op.output)
-                    self._g.topological_sort(self._g.get_nodes())
+                    need_sort = True
+        if need_sort:
+            self._g.topological_sort(self._g.get_nodes())
 
     def merge_duplicated_transposes(self):
         # strategy used in previous procedure is to move transpose nodes down if possible,
@@ -283,12 +286,12 @@ class TransposeOptimizer(GraphOptimizerBase):
                 op_handler = self._handler_map[p.type]
                 return op_handler(trans, p)
             return False
-        # move transpose into branches to let Transposes can be "handled" in each branch
-        for n in out_nodes:
-            branch_trans = n.graph.make_node("Transpose", [trans.input[0]], attr=trans.get_onnx_attrs())
-            n.graph.replace_input(n, trans.output[0], branch_trans.output[0])
-
-        self._g.remove_node(trans.name)
+        if out_nodes:
+            # move transpose into branches to let Transposes can be "handled" in each branch
+            for n in out_nodes:
+                branch_trans = n.graph.make_node("Transpose", [trans.input[0]], attr=trans.get_onnx_attrs())
+                n.graph.replace_input(n, trans.output[0], branch_trans.output[0])
+            self._g.remove_node(trans.name)
         return False
 
     def _remove_useless_tranpose(self, trans):


### PR DESCRIPTION
Signed-off-by: guschmue <guschmue@microsoft.com>

fix for https://github.com/onnx/tensorflow-onnx/issues/1277

transpose optimizer wrongly removes a transpose when trying to push to none existing subgraph.
