### PR TITLE
trim ci pipeline

### DIFF
--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -3,25 +3,8 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    python_versions: ['3.7']
-    tf_versions: ['1.15.2','2.3.0']
+    python_versions: ['3.8']
+    tf_versions: ['1.15.2','2.4.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'
-
-- template: 'templates/job_generator.yml'
-  parameters:
-    python_versions: [3.6']
-    tf_versions: ['1.14.0']
-    job:
-      steps:
-      - template: 'pretrained_model_test.yml'
-
-- template: 'templates/job_generator.yml'
-  parameters:
-    platforms: ['windows']
-    tf_versions: ['1.14.0']
-    job:
-      steps:
-      - template: 'pretrained_model_test.yml'
-

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -3,8 +3,8 @@
 jobs:
 - template: 'templates/job_generator.yml'
   parameters:
-    python_versions: ['3.8']
-    tf_versions: ['1.15.2','2.4.0']
+    python_versions: ['3.7']
+    tf_versions: ['1.15.5','2.4.1']
     job:
       steps:
       - template: 'pretrained_model_test.yml'


### PR DESCRIPTION
Signed-off-by: guschmue <guschmue@microsoft.com>

CI pipeline takes way to long.

Removing those because:
1) nightly will test it
2) various tensorflow and python versions are already tested in the unit tests. Same for windows. It is unlikely that integration tests will fail for those, at least we have never seen it.
