### PR TITLE
Disambiguate a unit test method

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3296,7 +3296,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT, _OUTPUT1], {_INPUT: boxes_val, _INPUT1: scores_val})
 
     @check_opset_min_version(10, "NonMaxSuppression")
-    def test_non_max_suppression_v4(self):
+    def test_non_max_suppression_v4_padded(self):
         box_num = 10
         boxes_val = np.random.random_sample([box_num, 4]).astype(np.float32)
         scores_val = np.random.random_sample([box_num]).astype(np.float32)


### PR DESCRIPTION
Two methods had the same name. Renamed one.