### PR TITLE
Add functions to decompose einsum summation

### DIFF
--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -1,0 +1,393 @@
+"""
+@brief      test log(time=6s)
+"""
+import unittest
+import io
+from contextlib import redirect_stdout
+import itertools
+import numpy as np
+from numpy.testing import assert_almost_equal
+from tf2onnx.optimizer.einsum_optimizer import (
+    numpy_diagonal, numpy_extended_dot,
+    analyse_einsum_equation, decompose_einsum_equation, EinsumSubOp,
+    apply_einsum_sequence)
+
+
+class TestEinsum(unittest.TestCase):
+
+    def assertRaise(self, fct, exc_type):
+        try:
+            fct()
+        except exc_type as e:
+            return
+        raise AssertionError("%r was not raised." % exc_type)
+
+    def test_numpy_diagonal(self):
+        mat = np.arange(8).reshape((2, 2, 2))
+        diag = numpy_diagonal(mat, 1, [1, 2])
+        assert_almost_equal(diag, np.array([[0, 3], [4, 7]]))
+        diag = numpy_diagonal(mat, 2, [1, 2])
+        assert_almost_equal(diag, np.array([[0, 3], [4, 7]]))
+
+        diag = numpy_diagonal(mat, 0, [0, 1])
+        assert_almost_equal(diag, np.array([[0, 1], [6, 7]]))
+        diag = numpy_diagonal(mat, 1, [0, 1])
+        assert_almost_equal(diag, np.array([[0, 1], [6, 7]]))
+
+        diag = numpy_diagonal(mat, 0, [0, 2])
+        assert_almost_equal(diag, np.array([[0, 2], [5, 7]]))
+        diag = numpy_diagonal(mat, 2, [0, 2])
+        assert_almost_equal(diag, np.array([[0, 2], [5, 7]]).T)
+
+    def test_numpy_extended_dot_2_a(self):
+        m1 = np.arange(4).reshape((2, 2)).astype(np.float32)
+        m2 = m1 + 10
+
+        self.assertRaise(lambda: numpy_extended_dot(m1, m2.T, [0], [1], [2]),
+                         ValueError)
+        dm1 = m1.reshape((2, 2, 1))
+        dm2 = m2.reshape((1, 2, 2))
+        dot = numpy_extended_dot(dm1, dm2, axes=[1], left=[0], right=[2])
+        exp = m1 @ m2
+        assert_almost_equal(exp, np.squeeze(dot))
+
+        dm1 = m1.reshape((2, 1, 2))
+        dm2 = m2.reshape((1, 2, 2))
+        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1])
+        exp = m1 @ m2.T
+        assert_almost_equal(exp, np.squeeze(dot))
+
+    def test_numpy_extended_dot_3(self):
+        m1 = np.arange(8).reshape((2, 2, 2))
+        m2 = m1 + 10
+
+        dot = numpy_extended_dot(m1, m2, [1], [0], [2])
+        exp = np.array([[[164, 176]], [[580, 624]]])
+        assert_almost_equal(exp, dot)
+
+        dot = numpy_extended_dot(m1, m2, [1], [2], [0])
+        exp = np.array([[[284, 376]], [[380, 504]]])
+        assert_almost_equal(exp, dot)
+
+        dot = numpy_extended_dot(m1, m2, [1], [2], [0, 1])
+        exp = np.array([[[84, 126], [200, 250]],
+                           [[116, 174], [264, 330]]])
+        assert_almost_equal(exp, dot)
+
+    def test_analyse_einsum_equation(self):
+        self.assertRaise(lambda: analyse_einsum_equation("abc"),
+                         NotImplementedError)
+        self.assertRaise(lambda: analyse_einsum_equation("abc0,ch->ah"),
+                         ValueError)
+        self.assertRaise(lambda: analyse_einsum_equation("abc,ch->a0"),
+                         ValueError)
+        res = analyse_einsum_equation("abc,ch->ah")
+        self.assertEqual(len(res), 4)
+        letters, mat, lengths, duplicates = res
+        self.assertEqual(letters, "abch")
+        assert_almost_equal(lengths, np.array([3, 2, 2]))
+        assert_almost_equal(
+            mat, np.array([[0, 1, 2, -1],
+                              [-1, -1, 0, 1],
+                              [0, -1, -1, 1]]))
+        self.assertEqual(duplicates, [None, None, None])
+
+    def test_analyse_einsum_equation_duplicates(self):
+        res = analyse_einsum_equation("aac,ca->aa")
+        self.assertEqual(len(res), 4)
+        letters, mat, lengths, duplicates = res
+        self.assertEqual(letters, "ac")
+        assert_almost_equal(lengths, np.array([3, 2, 2]))
+        self.assertEqual(duplicates, [{'a': [0, 1], 'c': [2]},
+                                      None,
+                                      {'a': [0, 1]}])
+        assert_almost_equal(
+            mat, np.array([[1, 2],
+                              [1, 0],
+                              [1, -1]]))
+
+    def test_decompose_einsum_equation_exc(self):
+        self.assertRaise(
+            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2), (2, 2),
+                                              strategy="donotexist"),
+            ValueError)
+        self.assertRaise(
+            lambda: decompose_einsum_equation("abc,ch->ah"), ValueError)
+        self.assertRaise(
+            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2), (2, 2),
+                                              "donotexist"),
+            TypeError)
+        self.assertRaise(
+            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2)),
+            ValueError)
+        self.assertRaise(
+            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2), (2, 2)),
+            ValueError)
+
+    def test_decompose_einsum_equation(self):
+        m1 = np.arange(0, 8).astype(np.float32).reshape((2, 2, 2))
+        m2 = np.arange(0, 4).astype(np.float32).reshape((2, 2))
+        exp = np.einsum("bac,ch->ah", m1, m2)
+
+        def fct():
+            print("########################## DECOMPOSE")
+            seq = decompose_einsum_equation("bac,ch->ah", (2, 2, 2), (2, 2))
+            print("########################## APPLY")
+            dot = seq.to_dot()
+            print(dot)
+            red = dot.split('red')
+            self.assertEqual(len(red), 4)
+            res = apply_einsum_sequence(seq, m1, m2)
+            print("########################## END")
+            return res
+
+        f = io.StringIO()
+        try:
+            with redirect_stdout(f):
+                res = fct()
+        except Exception as e:
+            raise AssertionError("Issue. Logs =\n%s" % f.getvalue()) from e
+
+        out = f.getvalue()
+        self.assertIn("DECOMPOSE", out)
+        assert_almost_equal(exp, res)
+
+    def test_einsum_sub_op(self):
+        self.assertRaise(lambda: EinsumSubOp(2, "er", (2, 2)), ValueError)
+        self.assertRaise(lambda: EinsumSubOp(2, "expand_dims"), RuntimeError)
+        self.assertRaise(lambda: EinsumSubOp(
+            2, "matmul", (2, 2)), RuntimeError)
+        self.assertRaise(lambda: EinsumSubOp(2, "id", (2, 2)), TypeError)
+
+    def test_case_1_iii_ii_i(self):
+        equation = 'ii->i'
+        m1 = np.arange(2 * 2).reshape((2, 2)) + 10
+        exp = np.einsum(equation, m1)
+        seq = decompose_einsum_equation(
+            equation, m1.shape)
+        res = apply_einsum_sequence(seq, m1)
+        assert_almost_equal(exp, res)
+
+    def test_case_1_iii_ii_i_j(self):
+        equation = 'iij->ij'
+        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
+        exp = np.einsum(equation, m1)
+        seq = decompose_einsum_equation(
+            equation, m1.shape)
+        dot = seq.to_dot()
+        self.assertIn("i=0,1", dot)
+        res = apply_einsum_sequence(seq, m1)
+        assert_almost_equal(exp, res)
+
+    def common_test_case_2(self, equation):
+        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
+        m2 = np.arange(4).reshape((2, 2)) + 100
+        exp = np.einsum(equation, m1, m2)
+        seq = decompose_einsum_equation(
+            equation, m1.shape, m2.shape)
+        res = apply_einsum_sequence(seq, m1, m2)
+        assert_almost_equal(exp, res)
+
+    def test_case_2_A(self):
+        self.common_test_case_2('abc,cd->abc')
+
+    def test_many_2(self):
+        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
+        m2 = np.arange(4).reshape((2, 2)) + 100
+
+        res = []
+        for p1 in itertools.permutations(list("abc")):
+            for p2 in itertools.permutations(list("cd")):
+                for i in [1, 2]:
+                    for j in [0, 1]:
+                        sp1 = "".join(p1)
+                        sp2 = "".join(p2)
+                        if len(set([sp1[0], sp1[i], sp2[j]])) != 3:
+                            continue
+                        equation = "%s,%s->%s%s%s" % (
+                            sp1, sp2, sp1[0], sp1[i], sp2[j])
+                        try:
+                            r = np.einsum(equation, m1, m2)
+                            res.append((equation, r))
+                        except ValueError:
+                            # Not viable equation.
+                            continue
+
+        for i, (eq, exp) in enumerate(res):
+            with self.subTest(equation=eq, index=i, total=len(res)):
+                seq = decompose_einsum_equation(
+                    eq, m1.shape, m2.shape)
+                res = apply_einsum_sequence(seq, m1, m2)
+                assert_almost_equal(exp, res)
+
+    def test_many_3(self):
+        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
+        m2 = np.arange(4).reshape((2, 2)) + 100
+        m3 = np.arange(8).reshape((2, 2, 2)) + 1000
+
+        res = []
+        for p1 in itertools.permutations(list("abc")):  # pylint: disable=R1702
+            for p2 in itertools.permutations(list("cd")):
+                for p3 in itertools.permutations(list("def")):
+                    for i in [1, 2]:
+                        for j in [0, 1]:
+                            sp1 = "".join(p1)
+                            sp2 = "".join(p2)
+                            sp3 = "".join(p3)
+                            equation = "%s,%s,%s->%s%s%s" % (
+                                sp1, sp2, sp3, sp1[0], sp1[i], sp3[j])
+                            try:
+                                r = np.einsum(equation, m1, m2, m3)
+                                res.append((equation, r))
+                            except ValueError:
+                                # Not viable equation.
+                                continue
+
+        for i, (eq, exp) in enumerate(res):
+            with self.subTest(equation=eq, index=i, total=len(res)):
+                seq = decompose_einsum_equation(
+                    eq, m1.shape, m2.shape, m3.shape)
+                res = apply_einsum_sequence(seq, m1, m2, m3)
+                assert_almost_equal(exp, res)
+
+    # Taken from https://github.com/numpy/numpy/blob/main/numpy/
+    # core/tests/test_einsum.py.
+
+    def optimize_compare(self, equation, operands=None):
+        if operands is not None:
+            inputs = operands
+        else:
+            eqs = equation.split("->")[0].split(",")
+            inputs = []
+            for eq in eqs:
+                i = np.arange(2 ** len(eq)).reshape(
+                    (2,) * len(eq)).astype(np.float32)
+                inputs.append(i + np.array([10], dtype=np.float32))
+
+        exp = np.einsum(equation, *inputs)
+        shapes = [m.shape for m in inputs]
+        seq = decompose_einsum_equation(equation, *shapes)
+        got = apply_einsum_sequence(seq, *inputs)
+        assert_almost_equal(exp, got)
+
+    def test_numpy_test_hadamard_like_products(self):
+        # Hadamard outer products
+        self.optimize_compare('a,ab,abc->abc')
+        self.optimize_compare('a,b,ab->ab')
+
+    def test_np_test_np_test_collapse(self):
+        # Inner products
+        self.optimize_compare('ab,ab,c->c')
+        self.optimize_compare('ab,ab,cd,cd->ac')
+        self.optimize_compare('ab,ab,cd,cd->cd')
+        # self.optimize_compare('ab,ab,c->')
+        # self.optimize_compare('ab,ab,cd,cd->')
+        # self.optimize_compare('ab,ab,cd,cd,ef,ef->')
+
+    def test_np_test_index_transformations(self):
+        # Simple index transformation cases
+        self.optimize_compare('ea,fb,gc,hd,abcd->efgh')
+        self.optimize_compare('ea,fb,abcd,gc,hd->efgh')
+        self.optimize_compare('abcd,ea,fb,gc,hd->efgh')
+
+    def test_np_test_expand(self):
+        # Outer products
+        self.optimize_compare('ab,cd,ef->abcdef')
+        self.optimize_compare('ab,cd,ef->acdf')
+        self.optimize_compare('ab,cd,de->abcde')
+        self.optimize_compare('ab,cd,de->be')
+        self.optimize_compare('ab,bcd,cd->abcd')
+        self.optimize_compare('ab,bcd,cd->abd')
+
+    def test_np_test_edge_cases(self):
+        # Difficult edge cases for optimization
+        self.optimize_compare(
+            'eac->ace', operands=[np.arange(24).reshape((2, 3, 4))])
+        self.optimize_compare('eac->ace')
+        self.optimize_compare('bd,db,eac->ace')
+        self.optimize_compare('eb,cb,fb->cef')
+        self.optimize_compare('efc,dbc,acf,fd->abe')
+        self.optimize_compare('ba,ac,da->bcd')
+
+    def test_np_test_random_cases(self):
+        # Randomly built test cases
+        self.optimize_compare('aab,fa,df,ecc->bde')
+        self.optimize_compare('bb,ff,be->e')
+        self.optimize_compare('afd,ba,cc,dc->bf')
+        self.optimize_compare('bbd,bda,fc,db->acf')
+        self.optimize_compare('dba,ead,cad->bce')
+        self.optimize_compare('aef,fbc,dca->bde')
+
+    def test_np_test_combined_views_mapping(self):
+        # gh-10792
+        a = np.arange(9).reshape(1, 1, 3, 1, 3)
+        b = np.einsum('bbcdc->d', a)
+        assert_almost_equal(b, [12])
+
+    def test_np_test_broadcasting_dot_cases1(self):
+        # Ensures broadcasting cases are not mistaken for GEMM
+
+        a = np.random.rand(1, 5, 4)
+        b = np.random.rand(4, 6)
+        c = np.random.rand(5, 6)
+        d = np.random.rand(10)
+
+        # self.optimize_compare('ijk,kl,jl', operands=[a, b, c])
+        self.optimize_compare('ijk,kl,jl,i->i', operands=[a, b, c, d])
+
+        e = np.random.rand(1, 1, 5, 4)
+        f = np.random.rand(7, 7)
+        # self.optimize_compare('abjk,kl,jl', operands=[e, b, c])
+        self.optimize_compare('abjk,kl,jl,ab->ab', operands=[e, b, c, f])
+
+    def test_np_test_broadcasting_dot_cases2(self):
+        # Edge case found in gh-11308
+        g = np.arange(64).reshape(2, 4, 8)
+        self.optimize_compare('obk,ijk->ioj', operands=[g, g])
+
+    def np_test_complex(self):
+        # Long test cases
+        self.optimize_compare('acdf,jbje,gihb,hfac,gfac,gifabc,hfac')
+        self.optimize_compare('acdf,jbje,gihb,hfac,gfac,gifabc,hfac')
+        self.optimize_compare('cd,bdhe,aidb,hgca,gc,hgibcd,hgac')
+        self.optimize_compare('abhe,hidj,jgba,hiab,gab')
+        self.optimize_compare('bde,cdh,agdb,hica,ibd,hgicd,hiac')
+        self.optimize_compare('chd,bde,agbc,hiad,hgc,hgi,hiad')
+        self.optimize_compare('chd,bde,agbc,hiad,bdi,cgh,agdb')
+        self.optimize_compare('bdhe,acad,hiab,agac,hibd')
+
+    def np_test_inner_product(self):
+        # Inner products
+        self.optimize_compare('ab,ab')
+        self.optimize_compare('ab,ba')
+        self.optimize_compare('abc,abc')
+        self.optimize_compare('abc,bac')
+        self.optimize_compare('abc,cba')
+
+    def test_np_test_random_cases_difficult(self):
+        self.optimize_compare('cac,c,h->h')
+        self.optimize_compare('cfc,c,h->h')
+        self.optimize_compare('cfc,c,d->d')
+        self.optimize_compare('c,cfc,d->d')
+        self.optimize_compare('d,c,cfc->d')
+        self.optimize_compare('d,bc,cfc->d')
+        self.optimize_compare('db,bc,cfc->d')
+        self.optimize_compare('adb,bc,cfc->d')
+        self.optimize_compare('adb,bc,fa,cfc->d')
+        self.optimize_compare('ecb,fef,bad,ed->ac')
+        self.optimize_compare('fdf,cdd,ccd,afe->ae')
+        self.optimize_compare('adb,cfc->d')
+
+    def test_np_test_edge_cases_duplicate_indices(self):
+        # Difficult edge cases for optimization
+        # self.optimize_compare('bca,cdb,dbf,afc->')
+        self.optimize_compare('dd,fb,be,cdb->cef')
+        self.optimize_compare('dcc,fce,ea,dbf->ab')
+        # self.optimize_compare('abcd,ad')
+        self.optimize_compare('ed,fcd,ff,bcf->be')
+        self.optimize_compare('baa,dcf,af,cde->be')
+        self.optimize_compare('fff,fae,bef,def->abd')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -1,6 +1,8 @@
-"""
-@brief      test log(time=6s)
-"""
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""Unit Tests for einsum decomposition."""
+
 import unittest
 import io
 from contextlib import redirect_stdout

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -10,9 +10,10 @@ from numpy.testing import assert_almost_equal
 from onnxruntime import InferenceSession
 from tf2onnx.optimizer.einsum_optimizer import (
     analyse_einsum_equation, decompose_einsum_equation, EinsumSubOp)
+from backend_test_base import Tf2OnnxBackendTestBase
 
 
-class TestEinsum(unittest.TestCase):
+class TestEinsum(Tf2OnnxBackendTestBase):
     "unit tests for einsum optimizer"
 
     def assert_raise(self, fct, exc_type):
@@ -24,7 +25,7 @@ class TestEinsum(unittest.TestCase):
 
     def apply_einsum_sequence(self, seq, *inputs):
         names = ["X%d" % i for i in range(len(inputs))]
-        onx = seq.to_onnx('Y', *names)
+        onx = seq.to_onnx('Y', *names, opset=self.config.opset)
         sess = InferenceSession(onx.SerializeToString())
         inps = {n: i.astype(np.float32) for n, i in zip(names, inputs)}
         res = sess.run(None, inps)

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -9,10 +9,9 @@ from contextlib import redirect_stdout
 import itertools
 import numpy as np
 from numpy.testing import assert_almost_equal
+from onnxruntime import InferenceSession
 from tf2onnx.optimizer.einsum_optimizer import (
-    numpy_diagonal, numpy_extended_dot,
-    analyse_einsum_equation, decompose_einsum_equation, EinsumSubOp,
-    apply_einsum_sequence)
+    analyse_einsum_equation, decompose_einsum_equation, EinsumSubOp)
 
 
 class TestEinsum(unittest.TestCase):
@@ -24,57 +23,13 @@ class TestEinsum(unittest.TestCase):
             return
         raise AssertionError("%r was not raised." % exc_type)
 
-    def test_numpy_diagonal(self):
-        mat = np.arange(8).reshape((2, 2, 2))
-        diag = numpy_diagonal(mat, 1, [1, 2])
-        assert_almost_equal(diag, np.array([[0, 3], [4, 7]]))
-        diag = numpy_diagonal(mat, 2, [1, 2])
-        assert_almost_equal(diag, np.array([[0, 3], [4, 7]]))
-
-        diag = numpy_diagonal(mat, 0, [0, 1])
-        assert_almost_equal(diag, np.array([[0, 1], [6, 7]]))
-        diag = numpy_diagonal(mat, 1, [0, 1])
-        assert_almost_equal(diag, np.array([[0, 1], [6, 7]]))
-
-        diag = numpy_diagonal(mat, 0, [0, 2])
-        assert_almost_equal(diag, np.array([[0, 2], [5, 7]]))
-        diag = numpy_diagonal(mat, 2, [0, 2])
-        assert_almost_equal(diag, np.array([[0, 2], [5, 7]]).T)
-
-    def test_numpy_extended_dot_2_a(self):
-        m1 = np.arange(4).reshape((2, 2)).astype(np.float32)
-        m2 = m1 + 10
-
-        self.assertRaise(lambda: numpy_extended_dot(m1, m2.T, [0], [1], [2]),
-                         ValueError)
-        dm1 = m1.reshape((2, 2, 1))
-        dm2 = m2.reshape((1, 2, 2))
-        dot = numpy_extended_dot(dm1, dm2, axes=[1], left=[0], right=[2])
-        exp = m1 @ m2
-        assert_almost_equal(exp, np.squeeze(dot))
-
-        dm1 = m1.reshape((2, 1, 2))
-        dm2 = m2.reshape((1, 2, 2))
-        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1])
-        exp = m1 @ m2.T
-        assert_almost_equal(exp, np.squeeze(dot))
-
-    def test_numpy_extended_dot_3(self):
-        m1 = np.arange(8).reshape((2, 2, 2))
-        m2 = m1 + 10
-
-        dot = numpy_extended_dot(m1, m2, [1], [0], [2])
-        exp = np.array([[[164, 176]], [[580, 624]]])
-        assert_almost_equal(exp, dot)
-
-        dot = numpy_extended_dot(m1, m2, [1], [2], [0])
-        exp = np.array([[[284, 376]], [[380, 504]]])
-        assert_almost_equal(exp, dot)
-
-        dot = numpy_extended_dot(m1, m2, [1], [2], [0, 1])
-        exp = np.array([[[84, 126], [200, 250]],
-                           [[116, 174], [264, 330]]])
-        assert_almost_equal(exp, dot)
+    def apply_einsum_sequence(self, seq, *inputs):
+        names = ["X%d" % i for i in range(len(inputs))]
+        onx = seq.to_onnx('Y', *names)
+        sess = InferenceSession(onx.SerializeToString())
+        inps = {n: i.astype(np.float32) for n, i in zip(names, inputs)}
+        res = sess.run(None, inps)
+        return res[0]
 
     def test_analyse_einsum_equation(self):
         self.assertRaise(lambda: analyse_einsum_equation("abc"),
@@ -108,86 +63,65 @@ class TestEinsum(unittest.TestCase):
                               [1, 0],
                               [1, -1]]))
 
-    def test_decompose_einsum_equation_exc(self):
-        self.assertRaise(
-            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2), (2, 2),
-                                              strategy="donotexist"),
-            ValueError)
-        self.assertRaise(
-            lambda: decompose_einsum_equation("abc,ch->ah"), ValueError)
-        self.assertRaise(
-            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2), (2, 2),
-                                              "donotexist"),
-            TypeError)
-        self.assertRaise(
-            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2, 2)),
-            ValueError)
-        self.assertRaise(
-            lambda: decompose_einsum_equation("abc,ch->ah", (2, 2), (2, 2)),
-            ValueError)
-
     def test_decompose_einsum_equation(self):
         m1 = np.arange(0, 8).astype(np.float32).reshape((2, 2, 2))
         m2 = np.arange(0, 4).astype(np.float32).reshape((2, 2))
         exp = np.einsum("bac,ch->ah", m1, m2)
+        seq = decompose_einsum_equation("bac,ch->ah", (2, 2, 2), (2, 2))
+        dot = seq.to_dot()
+        red = dot.split('red')
+        self.assertEqual(len(red), 5)
+        res = self.apply_einsum_sequence(seq, m1, m2)
+        assert_almost_equal(exp, res)
 
-        def fct():
-            print("########################## DECOMPOSE")
-            seq = decompose_einsum_equation("bac,ch->ah", (2, 2, 2), (2, 2))
-            print("########################## APPLY")
-            dot = seq.to_dot()
-            print(dot)
-            red = dot.split('red')
-            self.assertEqual(len(red), 4)
-            res = apply_einsum_sequence(seq, m1, m2)
-            print("########################## END")
-            return res
+    def test_decompose_einsum_equation_deep_case(self):
+        m1 = np.arange(0, 16).astype(np.float32).reshape((2, 2, 2, 2))
+        m2 = np.arange(0, 16).astype(np.float32).reshape((2, 2, 2, 2))
+        exp = np.einsum("bsnh,btnh->bnts", m1, m2)
+        seq = decompose_einsum_equation("bsnh,btnh->bnts")
+        res = self.apply_einsum_sequence(seq, m1, m2)
+        assert_almost_equal(exp, res)
 
-        f = io.StringIO()
-        try:
-            with redirect_stdout(f):
-                res = fct()
-        except Exception as e:
-            raise AssertionError("Issue. Logs =\n%s" % f.getvalue()) from e
+    def test_decompose_einsum_equation_onnx(self):
+        m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
+        m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
+        seq = decompose_einsum_equation("bac,ch->ah", (2, 3, 4), (4, 5))
+        exp = np.einsum("bac,ch->ah", m1, m2)
+        res = self.apply_einsum_sequence(seq, m1, m2)
+        assert_almost_equal(exp, res)
 
-        out = f.getvalue()
-        self.assertIn("DECOMPOSE", out)
+    def test_decompose_einsum_equation_noshape(self):
+        m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
+        m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
+        seq = decompose_einsum_equation("bac,ch->ah")
+        exp = np.einsum("bac,ch->ah", m1, m2)
+        res = self.apply_einsum_sequence(seq, m1, m2)
+        assert_almost_equal(exp, res)
+
+    def test_decompose_einsum_equation_onnx2(self):
+        m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
+        m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
+        m3 = np.arange(0, 77 * 5).astype(np.float32).reshape((5, 7, 11))
+
+        seq = decompose_einsum_equation(
+            "bac,cd,def->ebc", (2, 3, 4), (4, 5), (5, 7, 11))
+        exp = np.einsum("bac,cd,def->ebc", m1, m2, m3)
+        res = self.apply_einsum_sequence(seq, m1, m2, m3)
         assert_almost_equal(exp, res)
 
     def test_einsum_sub_op(self):
         self.assertRaise(lambda: EinsumSubOp(2, "er", (2, 2)), ValueError)
         self.assertRaise(lambda: EinsumSubOp(2, "expand_dims"), RuntimeError)
-        self.assertRaise(lambda: EinsumSubOp(
-            2, "matmul", (2, 2)), RuntimeError)
+        self.assertRaise(lambda: EinsumSubOp(2, "matmul", (2, 2)), RuntimeError)
         self.assertRaise(lambda: EinsumSubOp(2, "id", (2, 2)), TypeError)
-
-    def test_case_1_iii_ii_i(self):
-        equation = 'ii->i'
-        m1 = np.arange(2 * 2).reshape((2, 2)) + 10
-        exp = np.einsum(equation, m1)
-        seq = decompose_einsum_equation(
-            equation, m1.shape)
-        res = apply_einsum_sequence(seq, m1)
-        assert_almost_equal(exp, res)
-
-    def test_case_1_iii_ii_i_j(self):
-        equation = 'iij->ij'
-        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
-        exp = np.einsum(equation, m1)
-        seq = decompose_einsum_equation(
-            equation, m1.shape)
-        dot = seq.to_dot()
-        self.assertIn("i=0,1", dot)
-        res = apply_einsum_sequence(seq, m1)
-        assert_almost_equal(exp, res)
 
     def common_test_case_2(self, equation):
         m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
         m2 = np.arange(4).reshape((2, 2)) + 100
         exp = np.einsum(equation, m1, m2)
-        seq = decompose_einsum_equation(
-            equation, m1.shape, m2.shape)
-        res = apply_einsum_sequence(seq, m1, m2)
+
+        seq = decompose_einsum_equation(equation, m1.shape, m2.shape)
+        res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
     def test_case_2_A(self):
@@ -219,7 +153,8 @@ class TestEinsum(unittest.TestCase):
             with self.subTest(equation=eq, index=i, total=len(res)):
                 seq = decompose_einsum_equation(
                     eq, m1.shape, m2.shape)
-                res = apply_einsum_sequence(seq, m1, m2)
+                res = self.apply_einsum_sequence(seq, m1, m2)
+                exp = np.einsum(eq, m1, m2)
                 assert_almost_equal(exp, res)
 
     def test_many_3(self):
@@ -249,51 +184,48 @@ class TestEinsum(unittest.TestCase):
             with self.subTest(equation=eq, index=i, total=len(res)):
                 seq = decompose_einsum_equation(
                     eq, m1.shape, m2.shape, m3.shape)
-                res = apply_einsum_sequence(seq, m1, m2, m3)
+                res = self.apply_einsum_sequence(seq, m1, m2, m3)
+                exp = np.einsum(eq, m1, m2, m3)
                 assert_almost_equal(exp, res)
 
     # Taken from https://github.com/numpy/numpy/blob/main/numpy/
     # core/tests/test_einsum.py.
 
     def optimize_compare(self, equation, operands=None):
-        if operands is not None:
-            inputs = operands
-        else:
-            eqs = equation.split("->")[0].split(",")
-            inputs = []
-            for eq in eqs:
-                i = np.arange(2 ** len(eq)).reshape(
-                    (2,) * len(eq)).astype(np.float32)
-                inputs.append(i + np.array([10], dtype=np.float32))
+        with self.subTest(equation=equation):
+            if operands is not None:
+                inputs = operands
+            else:
+                eqs = equation.split("->")[0].split(",")
+                inputs = []
+                for d, eq in enumerate(eqs):
+                    i = np.arange(2 ** len(eq)).reshape(
+                        (2,) * len(eq)).astype(np.float32)
+                    inputs.append(
+                        i + np.array([3 ** d], dtype=np.float32))
 
-        exp = np.einsum(equation, *inputs)
-        shapes = [m.shape for m in inputs]
-        seq = decompose_einsum_equation(equation, *shapes)
-        got = apply_einsum_sequence(seq, *inputs)
-        assert_almost_equal(exp, got)
+            exp = np.einsum(equation, *inputs)
+            shapes = [m.shape for m in inputs]
+
+            seq = decompose_einsum_equation(equation, *shapes)
+            got = self.apply_einsum_sequence(seq, *inputs)
+            assert_almost_equal(exp, got, decimal=5)
 
     def test_numpy_test_hadamard_like_products(self):
-        # Hadamard outer products
         self.optimize_compare('a,ab,abc->abc')
         self.optimize_compare('a,b,ab->ab')
 
     def test_np_test_np_test_collapse(self):
-        # Inner products
-        self.optimize_compare('ab,ab,c->c')
         self.optimize_compare('ab,ab,cd,cd->ac')
+        self.optimize_compare('ab,ab,c->c')
         self.optimize_compare('ab,ab,cd,cd->cd')
-        # self.optimize_compare('ab,ab,c->')
-        # self.optimize_compare('ab,ab,cd,cd->')
-        # self.optimize_compare('ab,ab,cd,cd,ef,ef->')
 
     def test_np_test_index_transformations(self):
-        # Simple index transformation cases
         self.optimize_compare('ea,fb,gc,hd,abcd->efgh')
         self.optimize_compare('ea,fb,abcd,gc,hd->efgh')
         self.optimize_compare('abcd,ea,fb,gc,hd->efgh')
 
     def test_np_test_expand(self):
-        # Outer products
         self.optimize_compare('ab,cd,ef->abcdef')
         self.optimize_compare('ab,cd,ef->acdf')
         self.optimize_compare('ab,cd,de->abcde')
@@ -301,18 +233,21 @@ class TestEinsum(unittest.TestCase):
         self.optimize_compare('ab,bcd,cd->abcd')
         self.optimize_compare('ab,bcd,cd->abd')
 
-    def test_np_test_edge_cases(self):
-        # Difficult edge cases for optimization
+    def test_np_test_edge_cases1(self):
+        self.optimize_compare('efc,dbc,acf,fd->abe')
         self.optimize_compare(
             'eac->ace', operands=[np.arange(24).reshape((2, 3, 4))])
         self.optimize_compare('eac->ace')
         self.optimize_compare('bd,db,eac->ace')
-        self.optimize_compare('eb,cb,fb->cef')
-        self.optimize_compare('efc,dbc,acf,fd->abe')
         self.optimize_compare('ba,ac,da->bcd')
 
+    def test_np_test_edge_cases2(self):
+        self.optimize_compare(
+            'eac->ace', operands=[np.arange(24).reshape((2, 3, 4))])
+        self.optimize_compare('eb,cb,fb->cef')
+
+    @unittest.skipIf(True, "diagonal still not converted into ONNX")
     def test_np_test_random_cases(self):
-        # Randomly built test cases
         self.optimize_compare('aab,fa,df,ecc->bde')
         self.optimize_compare('bb,ff,be->e')
         self.optimize_compare('afd,ba,cc,dc->bf')
@@ -321,34 +256,26 @@ class TestEinsum(unittest.TestCase):
         self.optimize_compare('aef,fbc,dca->bde')
 
     def test_np_test_combined_views_mapping(self):
-        # gh-10792
         a = np.arange(9).reshape(1, 1, 3, 1, 3)
         b = np.einsum('bbcdc->d', a)
         assert_almost_equal(b, [12])
 
     def test_np_test_broadcasting_dot_cases1(self):
-        # Ensures broadcasting cases are not mistaken for GEMM
-
         a = np.random.rand(1, 5, 4)
         b = np.random.rand(4, 6)
         c = np.random.rand(5, 6)
         d = np.random.rand(10)
-
-        # self.optimize_compare('ijk,kl,jl', operands=[a, b, c])
         self.optimize_compare('ijk,kl,jl,i->i', operands=[a, b, c, d])
-
         e = np.random.rand(1, 1, 5, 4)
         f = np.random.rand(7, 7)
-        # self.optimize_compare('abjk,kl,jl', operands=[e, b, c])
         self.optimize_compare('abjk,kl,jl,ab->ab', operands=[e, b, c, f])
 
     def test_np_test_broadcasting_dot_cases2(self):
-        # Edge case found in gh-11308
-        g = np.arange(64).reshape(2, 4, 8)
-        self.optimize_compare('obk,ijk->ioj', operands=[g, g])
+        f = np.arange(7 * 55).reshape(7, 11, 5)
+        g = np.arange(30).reshape(2, 3, 5)
+        self.optimize_compare('obk,ijk->ioj', operands=[f, g])
 
     def np_test_complex(self):
-        # Long test cases
         self.optimize_compare('acdf,jbje,gihb,hfac,gfac,gifabc,hfac')
         self.optimize_compare('acdf,jbje,gihb,hfac,gfac,gifabc,hfac')
         self.optimize_compare('cd,bdhe,aidb,hgca,gc,hgibcd,hgac')
@@ -359,33 +286,31 @@ class TestEinsum(unittest.TestCase):
         self.optimize_compare('bdhe,acad,hiab,agac,hibd')
 
     def np_test_inner_product(self):
-        # Inner products
         self.optimize_compare('ab,ab')
         self.optimize_compare('ab,ba')
         self.optimize_compare('abc,abc')
         self.optimize_compare('abc,bac')
         self.optimize_compare('abc,cba')
 
+    @unittest.skipIf(True, "diagonal still not converted into ONNX")
     def test_np_test_random_cases_difficult(self):
+        self.optimize_compare('db,bc,cfc->d')
         self.optimize_compare('cac,c,h->h')
         self.optimize_compare('cfc,c,h->h')
         self.optimize_compare('cfc,c,d->d')
         self.optimize_compare('c,cfc,d->d')
         self.optimize_compare('d,c,cfc->d')
         self.optimize_compare('d,bc,cfc->d')
-        self.optimize_compare('db,bc,cfc->d')
         self.optimize_compare('adb,bc,cfc->d')
         self.optimize_compare('adb,bc,fa,cfc->d')
         self.optimize_compare('ecb,fef,bad,ed->ac')
         self.optimize_compare('fdf,cdd,ccd,afe->ae')
         self.optimize_compare('adb,cfc->d')
 
+    @unittest.skipIf(True, "diagonal still not converted into ONNX")
     def test_np_test_edge_cases_duplicate_indices(self):
-        # Difficult edge cases for optimization
-        # self.optimize_compare('bca,cdb,dbf,afc->')
         self.optimize_compare('dd,fb,be,cdb->cef')
         self.optimize_compare('dcc,fce,ea,dbf->ab')
-        # self.optimize_compare('abcd,ad')
         self.optimize_compare('ed,fcd,ff,bcf->be')
         self.optimize_compare('baa,dcf,af,cde->be')
         self.optimize_compare('fff,fae,bef,def->abd')

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -56,6 +56,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
 
     @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation(self):
+        "test decompose einsum"
         m1 = np.arange(0, 8).astype(np.float32).reshape((2, 2, 2))
         m2 = np.arange(0, 4).astype(np.float32).reshape((2, 2))
         exp = np.einsum("bac,ch->ah", m1, m2)
@@ -95,6 +96,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
 
     @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation_onnx2(self):
+        "test bac,cd,def->ebc"
         m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
         m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
         m3 = np.arange(0, 77 * 5).astype(np.float32).reshape((5, 7, 11))

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -11,6 +11,7 @@ from onnxruntime import InferenceSession
 from tf2onnx.optimizer.einsum_optimizer import (
     analyse_einsum_equation, decompose_einsum_equation, EinsumSubOp)
 from backend_test_base import Tf2OnnxBackendTestBase
+from common import check_opset_min_version
 
 
 class TestEinsum(Tf2OnnxBackendTestBase):
@@ -53,6 +54,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         self.assertEqual(duplicates, [{'a': [0, 1], 'c': [2]}, None, {'a': [0, 1]}])
         assert_almost_equal(mat, np.array([[1, 2], [1, 0], [1, -1]]))
 
+    @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation(self):
         m1 = np.arange(0, 8).astype(np.float32).reshape((2, 2, 2))
         m2 = np.arange(0, 4).astype(np.float32).reshape((2, 2))
@@ -64,6 +66,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation_deep_case(self):
         m1 = np.arange(0, 16).astype(np.float32).reshape((2, 2, 2, 2))
         m2 = np.arange(0, 16).astype(np.float32).reshape((2, 2, 2, 2))
@@ -72,6 +75,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation_onnx(self):
         m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
         m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
@@ -80,6 +84,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation_noshape(self):
         m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
         m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
@@ -88,6 +93,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_decompose_einsum_equation_onnx2(self):
         m1 = np.arange(0, 24).astype(np.float32).reshape((2, 3, 4))
         m2 = np.arange(0, 20).astype(np.float32).reshape((4, 5))
@@ -114,9 +120,11 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         res = self.apply_einsum_sequence(seq, m1, m2)
         assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_case_2_a(self):
         self.common_test_case_2('abc,cd->abc')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_many_2(self):
         "test many equation with 2 inputs"
         m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
@@ -148,6 +156,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
                 exp = np.einsum(eq, m1, m2)
                 assert_almost_equal(exp, res)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_many_3(self):
         "test many equation with 3 inputs"
         m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
@@ -204,20 +213,24 @@ class TestEinsum(Tf2OnnxBackendTestBase):
             got = self.apply_einsum_sequence(seq, *inputs)
             assert_almost_equal(exp, got, decimal=5)
 
+    @check_opset_min_version(13, "Squeeze")
     def test_numpy_test_hadamard_like_products(self):
         self.optimize_compare('a,ab,abc->abc')
         self.optimize_compare('a,b,ab->ab')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_np_test_collapse(self):
         self.optimize_compare('ab,ab,cd,cd->ac')
         self.optimize_compare('ab,ab,c->c')
         self.optimize_compare('ab,ab,cd,cd->cd')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_index_transformations(self):
         self.optimize_compare('ea,fb,gc,hd,abcd->efgh')
         self.optimize_compare('ea,fb,abcd,gc,hd->efgh')
         self.optimize_compare('abcd,ea,fb,gc,hd->efgh')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_expand(self):
         self.optimize_compare('ab,cd,ef->abcdef')
         self.optimize_compare('ab,cd,ef->acdf')
@@ -226,6 +239,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         self.optimize_compare('ab,bcd,cd->abcd')
         self.optimize_compare('ab,bcd,cd->abd')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_edge_cases1(self):
         self.optimize_compare('efc,dbc,acf,fd->abe')
         self.optimize_compare(
@@ -234,6 +248,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         self.optimize_compare('bd,db,eac->ace')
         self.optimize_compare('ba,ac,da->bcd')
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_edge_cases2(self):
         self.optimize_compare(
             'eac->ace', operands=[np.arange(24).reshape((2, 3, 4))])
@@ -253,6 +268,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         b = np.einsum('bbcdc->d', a)
         assert_almost_equal(b, [12])
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_broadcasting_dot_cases1(self):
         a = np.random.rand(1, 5, 4)
         b = np.random.rand(4, 6)
@@ -263,6 +279,7 @@ class TestEinsum(Tf2OnnxBackendTestBase):
         f = np.random.rand(7, 7)
         self.optimize_compare('abjk,kl,jl,ab->ab', operands=[e, b, c, f])
 
+    @check_opset_min_version(13, "Squeeze")
     def test_np_test_broadcasting_dot_cases2(self):
         f = np.arange(7 * 55).reshape(7, 11, 5)
         g = np.arange(30).reshape(2, 3, 5)

--- a/tests/test_einsum_helper.py
+++ b/tests/test_einsum_helper.py
@@ -13,6 +13,7 @@ from tf2onnx.optimizer.einsum_optimizer import (
 
 
 class TestEinsum(unittest.TestCase):
+    "unit tests for einsum optimizer"
 
     def assert_raise(self, fct, exc_type):
         try:
@@ -30,6 +31,7 @@ class TestEinsum(unittest.TestCase):
         return res[0]
 
     def test_analyse_einsum_equation(self):
+        "unit test"
         self.assert_raise(lambda: analyse_einsum_equation("abc"), NotImplementedError)
         self.assert_raise(lambda: analyse_einsum_equation("abc0,ch->ah"), ValueError)
         self.assert_raise(lambda: analyse_einsum_equation("abc,ch->a0"), ValueError)
@@ -284,6 +286,7 @@ class TestEinsum(unittest.TestCase):
 
     @unittest.skipIf(True, reason="diagonal still not converted into ONNX")
     def test_np_test_random_cases_difficult(self):
+        "unit test"
         self.optimize_compare('db,bc,cfc->d')
         self.optimize_compare('cac,c,h->h')
         self.optimize_compare('cfc,c,h->h')

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -109,6 +109,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         self.common_einsum('obk,ijk->ioj', operands=[f, g],
                            catch_errors=False)
 
+    @check_opset_min_version(11, "Einsum")
     def test_np_test_exp(self):
         self.common_einsum('iij,jk->ik', catch_errors=True)
 

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -109,7 +109,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         self.common_einsum('obk,ijk->ioj', operands=[f, g],
                            catch_errors=False)
 
-    @check_opset_min_version(11, "Einsum")
+    @check_opset_min_version(12, "Einsum")
     def test_np_test_exp(self):
         self.common_einsum('iij,jk->ik', catch_errors=True)
 

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""Unit Tests for optimizers such as TransposeOptimizer."""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+from collections import OrderedDict
+import numpy as np
+from numpy.testing import assert_almost_equal
+from onnx import helper, numpy_helper, TensorProto, OperatorSetIdProto
+from onnxruntime import InferenceSession
+from parameterized import parameterized
+
+from backend_test_base import Tf2OnnxBackendTestBase
+from common import unittest_main, group_nodes_by_type, check_opset_min_version, check_opset_max_version, get_test_config
+from tf2onnx import utils, constants
+from tf2onnx.graph import GraphUtil
+from tf2onnx.optimizer import EinsumOptimizer
+
+
+# pylint: disable=missing-docstring,invalid-name,unused-argument,using-constant-test
+
+class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
+    """Run original model proto and modified model proto with onnxruntime, compare the results."""
+
+    def run_and_compare(self, output_names_with_port, onnx_feed_dict, origin_proto, op_type,
+                        debug=False, rtol=1e-07):
+        optimizers = OrderedDict([("optimize_einsum", EinsumOptimizer)])
+        utils.make_sure(op_type is not None,
+                        "op_type should be specified")
+        utils.make_sure(self.config.is_onnxruntime_backend,
+                        "only onnxruntime is supported to test transpose optimizer")
+
+        origin_model_path = self.save_onnx_model(
+            origin_proto, onnx_feed_dict, postfix="_origin")
+        expected = self.run_onnxruntime(
+            origin_model_path, onnx_feed_dict, output_names_with_port)
+
+        new_proto, new_graph = GraphUtil.optimize_model_proto(
+            origin_proto, catch_errors=False, return_graph=True, optimizers=optimizers)
+        self.assertTrue(new_proto,
+                        msg="model proto after optimizer should not be None")
+                        
+        new_model_path = self.save_onnx_model(new_proto, onnx_feed_dict, postfix="_opt")
+        current = GraphUtil.get_node_count_from_onnx_graph(new_proto.graph)
+        actual = self.run_onnxruntime(new_model_path, onnx_feed_dict, output_names_with_port)
+
+        for expected_val, actual_val in zip(expected, actual):
+            self.assertAllClose(expected_val, actual_val, rtol=rtol, atol=1e-5)
+            self.assertEqual(expected_val.dtype, actual_val.dtype)
+            self.assertEqual(expected_val.shape, actual_val.shape)
+
+        self.assert_shapes_correct(new_graph, allow_missing=False, run_checker=True)
+        return new_proto
+
+    def run_einsum_compare(self, output_names_with_port, onnx_feed_dict, origin_proto,
+                           remaining_transpose_num=None, debug=False, rtol=1e-07):
+        return self.run_and_compare(output_names_with_port, onnx_feed_dict, origin_proto, op_type="Einsum",
+                                    debug=debug, rtol=rtol)
+
+    def make_model(self, graph, producer_name="onnx-tests"):
+        imp = OperatorSetIdProto()
+        imp.version = self.config.opset
+        model_proto = helper.make_model(graph, producer_name=producer_name, opset_imports=[imp])
+        try:
+            model_proto.ir_version = constants.OPSET_TO_IR_VERSION.get(
+                self.config.opset, model_proto.ir_version)
+        except:  # pylint: disable=bare-except
+            pass
+        return model_proto
+
+    def common_einsum(self, equation, operands=None):
+        if operands is not None:
+            inputs = operands
+        else:
+            eqs = equation.split("->")[0].split(",")
+            inputs = []
+            for d, eq in enumerate(eqs):
+                i = np.arange(2 ** len(eq)).reshape(
+                    (2,) * len(eq)).astype(np.float32)
+                inputs.append(
+                    i + np.array([3 ** d], dtype=np.float32))
+        output_dim = len(equation.split("->")[1])
+        node1 = helper.make_node("Einsum", ["X0", "X1"], ["Y"], equation=equation)
+        graph = helper.make_graph(
+            [node1],
+            "test_optimization",
+            [helper.make_tensor_value_info(
+                "X%d" % i, TensorProto.FLOAT, [None] * len(operands[i].shape))
+             for i in range(len(operands))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None] * output_dim)])
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        feed_dict = {"X%d" % i: o for i, o in enumerate(operands)}
+        new_model_proto = self.run_einsum_compare(["Y"], feed_dict, model_proto)
+
+        sess1 = InferenceSession(model_proto.SerializeToString())
+        sess2 = InferenceSession(new_model_proto.SerializeToString())
+        got1 = sess1.run(None, feed_dict)
+        got2 = sess2.run(None, feed_dict)
+        assert_almost_equal(got1, got2)
+        self.assertNotIn('Einsum', str(new_model_proto))        
+
+    def test_np_test_broadcasting_dot_cases2(self):
+        f = np.arange(7 * 55).reshape(7, 11, 5).astype(np.float32)
+        g = np.arange(30).reshape(2, 3, 5).astype(np.float32)
+        self.common_einsum('obk,ijk->ioj', operands=[f, g])
+
+
+if __name__ == "__main__":
+    unittest_main()

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -10,7 +10,7 @@ from onnx import helper, TensorProto, OperatorSetIdProto
 from onnxruntime import InferenceSession
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main
+from common import unittest_main, check_opset_min_version
 from tf2onnx import utils, constants
 from tf2onnx.graph import GraphUtil
 from tf2onnx.optimizer import EinsumOptimizer
@@ -102,6 +102,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         if not catch_errors:
             self.assertNotIn('Einsum', str(new_model_proto))
 
+    @check_opset_min_version(13, "Unsqueeze")
     def test_np_test_broadcasting_dot_cases2(self):
         f = np.arange(7 * 55).reshape(7, 11, 5).astype(np.float32)
         g = np.arange(30).reshape(2, 3, 5).astype(np.float32)

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -3,16 +3,11 @@
 
 """Unit Tests for optimizers such as TransposeOptimizer."""
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_almost_equal
 from onnx import helper, TensorProto, OperatorSetIdProto
 from onnxruntime import InferenceSession
-from parameterized import parameterized
 
 from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -7,16 +7,15 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
 from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_almost_equal
-from onnx import helper, numpy_helper, TensorProto, OperatorSetIdProto
+from onnx import helper, TensorProto, OperatorSetIdProto
 from onnxruntime import InferenceSession
 from parameterized import parameterized
 
 from backend_test_base import Tf2OnnxBackendTestBase
-from common import unittest_main, group_nodes_by_type, check_opset_min_version, check_opset_max_version, get_test_config
+from common import unittest_main
 from tf2onnx import utils, constants
 from tf2onnx.graph import GraphUtil
 from tf2onnx.optimizer import EinsumOptimizer
@@ -28,7 +27,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
     """Run original model proto and modified model proto with onnxruntime, compare the results."""
 
     def run_and_compare(self, output_names_with_port, onnx_feed_dict, origin_proto, op_type,
-                        debug=False, rtol=1e-07):
+                        debug=False, rtol=1e-07, catch_errors=True):
         optimizers = OrderedDict([("optimize_einsum", EinsumOptimizer)])
         utils.make_sure(op_type is not None,
                         "op_type should be specified")
@@ -41,7 +40,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
             origin_model_path, onnx_feed_dict, output_names_with_port)
 
         new_proto, new_graph = GraphUtil.optimize_model_proto(
-            origin_proto, catch_errors=False, return_graph=True, optimizers=optimizers)
+            origin_proto, catch_errors=catch_errors, return_graph=True, optimizers=optimizers)
         self.assertTrue(new_proto,
                         msg="model proto after optimizer should not be None")
 
@@ -58,9 +57,10 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         return new_proto
 
     def run_einsum_compare(self, output_names_with_port, onnx_feed_dict, origin_proto,
-                           remaining_transpose_num=None, debug=False, rtol=1e-07):
+                           remaining_transpose_num=None, debug=False, rtol=1e-07,
+                           catch_errors=True):
         return self.run_and_compare(output_names_with_port, onnx_feed_dict, origin_proto, op_type="Einsum",
-                                    debug=debug, rtol=rtol)
+                                    debug=debug, rtol=rtol, catch_errors=catch_errors)
 
     def make_model(self, graph, producer_name="onnx-tests"):
         imp = OperatorSetIdProto()
@@ -73,7 +73,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
             pass
         return model_proto
 
-    def common_einsum(self, equation, operands=None):
+    def common_einsum(self, equation, operands=None, catch_errors=True):
         if operands is not None:
             inputs = operands
         else:
@@ -90,25 +90,31 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
             [node1],
             "test_optimization",
             [helper.make_tensor_value_info(
-                "X%d" % i, TensorProto.FLOAT, [None] * len(operands[i].shape))
-             for i in range(len(operands))],
+                "X%d" % i, TensorProto.FLOAT, [None] * len(inputs[i].shape))
+             for i in range(len(inputs))],
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None] * output_dim)])
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
-        feed_dict = {"X%d" % i: o for i, o in enumerate(operands)}
-        new_model_proto = self.run_einsum_compare(["Y"], feed_dict, model_proto)
+        feed_dict = {"X%d" % i: o for i, o in enumerate(inputs)}
+        new_model_proto = self.run_einsum_compare(["Y"], feed_dict, model_proto,
+                                                  catch_errors=catch_errors)
 
         sess1 = InferenceSession(model_proto.SerializeToString())
         sess2 = InferenceSession(new_model_proto.SerializeToString())
         got1 = sess1.run(None, feed_dict)
         got2 = sess2.run(None, feed_dict)
         assert_almost_equal(got1, got2)
-        self.assertNotIn('Einsum', str(new_model_proto))
+        if not catch_errors:
+            self.assertNotIn('Einsum', str(new_model_proto))
 
     def test_np_test_broadcasting_dot_cases2(self):
         f = np.arange(7 * 55).reshape(7, 11, 5).astype(np.float32)
         g = np.arange(30).reshape(2, 3, 5).astype(np.float32)
-        self.common_einsum('obk,ijk->ioj', operands=[f, g])
+        self.common_einsum('obk,ijk->ioj', operands=[f, g],
+                           catch_errors=False)
+
+    def test_np_test_exp(self):
+        self.common_einsum('iij,jk->ik', catch_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -44,9 +44,9 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
             origin_proto, catch_errors=False, return_graph=True, optimizers=optimizers)
         self.assertTrue(new_proto,
                         msg="model proto after optimizer should not be None")
-                        
+
         new_model_path = self.save_onnx_model(new_proto, onnx_feed_dict, postfix="_opt")
-        current = GraphUtil.get_node_count_from_onnx_graph(new_proto.graph)
+        # current = GraphUtil.get_node_count_from_onnx_graph(new_proto.graph)
         actual = self.run_onnxruntime(new_model_path, onnx_feed_dict, output_names_with_port)
 
         for expected_val, actual_val in zip(expected, actual):
@@ -103,7 +103,7 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         got1 = sess1.run(None, feed_dict)
         got2 = sess2.run(None, feed_dict)
         assert_almost_equal(got1, got2)
-        self.assertNotIn('Einsum', str(new_model_proto))        
+        self.assertNotIn('Einsum', str(new_model_proto))
 
     def test_np_test_broadcasting_dot_cases2(self):
         f = np.arange(7 * 55).reshape(7, 11, 5).astype(np.float32)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1004,10 +1004,6 @@ class Graph(object):
         def _push_stack(stack, node, in_stack):
             stack.append(node)
             if node in in_stack:
-                import pprint
-                pprint.pprint(in_stack)
-                pprint.pprint(stack)
-                pprint.pprint(ops)
                 raise ValueError('Graph has cycles, node.name=%r.' % ops[node].name)
             in_stack[node] = True
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1576,11 +1576,12 @@ class GraphUtil(object):
     """Utilities for Graph manipulation."""
 
     @staticmethod
-    def optimize_graph(graph, catch_errors=True):
-        return optimizer.optimize_graph(graph, catch_errors)
+    def optimize_graph(graph, catch_errors=True, optimizers=None):
+        return optimizer.optimize_graph(graph, catch_errors, optimizers=optimizers)
 
     @staticmethod
-    def optimize_model_proto(onnx_model_proto, catch_errors=True, return_graph=False):
+    def optimize_model_proto(onnx_model_proto, catch_errors=True, return_graph=False,
+                             optimizers=None):
         """Optimize the model proto, for example: eliminating all useless Transpose pairs.
 
         Returns:
@@ -1590,7 +1591,7 @@ class GraphUtil(object):
         try:
             kwargs = GraphUtil.get_onnx_model_properties(onnx_model_proto)
             graph = GraphUtil.create_graph_from_onnx_model(onnx_model_proto)
-            graph = GraphUtil.optimize_graph(graph, catch_errors)
+            graph = GraphUtil.optimize_graph(graph, catch_errors, optimizers=optimizers)
             model_proto = graph.make_model(onnx_model_proto.graph.doc_string,
                                            graph_name=onnx_model_proto.graph.name, **kwargs)
 

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1004,7 +1004,11 @@ class Graph(object):
         def _push_stack(stack, node, in_stack):
             stack.append(node)
             if node in in_stack:
-                raise ValueError('Graph has cycles, node=' + ops[node].name)
+                import pprint
+                pprint.pprint(in_stack)
+                pprint.pprint(stack)
+                pprint.pprint(ops)
+                raise ValueError('Graph has cycles, node.name=%r.' % ops[node].name)
             in_stack[node] = True
 
         def _get_unvisited_child(g, node, not_visited):

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import copy
 
 from .const_fold_optimizer import ConstFoldOptimizer
+from .einsum_optimizer import EinsumOptimizer
 from .identity_optimizer import IdentityOptimizer
 from .merge_duplicated_nodes_optimizer import MergeDuplicatedNodesOptimizer
 from .transpose_optimizer import TransposeOptimizer
@@ -44,13 +45,13 @@ def _get_optimizers():
     return _optimizers
 
 
-def optimize_graph(graph, catch_errors=True):
+def optimize_graph(graph, catch_errors=True, optimizers=None):
     """ Optimize graph, return optimized graph. No throw if catch_errors is true"""
     logger = logging.getLogger(__name__)
     logger.info("Optimizing ONNX model")
 
     before = graph.dump_node_statistics()
-    opts = _get_optimizers()
+    opts = _get_optimizers() if optimizers is None else optimizers
     continue_flag = True
     iteration = 0
     while continue_flag:

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -34,6 +34,7 @@ _optimizers = OrderedDict([
     ("q_dq_optimizer", QDQOptimizer),
     ("remove_identity", IdentityOptimizer),
     ("remove_back_to_back", BackToBackOptimizer),
+    ("einsum_optimizer", EinsumOptimizer),
 ])
 
 

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -100,20 +100,6 @@ class EinsumSubOp:
             self.__class__.__name__, self.name, inps, kw)
         return m
 
-    def dot_label(self):
-        """
-        Displays some informations useful to understand the operator.
-        """
-        if self.name == "matmul":
-            ndim = self.kwargs['ndim']
-            axes = self.kwargs['axes']
-            left = self.kwargs['left']
-            right = self.kwargs['right']
-            eq = _numpy_extended_dot_equation(ndim, ndim, axes, left, right)
-            eq = eq.replace(">", "\\\\>")
-            return "~" + eq
-        return None
-
     def _check_arg_(self, name, typ, empty=False):
         if name not in self.kwargs:
             raise RuntimeError(
@@ -619,7 +605,7 @@ class EinsumSubOp:
         :return: output
         """
         if opset is None:
-            opset = get_opset_number_from_onnx()
+            opset = onnx_opset_version()
         method_name = "_to_onnx_%s" % self.name
         meth = getattr(self, method_name, None)
         if meth is None:
@@ -769,21 +755,16 @@ class GraphEinsumSubOp:
                 lab = "input %d\\\\n%s\\\\n%s%s" % (
                     v, letters, str(self.metadata['mat0'][v]), dup)
                 sk = v
-                extended_lab = ""
             else:
                 lab = "%s\\\\n%s" % (v.name, d2s(v.kwargs))
                 sk = id(v)
-                extended_lab = v.dot_label()
-                if extended_lab:
-                    extended_lab = "\\\\n" + extended_lab
 
             if sk in self._mark and isinstance(self._mark[sk], int):
                 la = self._mark[sk]
                 lab = lab.replace("\\\\n", " - I%d\\\\n" % la)
-                s = ('%d [label="%s%s" style=filled '
-                     'fillcolor=red];' % (k, lab, extended_lab))
+                s = ('%d [label="%s" style=filled fillcolor=red];' % (k, lab))
             else:
-                s = '%d [label="%s%s"];' % (k, lab, extended_lab)
+                s = '%d [label="%s"];' % (k, lab)
             rows.append(s)
             if not hasattr(v, 'inputs'):
                 continue

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -69,6 +69,7 @@ class EinsumSubOp:
         self._check_()
 
     def _check_(self):
+        "Checks for wrong values."
         if self.name == 'transpose':
             self._check_arg_('perm', tuple)
             perm = self.kwargs['perm']
@@ -201,13 +202,13 @@ class EinsumSubOp:
             for ch in choices:
                 if ch != choice:
                     to_remove.append(ch)
-            for i in range(len(row)):  # pylint: disable=C0200
+            for i in range(len(row)):
                 if row[i] in choices:
                     if row[i] != choice:
                         row[i] = choice
         to_remove.sort()
         for r in to_remove:
-            for i in range(len(row)):  # pylint: disable=C0200
+            for i in range(len(row)):
                 if row[i] == r:
                     raise RuntimeError(
                         "Unexpected result r=%r row=%r to_remove=%r "
@@ -301,6 +302,7 @@ class EinsumSubOp:
                 "%d." % (m.shape, self.full_dim))
 
     def _get_data(self, data, key):
+        "Returns data[key] or raises an exception if not here."
         if isinstance(key, int):
             if key not in data:
                 raise RuntimeError(
@@ -325,13 +327,13 @@ class EinsumSubOp:
                 "Opset (%r) must be >= %r for operator %r."
                 "" % (opset, limit, self.name))
 
-    def _to_onnx_id(self, names, opset, **kwargs):
+    def _to_onnx_id(self, names, opset):
         self._check_inputs_(1)
         inp = self.inputs[0]
         name = self._get_data(names, inp)
         yield helper.make_node('Identity', [name], [self._onnx_name()])
 
-    def _to_onnx_expand_dims(self, names, opset, **kwargs):
+    def _to_onnx_expand_dims(self, names, opset):
         self._check_inputs_(1)
         self._check_onnx_opset_(opset, 11)
         inp = self.inputs[0]
@@ -343,7 +345,7 @@ class EinsumSubOp:
         yield helper.make_node(
             'Unsqueeze', [name, name_axes], [self._onnx_name()])
 
-    def _to_onnx_squeeze(self, names, opset, **kwargs):
+    def _to_onnx_squeeze(self, names, opset):
         self._check_inputs_(1)
         self._check_onnx_opset_(opset, 11)
         inp = self.inputs[0]
@@ -355,7 +357,7 @@ class EinsumSubOp:
         yield helper.make_node(
             'Squeeze', [name, name_axes], [self._onnx_name()])
 
-    def _to_onnx_transpose(self, names, opset, **kwargs):
+    def _to_onnx_transpose(self, names, opset):
         self._check_inputs_(1)
         inp = self.inputs[0]
         name = self._get_data(names, inp)
@@ -363,7 +365,7 @@ class EinsumSubOp:
         yield helper.make_node(
             'Transpose', [name], [self._onnx_name()], perm=perm)
 
-    def _to_onnx_reduce_sum(self, names, opset, **kwargs):
+    def _to_onnx_reduce_sum(self, names, opset):
         self._check_inputs_(1)
         self._check_onnx_opset_(opset, 11)
         inp = self.inputs[0]
@@ -383,10 +385,10 @@ class EinsumSubOp:
         m2 = self._get_data(data, inp2)
         yield helper.make_node('Mul', [m1, m2], [self._onnx_name()])
 
-    def _to_onnx_batch_dot(self, names, opset, **kwargs):  # pylint: disable=R0914
+    def _to_onnx_batch_dot(self, names, opset):
         self._check_inputs_(2)
         self._check_onnx_opset_(opset, 13)
-        inp1, inp2 = self.inputs[:2]  # pylint: disable=W0632
+        inp1, inp2 = self.inputs[:2]
         name1 = self._get_data(names, inp1)
         name2 = self._get_data(names, inp2)
 
@@ -780,7 +782,7 @@ class GraphEinsumSubOp:
         Cleans nodes with unused outputs.
         """
 
-        def iteration(it):
+        def iteration(_):
             # Walks through all nodes.
             is_used = {}
             for node in self._ops:
@@ -1189,7 +1191,7 @@ def _decompose_einsum_equation(equation, *shapes, op_matmul='batch_dot'):
     rows = np.full((2, mat.shape[1]), -1)
     graph = GraphEinsumSubOp(letters, mat, lengths, duplicates)
     fd = mat.shape[1]
-    for i, sh in enumerate(shapes):
+    for i in range(len(shapes)):
         graph.append(i)
 
         # Input matrix aligned to the same dimensions.

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1876,7 +1876,8 @@ class EinsumOptimizer(GraphOptimizerBase):
         new_equation_obj = optimize_einsum(
             equation, decompose=True, dtype=np.float32, opset=graph.opset)
         if equation != new_equation_obj.equation_:
-            self.logger.debug("replacing einsum equation %r by %r",
+            self.logger.debug(
+                "replacing einsum equation %r by %r",
                 equation, new_equation_obj.equation_)
 
         seq = decompose_einsum_equation(new_equation_obj.equation_)

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1,0 +1,931 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rewrites operator einsum into simple ONNX operators.
+"""
+
+from __future__ import unicode_literals
+import numpy as np
+
+
+def _numpy_extended_dot_equation(m1_dim, m2_dim, axes, left, right):
+    """
+    Returns the equation equivalent to an extended version
+    of a matrix multiplication (see function *numpy_extended_dot*).
+
+    :param m1: number of dimensions of the first matrix
+    :param m2: number of dimensions of the second matrix
+    :param axes: summation axes
+    :param axes: summation axes
+    :param left: left axes
+    :param right: right axes
+    :return: equation
+    """
+    if m1_dim != m2_dim:
+        raise RuntimeError(
+            "Matrices m1 and m2 must have the same number of dimensions, "
+            "m1=%r, m2=%r." % (m1_dim, m2_dim))
+    total = set(axes) | set(left) | set(right)
+    if len(total) > m1_dim:
+        raise ValueError(
+            "Whole set of involved axes should be inferior to the number "
+            "of dimensions: %r = {%r} | {%r} | {%r} has more than %d elements"
+            "." % (total, axes, left, right, m1_dim))
+
+    def _check_(axs, n):
+        for a in axs:
+            if a < 0 or a >= n:
+                raise ValueError(
+                    "One axis %d (in %r) is negative or above the maximum "
+                    "dimension %d." % (a, axs, n))
+    _check_(axes, m1_dim)
+    _check_(left, m1_dim)
+    _check_(right, m1_dim)
+
+    l1 = [chr(i + 97) for i in range(m1_dim)]
+    l2 = [chr(i + 97) for i in range(m1_dim)]
+    l3 = [chr(i + 97) for i in range(m1_dim)]
+    for a in left:
+        l1[a] = l1[a].upper()
+        l3[a] = l3[a].upper()
+    for a in right:
+        l2[a] = l2[a].upper()
+        l3[a] = l3[a].upper()
+    for a in axes:
+        l1[a] = l1[a].lower()
+        l2[a] = l2[a].lower()
+        if a not in right:
+            l3[a] = None
+        else:
+            l3[a] = l3[a].lower()
+    eq = "%s,%s->%s" % ("".join(l1), "".join(l2),
+                        "".join(s for s in l3 if s))
+    return eq
+
+
+def numpy_extended_dot(m1, m2, axes, left, right):
+    """
+    Extended version of a matrix multiplication (:epkg:`numpy:dot`)
+    with two matrices *m1*, *m2* of the same dimensions.
+    Loops over *left* axes for *m1* and *right* axes for *m2*,
+    summation is done over *axes*.
+    Other axes must be empty.
+    This multiplication combines matrix multiplication (dot)
+    and broadcasted multiplication term by term.
+
+    :param m1: first matrix
+    :param m2: second matrix
+    :param axes: summation axes
+    :param left: left axes
+    :param right: right axes
+    :return: output
+
+    The dot product is equivalent to:
+
+    ::
+
+        m1 = np.arange(4).reshape((2, 2))
+        m2 = m1 + 10
+        print("dot product")
+        print(m1 @ m2)
+
+        dm1 = m1.reshape((2, 2, 1))
+        dm2 = m2.reshape((1, 2, 2))
+        dot = numpy_extended_dot(dm1, dm2, axes=[1], left=[0], right=[2])
+        print("extended dot product")
+        print(dot)
+
+    Empty axes should be squeezed to get identical results.
+    Dot product when the second matrix is transposed.
+
+    ::
+
+        m1 = np.arange(4).reshape((2, 2))
+        m2 = m1 + 10
+        print("dot product")
+        print(m1 @ m2.T)
+
+        dm1 = m1.reshape((2, 1, 2))
+        dm2 = m2.reshape((1, 2, 2))
+        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1])
+        print("extended dot product")
+        print(dot)
+
+    An example when right axes include the summation axis.
+
+    ::
+
+        m1 = np.arange(4).reshape((2, 2))
+        m2 = m1 + 10
+        dm1 = m1.reshape((2, 2, 1))
+        dm2 = m2.reshape((1, 2, 2))
+        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1, 2])
+        print(dot)
+
+    Example in higher dimension:
+
+    ::
+
+        m1 = np.arange(8).reshape((2, 2, 2))
+        m2 = m1 + 10
+
+        dot = numpy_extended_dot(m1, m2, [1], [0], [2]))
+        print(dot)
+
+    The current implementation still uses :epkg:`numpy:einsum`
+    but this should be replaced.
+    """
+    if m1.dtype != m2.dtype:
+        raise TypeError(
+            "Both matrices should share the same dtype %r != %r."
+            "" % (m1.dtype, m2.dtype))
+    eq = _numpy_extended_dot_equation(
+        len(m1.shape), len(m2.shape), axes, left, right)
+    output = np.einsum(eq, m1, m2)
+    new_shape = list(output.shape)
+    for a in axes:
+        if a not in right:
+            new_shape.insert(a, 1)
+    return output.reshape(tuple(new_shape))
+
+
+def numpy_diagonal(m, axis, axes):
+    """
+    Extracts diagonal coefficients from an array.
+
+    :param m: input array
+    :param axis: kept axis among the diagonal ones
+    :param axes: diagonal axes (axis must be one of them)
+    :return: output
+
+    ::
+
+        mat = np.arange(8).reshape((2, 2, 2))
+        print(mat)
+        diag = numpy_diagonal(mat, 1, [1, 2])
+        print(diag)
+    """
+    if axis not in axes:
+        raise RuntimeError(
+            "axis %r must be in axes %r." % (axis, axes))
+    shape = []
+    new_shape = []
+    for i, s in enumerate(m.shape):
+        if i in axes:
+            if i == axis:
+                shape.append(s)
+                new_shape.append(s)
+            else:
+                shape.append(1)
+        else:
+            shape.append(s)
+            new_shape.append(s)
+
+    # Extracts coefficients.
+    output = np.empty(tuple(shape), dtype=m.dtype)
+    index_in = [slice(s) for s in m.shape]
+    index_out = [slice(s) for s in m.shape]
+    for i in range(0, shape[axis]):
+        for a in axes:
+            index_in[a] = i
+            index_out[a] = i if a == axis else 0
+        output[tuple(index_out)] = m[tuple(index_in)]
+
+    # Removes axis.
+    return output.reshape(tuple(new_shape))
+
+
+class EinsumSubOp:
+    """
+    Defines a sub operation used in Einsum decomposition.
+
+    :param name: name (reshape, transpose, reduce_sum, matmul, id)
+    :param inputs: inputs
+    :param kwargs: arguments
+    """
+    _allowed = {'expand_dims', 'transpose', 'reduce_sum', 'matmul', 'id',
+                'squeeze', 'diagonal'}
+
+    def __init__(self, full_dim, name, *inputs, **kwargs):
+        self.full_dim = full_dim
+        self.name = name
+        self.inputs = inputs
+        self.kwargs = kwargs
+        if name not in EinsumSubOp._allowed:
+            raise ValueError(
+                "Unexpected name %r. It should be in %r."
+                "" % (name, EinsumSubOp._allowed))
+        if len(inputs) not in (1, 2):
+            raise RuntimeError(
+                "Inputs must contains 1 or 2 inputs not %d." % len(inputs))
+        if name == 'matmul' and len(inputs) != 2:
+            raise RuntimeError(
+                "Inputs must contains 2 inputs not %d for operator 'matmul'."
+                "" % len(inputs))
+        for i, inp in enumerate(inputs):
+            if not isinstance(inp, (int, EinsumSubOp)):
+                raise TypeError(
+                    "Input %d has type %r, int or EinsumSubOp is expected."
+                    "" % (i, type(inp)))
+        self._check_()
+
+    def _check_(self):
+        if self.name == 'transpose':
+            self._check_arg_('perm', tuple)
+            perm = self.kwargs['perm']
+            if len(perm) != len(set(perm)):
+                raise RuntimeError(
+                    "perm has duplicated values %r (name=%r)."
+                    "" % (perm, self.name))
+
+    def __repr__(self):
+        inps = ", ".join(map(str, self.inputs))
+        kw = ", ".join("%s=%r" % (k, w) for k, w in self.kwargs.items())
+        m = "%s(%r, %s, %s)" % (
+            self.__class__.__name__, self.name, inps, kw)
+        return m
+
+    def dot_label(self):
+        """
+        Displays some informations useful to understand the operator.
+        """
+        if self.name == "matmul":
+            ndim = self.kwargs['ndim']
+            axes = self.kwargs['axes']
+            left = self.kwargs['left']
+            right = self.kwargs['right']
+            eq = _numpy_extended_dot_equation(ndim, ndim, axes, left, right)
+            eq = eq.replace(">", "\\\\>")
+            return "~" + eq
+
+    def _check_arg_(self, name, typ):
+        if name not in self.kwargs:
+            raise RuntimeError(
+                "Parameter %r not found for operator %r." % (name, self.name))
+        if not isinstance(self.kwargs[name], typ):
+            raise TypeError(
+                "Unexpected type %r for parameter %r and parameter %r."
+                "" % (type(self.kwargs[name]), name, self.name))
+
+    def _compute_output_row_id(self, row, row2=None):
+        row[:] = row2[:]
+
+    def _compute_output_row_transpose(self, row, row2=None):
+        self._check_arg_('perm', tuple)
+        if len(self.kwargs['perm']) != len(row):
+            raise RuntimeError(
+                "Unexpected permutation %r (row=%r)."
+                "" % (self.kwargs['perm'], row))
+        cpy = row.copy()
+        for i, p in enumerate(self.kwargs['perm']):
+            row[i] = cpy[p]
+
+    def _compute_output_row_expand_dims(self, row, row2=None):
+        self._check_arg_('axis', tuple)
+        if row[self.kwargs['axis'][1]] != -1:
+            raise RuntimeError(
+                "Dimension should be -1 in row %r axis=%r." % (
+                    row, self.kwargs['axis']))
+
+    def _compute_output_row_reduce_sum(self, row, row2=None):
+        self._check_arg_('axes', tuple)
+        for a in self.kwargs['axes']:
+            row[a] = -1
+
+    def _compute_output_row_matmul(self, row, row2=None):
+        self._check_arg_('axes', tuple)
+        self._check_arg_('left', tuple)
+        self._check_arg_('right', tuple)
+        self._check_arg_('ndim', int)
+        if row2 is None:
+            raise RuntimeError("matmul expects two inputs.")
+        row2[:] = np.maximum(row, row2)
+        for a in self.kwargs['axes']:
+            if a not in self.kwargs['right']:
+                row2[a] = -1
+
+    def _compute_output_row_squeeze(self, row, row2=None):
+        self._check_arg_('axes', tuple)
+        for a in self.kwargs['axes']:
+            row[a] = -1
+
+    def _compute_output_row_diagonal(self, row, row2=None):
+        self._check_arg_('diag', list)
+        to_remove = []
+        for choice, choices in self.kwargs['diag']:
+            for ch in choices:
+                if ch != choice:
+                    to_remove.append(ch)
+            for i in range(len(row)):  # pylint: disable=C0200
+                if row[i] in choices:
+                    if row[i] != choice:
+                        row[i] = choice
+        to_remove.sort()
+        for r in to_remove:
+            for i in range(len(row)):  # pylint: disable=C0200
+                if row[i] == r:
+                    raise RuntimeError(
+                        "Unexpected result r=%r row=%r to_remove=%r "
+                        "diag=%r." % (
+                            r, row, to_remove, self.kwargs['diag']))
+                if row[i] > r:
+                    row[i] -= 1
+
+    def compute_output_row(self, row, row2=None):
+        """
+        Updates *row* based on the operator.
+        """
+        method_name = "_compute_output_row_%s" % self.name
+        meth = getattr(self, method_name, None)
+        if meth is None:
+            raise NotImplementedError(
+                "compute_output_row not implemented for %r." % self.name)
+        meth(row, row2=row2)
+
+    def _check_inputs_(self, n_expected, check_dim=False):
+        if len(self.inputs) != n_expected:
+            raise RuntimeError(
+                "Number of inputs must be %d not %d for operator %r."
+                "" % (n_expected, len(self.inputs), self.name))
+
+    def _check_shape_(self, m):
+        if len(m.shape) != self.full_dim:
+            raise RuntimeError(
+                "Number of dimensions %r is different from expected value "
+                "%d." % (m.shape, self.full_dim))
+
+    def _get_data(self, data, key):
+        if isinstance(key, int):
+            if key not in data:
+                raise RuntimeError(
+                    "Unable to find key %d in %r." % (
+                        key, list(sorted(data))))
+            return data[key]
+        if isinstance(key, EinsumSubOp):
+            if id(key) not in data:
+                raise RuntimeError(
+                    "Unable to find key %d in %r." % (
+                        id(key), list(sorted(data))))
+            return data[id(key)]
+        raise TypeError(
+            "Unexpected input type %r." % type(key))
+
+    def _apply_id(self, data):
+        self._check_inputs_(1)
+        inp = self.inputs[0]
+        output = self._get_data(data, inp)
+        return output
+
+    def _apply_diagonal(self, data):
+        self._check_inputs_(1)
+        inp = self.inputs[0]
+        m = self._get_data(data, inp)
+        diag = self.kwargs['diag']
+        if len(diag) != 1:
+            raise NotImplementedError(
+                "Not implemented with more than one duplicated indice "
+                "%r." % diag)
+        diag0 = diag[0]
+        output = numpy_diagonal(m, axis=diag0[0], axes=diag0[1])
+        return output
+
+    def _apply_expand_dims(self, data):
+        self._check_inputs_(1)
+        inp = self.inputs[0]
+        m = self._get_data(data, inp)
+        output = np.expand_dims(m, self.kwargs['axis'][0])
+        return output
+
+    def _apply_transpose(self, data):
+        self._check_inputs_(1, True)
+        inp = self.inputs[0]
+        m = self._get_data(data, inp)
+        self._check_shape_(m)
+        output = np.transpose(m, self.kwargs['perm'])
+        self._check_shape_(output)
+        return output
+
+    def _apply_matmul(self, data):
+        self._check_inputs_(2)
+        inp1 = self.inputs[0]
+        inp2 = self.inputs[1]
+        m1 = self._get_data(data, inp1)
+        m2 = self._get_data(data, inp2)
+        self._check_shape_(m1)
+        self._check_shape_(m2)
+        axes = self.kwargs['axes']
+        left = self.kwargs['left']
+        right = self.kwargs['right']
+        output = numpy_extended_dot(m1, m2, axes, left, right)
+        self._check_shape_(output)
+        return output
+
+    def _apply_reduce_sum(self, data):
+        self._check_inputs_(1)
+        inp = self.inputs[0]
+        m = self._get_data(data, inp)
+        self._check_shape_(m)
+        axes = self.kwargs['axes']
+        output = np.sum(m, axis=axes, keepdims=True)
+        self._check_shape_(output)
+        return output
+
+    def _apply_squeeze(self, data):
+        self._check_inputs_(1)
+        inp = self.inputs[0]
+        m = self._get_data(data, inp)
+        axes = self.kwargs['axes']
+        output = m
+        for a in axes[::-1]:
+            output = np.squeeze(output, axis=a)
+        return output
+
+    def apply(self, data):
+        """
+        Applies one operator on the data.
+
+        :param data: dictionary storing the results
+        """
+        method_name = "_apply_%s" % self.name
+        meth = getattr(self, method_name, None)
+        if meth is None:
+            raise NotImplementedError(
+                "apply not implemented for %r." % self.name)
+        output = meth(data)
+
+        data[id(self)] = output
+        return output
+
+
+class GraphEinsumSubOp:
+    """
+    Class gathering all nodes produced to explicit einsum
+    operators.
+    """
+
+    def __init__(self, letters, mat, lengths, duplicates):
+        self._nodes = {}
+        self._mark = {}
+        self._ops = []
+        self.last_op = None
+        self.last_added_op = None
+        self.metadata = dict(
+            letters=letters, mat=mat, lengths=lengths,
+            mat0=mat.copy(), duplicates=duplicates)
+
+    def append(self, op):
+        """
+        Adds one input or result.
+
+        :param op: integer (an input) or an instance of *EinsumSubOp*.
+        :return: op or None if op is an integer
+        """
+        if isinstance(op, int):
+            if op in self._nodes:
+                raise RuntimeError("Key %d already added." % op)
+            self._nodes[op] = op
+            self.last_added_op = op
+            return None
+        if isinstance(op, EinsumSubOp):
+            if op in self._nodes:
+                raise RuntimeError(
+                    "Key %d already added, op=%r." % (id(op), op))
+            self._nodes[id(op)] = op
+            self._ops.append(op)
+            self.last_added_op = op
+            return op
+        raise TypeError("Unexpected type %r." % type(op))
+
+    def mark(self, i, op):
+        """
+        Marks one input or result as an intermediate result
+        after a full einsum step.
+
+        :param op: integer (an input) or an instance of *EinsumSubOp*.
+        """
+        if not isinstance(i, int):
+            raise TypeError("i must an integer not %r." % type(i))
+        if isinstance(op, EinsumSubOp):
+            if id(op) not in self._nodes:
+                raise RuntimeError(
+                    "Key %d not found, op=%r." % (id(op), op))
+            self._mark[i] = op
+            self._mark[id(op)] = i
+            self.last_op = op
+        else:
+            raise TypeError("Unexpected type %r." % type(i))
+
+    def __iter__(self):
+        "Iterates on nodes."
+        for op in self._ops:
+            yield op
+
+    def to_dot(self, **kwargs):
+        """
+        Produces a graph in :epkg:`dot`.
+
+        :param kwargs: additional graph option
+        :return: string
+        """
+        options = {
+            'orientation': 'portrait',
+            'ranksep': '0.25',
+            'nodesep': '0.05',
+            'width': '0.5',
+            'height': '0.1',
+            'size': '5',
+            'node': '[shape=record]',
+        }
+        options.update(kwargs)
+
+        def d2s(d):
+            it = []
+            for k, v in sorted(d.items()):
+                it.append("%s=%s" % (k, v))
+            return " ".join(it)
+
+        def d2sd(d):
+            it = []
+            for k, v in sorted(d.items()):
+                if len(v) > 1:
+                    it.append("%s=%s" % (k, ",".join(map(str, v))))
+            return " ".join(it)
+
+        rows = ["digraph{"]
+        for k, v in options.items():
+            if isinstance(v, str) and "[" in v:
+                rows.append("{} {};".format(k, v))
+            else:
+                rows.append("{}={};".format(k, v))
+        for k, v in self._nodes.items():
+            if isinstance(v, int):
+                let = [(r, self.metadata['letters'][i])
+                       for i, r in enumerate(self.metadata['mat0'][v])
+                       if r != -1]
+                dup = self.metadata['duplicates'][v]
+                if dup is None:
+                    dup = ""
+                else:
+                    dup = " - %s" % d2sd(dup)
+                let.sort()
+                letters = "".join(_[1] for _ in let)
+                lab = "input %d\\\\n%s\\\\n%s%s" % (
+                    v, letters, str(self.metadata['mat0'][v]), dup)
+                sk = v
+                extended_lab = ""
+            else:
+                lab = "%s\\\\n%s" % (v.name, d2s(v.kwargs))
+                sk = id(v)
+                extended_lab = v.dot_label()
+                if extended_lab:
+                    extended_lab = "\\\\n" + extended_lab
+
+            if sk in self._mark and isinstance(self._mark[sk], int):
+                la = self._mark[sk]
+                lab = lab.replace("\\\\n", " - I%d\\\\n" % la)
+                s = ('%d [label="%s%s" style=filled '
+                     'fillcolor=red];' % (k, lab, extended_lab))
+            else:
+                s = '%d [label="%s%s"];' % (k, lab, extended_lab)
+            rows.append(s)
+            if not hasattr(v, 'inputs'):
+                continue
+            for i in v.inputs:
+                vid = i if isinstance(i, int) else id(i)
+                s = "%d -> %d;" % (vid, k)
+                rows.append(s)
+        rows.append("}")
+        return "\n".join(rows)
+
+    def apply_sequence(self, *inputs):
+        """
+        Applies a sequence of operations on a list of inputs.
+
+        :param inputs: inputs:
+        :return: output
+        """
+        data = {i: inp for i, inp in enumerate(inputs)}
+        last = None
+        for op in self:
+            last = op.apply(data)
+        if last is None:
+            raise RuntimeError(
+                "Sequence of operations is empty.")
+        return last
+
+
+def analyse_einsum_equation(equation):
+    """
+    Analyses an einsum equation.
+
+    :param equation: :epkg:`numpy:einsum` equation
+    :return: three results, list of letters,
+        a matrix (see below), lengths of each components,
+        duplicates
+
+    The returned a matrix is defined as follows:
+
+    .. math::
+
+        m_{ij}=\\left\\{\\begin{array}{ll}-1 &
+        \\text{if letter j is involved in input i} \\\\
+        p & \\text{p is position of letter j in equation i}
+        \\end{array}\\right.
+    """
+    spl = equation.strip(' ,').split("->")
+    if len(spl) != 2 or len(spl[1]) == 0 or len(spl[0]) == 0:
+        raise NotImplementedError(
+            "The function only implements the case when there are "
+            "two sides in the equation: %r." % equation)
+    inputs = list(map(lambda s: s.strip(), spl[0].split(',')))
+    output = spl[1]
+    all_letters = set(inputs[0])
+
+    # Set of letters
+    for inp in inputs[1:]:
+        all_letters |= set(inp)
+    letters = list(sorted(all_letters))
+    for c in letters:
+        if not(('a' <= c <= 'z') or ('A' <= c <= 'Z')):
+            raise ValueError(
+                "Equation %r must only contain lower or upper letters "
+                "but %r is not." % (equation, c))
+
+    rev = {c: i for i, c in enumerate(letters)}
+    for c in output:
+        if c not in letters:
+            raise ValueError(
+                "Output contains one unexpected letter %r in "
+                "equation %r." % (c, equation))
+    mat = np.full((len(inputs) + 1, len(letters)), -1, dtype=np.int8)
+    for i, inp in enumerate(inputs):
+        for k, c in enumerate(inp):
+            mat[i, rev[c]] = k
+    for k, c in enumerate(output):
+        mat[len(inputs), rev[c]] = k
+    lengths = [len(inp) for inp in inputs]
+    lengths.append(len(output))
+
+    # Look for duplicates
+    duplicates = []
+    for inp in inputs + [output]:
+        if len(inp) == len(set(inp)):
+            duplicates.append(None)
+            continue
+        # There is some duplicates.
+        counts = {}
+        for i, c in enumerate(inp):
+            if c in counts:
+                counts[c].append(i)
+            else:
+                counts[c] = [i]
+        duplicates.append(counts)
+
+    return "".join(letters), mat, lengths, duplicates
+
+
+def decompose_einsum_equation(equation, *shapes, strategy="simple"):
+    """
+    Decomposes an equation used in :epkg:`numpy:einsum` knowing
+    the input shapes. It returns a sequence of operations
+    to do to compute the results.
+
+    :param equation: a string
+    :param shapes: sequence of input shapes
+    :param strategy: there are different way to decompose the equation,
+        this parameters defines the way to do it (see below)
+    :return: instance of *GraphEinsumSubOp*
+
+    About *strategy*:
+    * `'simple'`: align all dimensions in the alphabetical order
+
+    Available operations: *expand_dims*, *transpose*, *matmul*, *reduce_sum*,
+    *id*, *squeeze*, *diagonal*. It analyses an equation and produces a graph
+    where node are instance of class *EinsumSubOp*.
+
+    ::
+
+        seq = decompose_einsum_equation(
+            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
+        for op in seq:
+            print(op)
+
+    It can be better displayed as follows.
+    
+    ::
+
+        seq = decompose_einsum_equation(
+            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
+        print(seq.to_dot())
+    """
+    if len(shapes) == 0:
+        raise ValueError("No input shapes.")
+    for sh in shapes:
+        if not isinstance(sh, tuple):
+            raise TypeError(
+                "All shapes must be tuples for %r is not." % sh)
+    if strategy == "simple":
+        return _decompose_einsum_equation_simple(equation, *shapes)
+    raise ValueError("Unknown strategy %r." % strategy)
+
+
+def apply_einsum_sequence(seq, *inputs):
+    """
+    Applies a sequence of operations on a list of inputs.
+    The sequence of operations is produced by function
+    *decompose_einsum_equation*.
+
+    :param seq: sequence of operations
+    :param inputs: inputs:
+    :return: output
+
+    ::
+
+        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
+        m2 = np.arange(4).reshape((2, 2)) + 100
+        m3 = np.arange(2 * 2).reshape((2, 2)) + 1000
+
+        seq = decompose_einsum_equation(
+            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
+        res = apply_einsum_sequence(seq, m1, m2)
+        print(res)
+
+    See notebook :ref:`einsumdecompositionrst`.
+    """
+    return seq.apply_sequence(*inputs)
+
+
+def _basic_verification(lengths, shapes, equation):
+    if len(lengths) - 1 != len(shapes):
+        raise ValueError(
+            "Equation %r has %d inputs but %d shapes are given."
+            "" % (equation, len(lengths), len(shapes)))
+    for i, (le, sh) in enumerate(zip(lengths, shapes)):
+        if le != len(sh):
+            raise ValueError(
+                "Inputs %d has %d dimensions but shapes %r has %d "
+                " in equation %r." % (i, le, sh, len(sh), equation))
+
+
+def _apply_transpose_reshape(op, row):
+    """
+    Put all dimensions in the same order.
+
+    :param op: integer (for one input) or an operator
+    :param row: letter involved in this input (as a vector of binaries)
+    :return: last created operator
+    """
+    axes = []
+    p = 0
+    perm = []
+    for i, r in enumerate(row):
+        if r == -1:
+            axes.append((p, i))
+        else:
+            p += 1
+            perm.append((r, i))
+    for a in reversed(axes):
+        op = EinsumSubOp(len(row), 'expand_dims', op, axis=a)
+        yield op
+    perm.sort()
+    p = 0
+    new_perm = np.arange(len(row))
+    for i, r in enumerate(row):
+        if r == -1:
+            continue
+        new_perm[perm[p][1]] = i
+        p += 1
+    op = EinsumSubOp(len(row), 'transpose', op, perm=tuple(new_perm))
+    yield op
+
+
+def _apply_squeeze_transpose(op, row_last, row_output):
+    """
+    Puts output dimension in the expected order.
+    """
+    perm = []
+    sq = []
+    for i, d in enumerate(row_output):
+        if d == -1:
+            sq.append(i)
+        else:
+            perm.append((d, i))
+    perm.sort()
+    new_perm = np.arange(len(row_last))
+    p = 0
+    for i, d in enumerate(row_output):
+        if d == -1:
+            continue
+        new_perm[i] = perm[p][1]
+        p += 1
+    perm = [p[1] for p in perm]
+    op = EinsumSubOp(len(row_last), 'transpose', op, perm=tuple(new_perm))
+    yield op
+    if len(sq) > 0:
+        op = EinsumSubOp(len(row_last), 'squeeze', op, axes=tuple(sq))
+        yield op
+
+
+def _decompose_einsum_equation_simple(equation, *shapes):
+    """
+    Applies strategy simple of function *decompose_einsum_equation*.
+    """
+    letters, mat, lengths, duplicates = analyse_einsum_equation(equation)
+    if len(letters) != mat.shape[1]:
+        raise RuntimeError(  # pragma: no cover
+            "Unexpected number of letters %r, shape=%r." % (
+                letters, mat.shape))
+    _basic_verification(lengths, shapes, equation)
+
+    # last_row, current_row (row = shape)
+    rows = np.full((2, mat.shape[1]), -1)
+    graph = GraphEinsumSubOp(letters, mat, lengths, duplicates)
+    fd = mat.shape[1]
+
+    for i, sh in enumerate(shapes):
+        graph.append(i)
+
+        # Input matrix aligned to the same dimensions.
+        op = EinsumSubOp(fd, 'id', i)
+        op.compute_output_row(rows[1, :], mat[i, :])
+        marked = graph.append(op)
+
+        duplicate = duplicates[i]
+        if duplicate is not None:
+            # Diagonal
+            diag = []
+            for _, v in duplicate.items():
+                if len(v) == 1:
+                    continue
+                diag.append((v[0], tuple(v)))
+            op = EinsumSubOp(fd, 'diagonal', op, diag=diag)
+            op.compute_output_row(rows[1, :], mat[i, :])
+            tr_row = rows[1, :]
+            marked = graph.append(op)
+        else:
+            diag = None
+            tr_row = mat[i]
+
+        for op in _apply_transpose_reshape(op, tr_row):
+            op.compute_output_row(rows[1, :])
+            marked = graph.append(op)
+
+        # Reduction? (a dimension not used later)
+        red = []
+        for d in range(0, mat.shape[1]):
+            if (mat[i + 1:, d].max() == -1 and rows[1, d] != -1 and
+                    rows[0, d] == -1):
+                red.append(d)
+        if len(red) > 0:
+            op = EinsumSubOp(fd, 'reduce_sum',
+                             graph.last_added_op, axes=tuple(red))
+            op.compute_output_row(rows[1, :])
+            marked = graph.append(op)
+
+        if graph.last_op is not None:
+            # Matrix multiplication?
+            common_dims = []
+            left = []
+            right = []
+            for d in range(0, mat.shape[1]):
+                if rows[:, d].min() >= 0:
+                    common_dims.append(d)
+                    if mat[i + 1:, d].max() >= 0:
+                        left.append(d)
+                        right.append(d)
+                else:
+                    if rows[0, d] >= 0:
+                        left.append(d)
+                    if rows[1, d] >= 0:
+                        right.append(d)
+            op = EinsumSubOp(fd, 'matmul', graph.last_op, op,
+                             axes=tuple(common_dims),
+                             left=tuple(left), right=tuple(right),
+                             ndim=rows.shape[1])
+            op.compute_output_row(rows[0, :], rows[1, :])
+            marked = graph.append(op)
+
+        # End
+        graph.mark(i, marked)
+        rows[0, :] = rows[1, :]
+
+    # Final output
+    if mat[len(shapes), :].max() >= 0:
+        rows[1, :] = mat[len(shapes), :]
+        red = []
+        for d in range(0, mat.shape[1]):
+            if rows[0, d] > 0 and rows[1, d] == -1:
+                red.append(d)
+            elif rows[0, d] == -1 and rows[1, d] >= 0:
+                raise RuntimeError(
+                    "Issue in equation %r, variable %d, last_result is %r, "
+                    "output is %r." % (equation, d, rows[0, :], rows[1, :]))
+        if len(red) > 0:
+            op = EinsumSubOp(fd, 'reduce_sum', op, axes=tuple(red))
+            graph.append(op)
+            op.compute_output_row(rows[1, :])
+
+        # Removes empty axes.
+        for op in _apply_squeeze_transpose(op, rows[1, :], mat[len(shapes), :]):
+            op.compute_output_row(rows[1, :])
+            graph.append(op)
+    return graph

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -39,6 +39,10 @@ class EinsumSubOp:
     Operator suffixed by `_mm` (*transpose_mm*, *reduce_sum_mm*)
     are equivalent to the same operator without the suffix
     but takes two inputs and only changes the first one.
+
+    Attributes `_info` summarizes the known information
+    about dimensions. Many of them are empty because inserted.
+    Value `1` means it was the case, `2` means it is a plain dimension.
     """
     _allowed = {'expand_dims', 'transpose', 'reduce_sum', 'matmul', 'id',
                 'squeeze', 'diagonal', 'mul', 'batch_dot',
@@ -411,13 +415,12 @@ class EinsumSubOp:
         right = self.kwargs['right']
         root = self._onnx_name()
 
-        name_one = root + "_1"
-        name_zero = root + "_0"
-        yield numpy_helper.from_array(
-            np.array([1], dtype=np.int64), name=name_one)
-        yield numpy_helper.from_array(
-            np.array([0], dtype=np.int64), name=name_zero)
+        def return_name_one():
+            name_one = root + "_1"
+            return name_one, numpy_helper.from_array(
+                np.array([1], dtype=np.int64), name=name_one)
 
+        name_one = None
         name_shape1 = root + "_shape1"
         name_shape2 = root + "_shape2"
         concat_left = []
@@ -464,6 +467,9 @@ class EinsumSubOp:
             yield helper.make_node(
                 'Gather', [name_shape2, name_batch_axes], [name_dim0bg])
         else:
+            if name_one is None:
+                name_one, cst_init = return_name_one()
+                yield cst_init
             name_dim0 = name_one
             name_dim0b = name_one
             concat_left.append(name_dim0)
@@ -504,6 +510,9 @@ class EinsumSubOp:
         # dim2 = int(np.prod([m2.shape[i] for i in sum_axes]))
 
         if len(sum_axes) == 0:
+            if name_one is None:
+                name_one, cst_init = return_name_one()
+                yield cst_init
             name_dim1 = name_one
             name_dim2 = name_one
             concat_left.append(name_dim1)
@@ -535,29 +544,55 @@ class EinsumSubOp:
             yield helper.make_node(
                 'ReduceProd', [name_dim2g], [name_dim2], keepdims=1)
 
-        # *shape1, *shape2
-        name_agg_shape1 = root + "_resh1"
-        name_agg_shape2 = root + "_resh2"
-        yield helper.make_node(
-            'Concat', concat_left, [name_agg_shape1], axis=0)
-        yield helper.make_node(
-            'Concat', concat_right, [name_agg_shape2], axis=0)
+        batch_kind = self.get_dot_kind()
+        if batch_kind in ('11', 'N1', 'N1'):
+            # *shape1, *shape2
+            name_minus_one = root + "__01"
+            yield numpy_helper.from_array(
+                np.array([-1], dtype=np.int64), name=name_minus_one)
+            name_agg_shape1_2 = root + "_resh1_%s" % batch_kind
+            name_agg_shape2_2 = root + "_resh2_%s" % batch_kind
+            yield helper.make_node(
+                'Concat', [name_minus_one, name_dim1], [name_agg_shape1_2], axis=0)
+            yield helper.make_node(
+                'Concat', [name_minus_one, name_dim2], [name_agg_shape2_2], axis=0)
 
-        # m1sh = m1.reshape((dim0, dimb, dim1))
-        # m2sh = m2.reshape((dim0b, dimb, dim2))
-        name_agg1 = root + "_aresh1"
-        name_agg2 = root + "_aresh2"
-        yield helper.make_node('Reshape', [name1, name_agg_shape1], [name_agg1])
-        yield helper.make_node('Reshape', [name2, name_agg_shape2], [name_agg2])
+            # m1sh = m1.reshape((-1, dim1))
+            # m2sh = m2.reshape((-1, dim2))
+            name_agg1_2 = root + "_aresh1"
+            name_agg2_2 = root + "_aresh2"
+            yield helper.make_node('Reshape', [name1, name_agg_shape1_2], [name_agg1_2])
+            yield helper.make_node('Reshape', [name2, name_agg_shape2_2], [name_agg2_2])
 
-        # dot = m1sh @ np.transpose(m2sh, (0, 2, 1))
-        name_agg2_tr = root + "_aresh2_tr"
-        yield helper.make_node(
-            'Transpose', [name_agg2], [name_agg2_tr], perm=[0, 2, 1])
+            # dot = gemm(m1sh, m2sh, False, True)
+            name_dot = root + "_gemm"
+            yield helper.make_node(
+                'Gemm', [name_agg1_2, name_agg2_2], [name_dot],
+                alpha=1., beta=0., transA=0, transB=1)
+        else:
+            # *shape1, *shape2
+            name_agg_shape1 = root + "_resh1"
+            name_agg_shape2 = root + "_resh2"
+            yield helper.make_node(
+                'Concat', concat_left, [name_agg_shape1], axis=0)
+            yield helper.make_node(
+                'Concat', concat_right, [name_agg_shape2], axis=0)
 
-        name_dot = root + "_dot"
-        yield helper.make_node(
-            'MatMul', [name_agg1, name_agg2_tr], [name_dot])
+            # m1sh = m1.reshape((dim0, dimb, dim1))
+            # m2sh = m2.reshape((dim0b, dimb, dim2))
+            name_agg1 = root + "_aresh1"
+            name_agg2 = root + "_aresh2"
+            yield helper.make_node('Reshape', [name1, name_agg_shape1], [name_agg1])
+            yield helper.make_node('Reshape', [name2, name_agg_shape2], [name_agg2])
+
+            # dot = m1sh @ np.transpose(m2sh, (0, 2, 1))
+            name_agg2_tr = root + "_aresh2_tr"
+            yield helper.make_node(
+                'Transpose', [name_agg2], [name_agg2_tr], perm=[0, 2, 1])
+
+            name_dot = root + "_dot"
+            yield helper.make_node(
+                'MatMul', [name_agg1, name_agg2_tr], [name_dot])
 
         # new_shape = ([max(m1.shape[i], m2.shape[i]) for i in batch_axes] +
         #      [m1.shape[i] for i in left if i not in batch_axes] +
@@ -634,6 +669,30 @@ class EinsumSubOp:
             if hasattr(node, 'output'):
                 names[id(self)] = node.output[0]
             yield node
+
+    def get_dot_kind(self):
+        """
+        Every matrix multiplication can be either:
+        * a simple multiplication (`M`) (undetected)
+        * a 2D matrix multiplication (`11`)
+        * a broadcasted matrix multiplication (`N1` or `1N`)
+        * a batch matrix multiplication (`NN`)
+        This method returns which kind it is.
+        """
+        batch_axes = self.kwargs['batch_axes']
+        # keep_axes = self.kwargs['keep_axes']
+        # sum_axes = self.kwargs['sum_axes']
+        # left = self.kwargs['left']
+        # right = self.kwargs['right']
+        info = self._info
+        row_left = info['i_row']
+        row_right = info['i_row2']
+
+        batch_left = [row_left[k] for k in batch_axes]
+        batch_right = [row_right[k] for k in batch_axes]
+        n_left = len(batch_left) > 0 and max(batch_left) == 2
+        n_right = len(batch_right) > 0 and max(batch_right) == 2
+        return "%s%s" % ('N' if n_left else '1', 'N' if n_right else '1')
 
 
 class GraphEinsumSubOp:

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1856,7 +1856,7 @@ class EinsumOptimizer(GraphOptimizerBase):
 
     def __init__(self, decompose=True):  # pylint: disable=useless-super-delegation
         super(EinsumOptimizer, self).__init__()
-        self._decompose = True
+        self._decompose = decompose
 
     def _optimize(self, graph):
         return self._apply_optimization(graph, self._optimize_at_current_graph_level)

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1163,14 +1163,14 @@ def decompose_einsum_equation(equation, *shapes):
             seq = decompose_einsum_equation(equation)
             onx = seq.to_onnx("Z", "X", "Y", initializer=initializer)
             return onx
-            
+
 
         def main():
             inp1 = np.random.uniform(size=[100, 20, 768]).astype(np.float32)
             inp2 = np.random.uniform(size=[768, 32000]).astype(np.float32)
             model_matmul = make_model("MatMul", inp2, {})
             sess_matmul = ort.InferenceSession(model_matmul.SerializeToString())
-            
+
             start = time.time()
             for i in range(20):
                 res_matmul = sess_matmul.run(["Z"], {"X": inp1})[0]
@@ -1182,11 +1182,11 @@ def decompose_einsum_equation(equation, *shapes):
             # the last two dimensions are switched.
             for eq in ['bid,nd->bin', 'bdn,in->bdi']:
                 eq_name = eq.replace(",", "_").replace("->", "_")
-                
+
                 model_einsum = make_model("Einsum", inp2.transpose(), {'equation': eq})
                 with open("model_einsum_%s.onnx" % eq_name, "wb") as f:
                     f.write(model_einsum.SerializeToString())
-                
+
                 model_decompose = make_model2(eq, inp2.transpose())
                 with open("model_decompose_%s.onnx" % eq_name, "wb") as f:
                     f.write(model_decompose.SerializeToString())
@@ -1223,7 +1223,7 @@ def decompose_einsum_equation(equation, *shapes):
         bdn,in->bdi einsum time: 22.701029539108276
         Results match
         bdn,in->bdi decompose time: 20.90113353729248
-        Results match    
+        Results match
     """
     graph = _decompose_einsum_equation(
         equation, *shapes, op_matmul='batch_dot')

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1849,10 +1849,14 @@ class EinsumOptimizer(GraphOptimizerBase):
     in the equation. Depending on that order, the transposing
     and the matrix computation may be more or less efficient.
     The worst order may be 4, 5 times slower than the best order.
+
+    :param decompose: keep the operator einsum or replace it
+        by a graph combining operators listed above
     """
 
-    def __init__(self):  # pylint: disable=useless-super-delegation
+    def __init__(self, decompose=True):  # pylint: disable=useless-super-delegation
         super(EinsumOptimizer, self).__init__()
+        self._decompose = True
 
     def _optimize(self, graph):
         return self._apply_optimization(graph, self._optimize_at_current_graph_level)
@@ -1880,10 +1884,9 @@ class EinsumOptimizer(GraphOptimizerBase):
         equation = node.attr['equation'].s.decode('ascii')
 
         # optimize the equation? decompose=True, False
-        decompose = True
         new_equation_obj = optimize_einsum(
-            equation, decompose=decompose, dtype=np.float32, opset=graph.opset)
-        if decompose:
+            equation, decompose=self._decompose, dtype=np.float32, opset=graph.opset)
+        if self._decompose:
             seq = decompose_einsum_equation(new_equation_obj.equation_)
             new_nodes = list(seq.to_tf2onnx(graph, node))
 

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -1405,7 +1405,6 @@ def _apply_squeeze_transpose(op, row_last, row_output):
             continue
         new_perm[i] = perm[p][1]
         p += 1
-    perm = [p[1] for p in perm]
     if not is_transpose_identity(new_perm):
         op = EinsumSubOp(len(row_last), 'transpose', op,
                          perm=tuple(new_perm))
@@ -1697,7 +1696,6 @@ class CachedEinsum:
             subset = possible
             best = []
             confs = []
-            very_best = None
             inputs = None
             for perm in subset:
                 replace = {d: c for c, d in zip(letters, perm)}

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -118,6 +118,7 @@ class EinsumSubOp:
         """
 
     def _compute_output_row_id(self, row, row2=None, ab=False):
+        "compute shape after operator id"
         if ab:
             raise RuntimeError("ab option not allowed.")
         self._check_row_(row, True)
@@ -142,6 +143,7 @@ class EinsumSubOp:
         self._check_row_(row)
 
     def _compute_output_row_transpose_mm(self, row, row2=None, ab=False):
+        "compute shape after operator transpose"
         if not ab:
             raise RuntimeError("ab must be True.")
         self._check_row_(row, True)
@@ -150,6 +152,7 @@ class EinsumSubOp:
         self._compute_output_row_transpose(row, row2=None)
 
     def _compute_output_row_expand_dims(self, row, row2=None, ab=False):
+        "compute shape after operator expand_dims"
         if ab:
             raise RuntimeError("ab option not allowed.")
         self._check_row_(row, True)
@@ -167,6 +170,7 @@ class EinsumSubOp:
         self._check_row_(row)
 
     def _compute_output_row_reduce_sum(self, row, row2=None, ab=False):
+        "compute shape after operator reduce_sum"
         if ab:
             raise RuntimeError("ab option not allowed.")
         self._check_row_(row, True)
@@ -176,6 +180,7 @@ class EinsumSubOp:
         self._check_row_(row)
 
     def _compute_output_row_reduce_sum_mm(self, row, row2=None, ab=False):
+        "compute shape after operator reduce_sum"
         if not ab:
             raise RuntimeError("ab must be true.")
         self._check_row_(row2, True)
@@ -184,6 +189,7 @@ class EinsumSubOp:
         self._compute_output_row_reduce_sum(row, row2=None)
 
     def _compute_output_row_squeeze(self, row, row2=None, ab=False):
+        "compute shape after operator squeeze"
         if ab:
             raise RuntimeError("ab option not allowed.")
         self._check_row_(row, True)
@@ -258,6 +264,7 @@ class EinsumSubOp:
         self._check_row_(row2)
 
     def _compute_output_row_mul(self, row, row2=None, ab=False):
+        "compute shape after operator mul"
         if not ab:
             raise RuntimeError("ab must be True.")
         self._check_row_(row, True)
@@ -382,6 +389,7 @@ class EinsumSubOp:
 
     def _to_onnx_mul(self, data, opset):
         self._check_inputs_(2)
+        self._check_onnx_opset_(opset, 1)
         inp1 = self.inputs[0]
         inp2 = self.inputs[1]
         m1 = self._get_data(data, inp1)

--- a/tf2onnx/optimizer/einsum_optimizer.py
+++ b/tf2onnx/optimizer/einsum_optimizer.py
@@ -5,211 +5,51 @@
 
 from __future__ import unicode_literals
 import numpy as np
+from onnx import helper, numpy_helper
+from onnx.defs import onnx_opset_version
+from onnx.onnx_pb import TensorProto
+from ..constants import OPSET_TO_IR_VERSION
 
 
-def _numpy_extended_dot_equation(m1_dim, m2_dim, axes, left, right):
+def single_axes(axes):
     """
-    Returns the equation equivalent to an extended version
-    of a matrix multiplication (see function *numpy_extended_dot*).
+    *axes* contains positive values, then it is the position
+    of this axis in the original matrix, otherwise it is -1
+    meaning this axis is an added single dimension to align
+    all the dimensions based on the einsum equation.
 
-    :param m1: number of dimensions of the first matrix
-    :param m2: number of dimensions of the second matrix
-    :param axes: summation axes
-    :param axes: summation axes
-    :param left: left axes
-    :param right: right axes
-    :return: equation
+    :param axes: axes described above
+    :return: list of integer in set `{1, 2}`, 1 for
+        a single axis, 2 otherwise
     """
-    if m1_dim != m2_dim:
-        raise RuntimeError(
-            "Matrices m1 and m2 must have the same number of dimensions, "
-            "m1=%r, m2=%r." % (m1_dim, m2_dim))
-    total = set(axes) | set(left) | set(right)
-    if len(total) > m1_dim:
-        raise ValueError(
-            "Whole set of involved axes should be inferior to the number "
-            "of dimensions: %r = {%r} | {%r} | {%r} has more than %d elements"
-            "." % (total, axes, left, right, m1_dim))
-
-    def _check_(axs, n):
-        for a in axs:
-            if a < 0 or a >= n:
-                raise ValueError(
-                    "One axis %d (in %r) is negative or above the maximum "
-                    "dimension %d." % (a, axs, n))
-    _check_(axes, m1_dim)
-    _check_(left, m1_dim)
-    _check_(right, m1_dim)
-
-    l1 = [chr(i + 97) for i in range(m1_dim)]
-    l2 = [chr(i + 97) for i in range(m1_dim)]
-    l3 = [chr(i + 97) for i in range(m1_dim)]
-    for a in left:
-        l1[a] = l1[a].upper()
-        l3[a] = l3[a].upper()
-    for a in right:
-        l2[a] = l2[a].upper()
-        l3[a] = l3[a].upper()
-    for a in axes:
-        l1[a] = l1[a].lower()
-        l2[a] = l2[a].lower()
-        if a not in right:
-            l3[a] = None
-        else:
-            l3[a] = l3[a].lower()
-    eq = "%s,%s->%s" % ("".join(l1), "".join(l2),
-                        "".join(s for s in l3 if s))
-    return eq
-
-
-def numpy_extended_dot(m1, m2, axes, left, right):
-    """
-    Extended version of a matrix multiplication (:epkg:`numpy:dot`)
-    with two matrices *m1*, *m2* of the same dimensions.
-    Loops over *left* axes for *m1* and *right* axes for *m2*,
-    summation is done over *axes*.
-    Other axes must be empty.
-    This multiplication combines matrix multiplication (dot)
-    and broadcasted multiplication term by term.
-
-    :param m1: first matrix
-    :param m2: second matrix
-    :param axes: summation axes
-    :param left: left axes
-    :param right: right axes
-    :return: output
-
-    The dot product is equivalent to:
-
-    ::
-
-        m1 = np.arange(4).reshape((2, 2))
-        m2 = m1 + 10
-        print("dot product")
-        print(m1 @ m2)
-
-        dm1 = m1.reshape((2, 2, 1))
-        dm2 = m2.reshape((1, 2, 2))
-        dot = numpy_extended_dot(dm1, dm2, axes=[1], left=[0], right=[2])
-        print("extended dot product")
-        print(dot)
-
-    Empty axes should be squeezed to get identical results.
-    Dot product when the second matrix is transposed.
-
-    ::
-
-        m1 = np.arange(4).reshape((2, 2))
-        m2 = m1 + 10
-        print("dot product")
-        print(m1 @ m2.T)
-
-        dm1 = m1.reshape((2, 1, 2))
-        dm2 = m2.reshape((1, 2, 2))
-        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1])
-        print("extended dot product")
-        print(dot)
-
-    An example when right axes include the summation axis.
-
-    ::
-
-        m1 = np.arange(4).reshape((2, 2))
-        m2 = m1 + 10
-        dm1 = m1.reshape((2, 2, 1))
-        dm2 = m2.reshape((1, 2, 2))
-        dot = numpy_extended_dot(dm1, dm2, axes=[2], left=[0], right=[1, 2])
-        print(dot)
-
-    Example in higher dimension:
-
-    ::
-
-        m1 = np.arange(8).reshape((2, 2, 2))
-        m2 = m1 + 10
-
-        dot = numpy_extended_dot(m1, m2, [1], [0], [2]))
-        print(dot)
-
-    The current implementation still uses :epkg:`numpy:einsum`
-    but this should be replaced.
-    """
-    if m1.dtype != m2.dtype:
-        raise TypeError(
-            "Both matrices should share the same dtype %r != %r."
-            "" % (m1.dtype, m2.dtype))
-    eq = _numpy_extended_dot_equation(
-        len(m1.shape), len(m2.shape), axes, left, right)
-    output = np.einsum(eq, m1, m2)
-    new_shape = list(output.shape)
-    for a in axes:
-        if a not in right:
-            new_shape.insert(a, 1)
-    return output.reshape(tuple(new_shape))
-
-
-def numpy_diagonal(m, axis, axes):
-    """
-    Extracts diagonal coefficients from an array.
-
-    :param m: input array
-    :param axis: kept axis among the diagonal ones
-    :param axes: diagonal axes (axis must be one of them)
-    :return: output
-
-    ::
-
-        mat = np.arange(8).reshape((2, 2, 2))
-        print(mat)
-        diag = numpy_diagonal(mat, 1, [1, 2])
-        print(diag)
-    """
-    if axis not in axes:
-        raise RuntimeError(
-            "axis %r must be in axes %r." % (axis, axes))
-    shape = []
-    new_shape = []
-    for i, s in enumerate(m.shape):
-        if i in axes:
-            if i == axis:
-                shape.append(s)
-                new_shape.append(s)
-            else:
-                shape.append(1)
-        else:
-            shape.append(s)
-            new_shape.append(s)
-
-    # Extracts coefficients.
-    output = np.empty(tuple(shape), dtype=m.dtype)
-    index_in = [slice(s) for s in m.shape]
-    index_out = [slice(s) for s in m.shape]
-    for i in range(0, shape[axis]):
-        for a in axes:
-            index_in[a] = i
-            index_out[a] = i if a == axis else 0
-        output[tuple(index_out)] = m[tuple(index_in)]
-
-    # Removes axis.
-    return output.reshape(tuple(new_shape))
+    if axes is None:
+        return axes
+    return [(1 if a == -1 else 2) for a in axes]
 
 
 class EinsumSubOp:
     """
     Defines a sub operation used in Einsum decomposition.
 
-    :param name: name (reshape, transpose, reduce_sum, matmul, id)
+    :param name: name (reshape, transpose, reduce_sum, matmul, id,
+        squeeze, diagonal, mul, batch_dot)
     :param inputs: inputs
     :param kwargs: arguments
+
+    Operator suffixed by `_mm` (*transpose_mm*, *reduce_sum_mm*)
+    are equivalent to the same operator without the suffix
+    but takes two inputs and only changes the first one.
     """
     _allowed = {'expand_dims', 'transpose', 'reduce_sum', 'matmul', 'id',
-                'squeeze', 'diagonal'}
+                'squeeze', 'diagonal', 'mul', 'batch_dot',
+                'transpose_mm', 'reduce_sum_mm'}
 
     def __init__(self, full_dim, name, *inputs, **kwargs):
         self.full_dim = full_dim
         self.name = name
         self.inputs = inputs
         self.kwargs = kwargs
+        self._info = {}
         if name not in EinsumSubOp._allowed:
             raise ValueError(
                 "Unexpected name %r. It should be in %r."
@@ -236,6 +76,22 @@ class EinsumSubOp:
                 raise RuntimeError(
                     "perm has duplicated values %r (name=%r)."
                     "" % (perm, self.name))
+            if list(perm) == list(range(len(perm))):
+                raise ValueError(
+                    "Transpose = identity perm=%r. It must be removed."
+                    "" % perm)
+        elif self.name == 'matmul':
+            self._check_arg_('axes', tuple)
+            self._check_arg_('left', tuple)
+            self._check_arg_('right', tuple)
+            axes = self.kwargs['axes']
+            left = self.kwargs['left']
+            right = self.kwargs['right']
+            for a in axes:
+                if a in left and a in right:
+                    raise RuntimeError(
+                        "One axis belongs to every set (axes, left, right). "
+                        "axes=%r, left=%r, right=%r." % (axes, left, right))
 
     def __repr__(self):
         inps = ", ".join(map(str, self.inputs))
@@ -256,59 +112,103 @@ class EinsumSubOp:
             eq = _numpy_extended_dot_equation(ndim, ndim, axes, left, right)
             eq = eq.replace(">", "\\\\>")
             return "~" + eq
+        return None
 
-    def _check_arg_(self, name, typ):
+    def _check_arg_(self, name, typ, empty=False):
         if name not in self.kwargs:
             raise RuntimeError(
                 "Parameter %r not found for operator %r." % (name, self.name))
+        if empty and self.kwargs[name] is None:
+            return
         if not isinstance(self.kwargs[name], typ):
             raise TypeError(
                 "Unexpected type %r for parameter %r and parameter %r."
                 "" % (type(self.kwargs[name]), name, self.name))
 
-    def _compute_output_row_id(self, row, row2=None):
-        row[:] = row2[:]
+    def _check_row_(self, row, inp=False):
+        """
+        Checks input or output is valid.
+        """
+        pass
 
-    def _compute_output_row_transpose(self, row, row2=None):
+    def _compute_output_row_id(self, row, row2=None, ab=False):
+        if ab:
+            raise RuntimeError("ab option not allowed.")
+        self._check_row_(row, True)
+        row[:] = row2[:]
+        self._check_row_(row)
+
+    def _compute_output_row_transpose(self, row, row2=None, ab=False):
+        if ab:
+            self._compute_output_row_transpose(row2)
+            return
+        self._check_row_(row, True)
         self._check_arg_('perm', tuple)
         if len(self.kwargs['perm']) != len(row):
             raise RuntimeError(
                 "Unexpected permutation %r (row=%r)."
                 "" % (self.kwargs['perm'], row))
+        perm = self.kwargs['perm']
         cpy = row.copy()
-        for i, p in enumerate(self.kwargs['perm']):
+        for i, p in enumerate(perm):
             row[i] = cpy[p]
+        self._check_row_(row)
 
-    def _compute_output_row_expand_dims(self, row, row2=None):
-        self._check_arg_('axis', tuple)
-        if row[self.kwargs['axis'][1]] != -1:
-            raise RuntimeError(
-                "Dimension should be -1 in row %r axis=%r." % (
-                    row, self.kwargs['axis']))
-
-    def _compute_output_row_reduce_sum(self, row, row2=None):
-        self._check_arg_('axes', tuple)
-        for a in self.kwargs['axes']:
-            row[a] = -1
-
-    def _compute_output_row_matmul(self, row, row2=None):
-        self._check_arg_('axes', tuple)
-        self._check_arg_('left', tuple)
-        self._check_arg_('right', tuple)
-        self._check_arg_('ndim', int)
+    def _compute_output_row_transpose_mm(self, row, row2=None, ab=False):
+        if not ab:
+            raise RuntimeError("ab must be True.")
+        self._check_row_(row, True)
         if row2 is None:
-            raise RuntimeError("matmul expects two inputs.")
-        row2[:] = np.maximum(row, row2)
-        for a in self.kwargs['axes']:
-            if a not in self.kwargs['right']:
-                row2[a] = -1
+            raise RuntimeError("transpose_mm expects a second input.")
+        self._compute_output_row_transpose(row, row2=None)
 
-    def _compute_output_row_squeeze(self, row, row2=None):
+    def _compute_output_row_expand_dims(self, row, row2=None, ab=False):
+        if ab:
+            raise RuntimeError("ab option not allowed.")
+        self._check_row_(row, True)
+        self._check_arg_('axes', tuple)
+        axes = self.kwargs['axes']
+        for axis in axes:
+            if not isinstance(axis, tuple):
+                raise TypeError(
+                    "Parameter axes of expand_dims should be a tuple of "
+                    "tuple, axes=%r." % axes)
+            if row[axis[1]] != -1:
+                raise RuntimeError(
+                    "Dimension should be -1 in row %r axis=%r." % (
+                        row, self.kwargs['axis']))
+        self._check_row_(row)
+
+    def _compute_output_row_reduce_sum(self, row, row2=None, ab=False):
+        if ab:
+            raise RuntimeError("ab option not allowed.")
+        self._check_row_(row, True)
         self._check_arg_('axes', tuple)
         for a in self.kwargs['axes']:
             row[a] = -1
+        self._check_row_(row)
 
-    def _compute_output_row_diagonal(self, row, row2=None):
+    def _compute_output_row_reduce_sum_mm(self, row, row2=None, ab=False):
+        if not ab:
+            raise RuntimeError("ab must be true.")
+        self._check_row_(row2, True)
+        if row2 is None:
+            raise RuntimeError("reduce_sum_mm expects a second input.")
+        self._compute_output_row_reduce_sum(row, row2=None)
+
+    def _compute_output_row_squeeze(self, row, row2=None, ab=False):
+        if ab:
+            raise RuntimeError("ab option not allowed.")
+        self._check_row_(row, True)
+        self._check_arg_('axes', tuple)
+        for a in self.kwargs['axes']:
+            row[a] = -1
+        self._check_row_(row)
+
+    def _compute_output_row_diagonal(self, row, row2=None, ab=False):
+        if ab:
+            raise RuntimeError("ab option not allowed.")
+        self._check_row_(row, True)
         self._check_arg_('diag', list)
         to_remove = []
         for choice, choices in self.kwargs['diag']:
@@ -329,8 +229,55 @@ class EinsumSubOp:
                             r, row, to_remove, self.kwargs['diag']))
                 if row[i] > r:
                     row[i] -= 1
+        self._check_row_(row)
 
-    def compute_output_row(self, row, row2=None):
+    def _compute_output_row_matmul(self, row, row2=None, ab=False):
+        if not ab:
+            raise RuntimeError("ab must be True.")
+        self._check_row_(row, True)
+        self._check_row_(row2, True)
+        self._check_arg_('axes', tuple)
+        self._check_arg_('left', tuple)
+        self._check_arg_('right', tuple)
+        self._check_arg_('ndim', int)
+        if row2 is None:
+            raise RuntimeError("matmul expects two inputs.")
+        row2[:] = np.maximum(row, row2)
+        for a in self.kwargs['axes']:
+            if a not in self.kwargs['right']:
+                row2[a] = -1
+        self._check_row_(row2)
+
+    def _compute_output_row_batch_dot(self, row, row2=None, ab=False):
+        if not ab:
+            raise RuntimeError("ab must be True.")
+        self._check_row_(row, True)
+        self._check_row_(row2, True)
+        self._check_arg_('batch_axes', tuple)
+        self._check_arg_('keep_axes', tuple, empty=True)
+        self._check_arg_('sum_axes', tuple)
+        self._check_arg_('left', tuple)
+        self._check_arg_('right', tuple)
+        self._check_arg_('ndim', int)
+        if row2 is None:
+            raise RuntimeError("batch_dot expects two inputs.")
+        row2[:] = np.maximum(row, row2)
+        for a in self.kwargs['sum_axes']:
+            if a not in self.kwargs['right']:
+                row2[a] = -1
+        self._check_row_(row2)
+
+    def _compute_output_row_mul(self, row, row2=None, ab=False):
+        if not ab:
+            raise RuntimeError("ab must be True.")
+        self._check_row_(row, True)
+        self._check_row_(row2, True)
+        if row2 is None:
+            raise RuntimeError("mul expects two inputs.")
+        row2[:] = np.maximum(row, row2)
+        self._check_row_(row2)
+
+    def compute_output_row(self, row, row2=None, ab=False):
         """
         Updates *row* based on the operator.
         """
@@ -339,7 +286,21 @@ class EinsumSubOp:
         if meth is None:
             raise NotImplementedError(
                 "compute_output_row not implemented for %r." % self.name)
-        meth(row, row2=row2)
+        self.add_info(i_row=single_axes(row), i_row2=single_axes(row2))
+        meth(row, row2=row2, ab=ab)
+        self.add_info(o_row=single_axes(row), o_row2=single_axes(row2))
+
+    def add_info(self, **kwargs):
+        """
+        Adds information to the node.
+
+        :param kwargs: dictionary
+        """
+        for k, v in kwargs.items():
+            if k in self._info:
+                raise KeyError(
+                    "Key %r already added (operator %r)." % (k, self.name))
+            self._info[k] = v
 
     def _check_inputs_(self, n_expected, check_dim=False):
         if len(self.inputs) != n_expected:
@@ -369,103 +330,328 @@ class EinsumSubOp:
         raise TypeError(
             "Unexpected input type %r." % type(key))
 
-    def _apply_id(self, data):
+    def _onnx_name(self):
+        return 'einsum%d_%s' % (id(self), self.name[:2])
+
+    def _check_onnx_opset_(self, opset, limit):
+        if opset is not None and opset < limit:
+            raise RuntimeError(
+                "Opset (%r) must be >= %r for operator %r."
+                "" % (opset, limit, self.name))
+
+    def _to_onnx_id(self, names, opset, **kwargs):
         self._check_inputs_(1)
         inp = self.inputs[0]
-        output = self._get_data(data, inp)
-        return output
+        name = self._get_data(names, inp)
+        yield helper.make_node('Identity', [name], [self._onnx_name()])
 
-    def _apply_diagonal(self, data):
+    def _to_onnx_expand_dims(self, names, opset, **kwargs):
+        self._check_inputs_(1)
+        self._check_onnx_opset_(opset, 11)
+        inp = self.inputs[0]
+        name = self._get_data(names, inp)
+        axes = self.kwargs['axes']
+        name_axes = name + '_axes'
+        yield numpy_helper.from_array(
+            np.array([a[1] for a in axes], dtype=np.int64), name=name_axes)
+        yield helper.make_node(
+            'Unsqueeze', [name, name_axes], [self._onnx_name()])
+
+    def _to_onnx_squeeze(self, names, opset, **kwargs):
+        self._check_inputs_(1)
+        self._check_onnx_opset_(opset, 11)
+        inp = self.inputs[0]
+        name = self._get_data(names, inp)
+        axes = self.kwargs['axes']
+        name_axes = name + '_axes'
+        yield numpy_helper.from_array(
+            np.array(axes, dtype=np.int64), name=name_axes)
+        yield helper.make_node(
+            'Squeeze', [name, name_axes], [self._onnx_name()])
+
+    def _to_onnx_transpose(self, names, opset, **kwargs):
         self._check_inputs_(1)
         inp = self.inputs[0]
-        m = self._get_data(data, inp)
-        diag = self.kwargs['diag']
-        if len(diag) != 1:
-            raise NotImplementedError(
-                "Not implemented with more than one duplicated indice "
-                "%r." % diag)
-        diag0 = diag[0]
-        output = numpy_diagonal(m, axis=diag0[0], axes=diag0[1])
-        return output
+        name = self._get_data(names, inp)
+        perm = self.kwargs['perm']
+        yield helper.make_node(
+            'Transpose', [name], [self._onnx_name()], perm=perm)
 
-    def _apply_expand_dims(self, data):
+    def _to_onnx_reduce_sum(self, names, opset, **kwargs):
         self._check_inputs_(1)
+        self._check_onnx_opset_(opset, 11)
         inp = self.inputs[0]
-        m = self._get_data(data, inp)
-        output = np.expand_dims(m, self.kwargs['axis'][0])
-        return output
+        name = self._get_data(names, inp)
+        axes = self.kwargs['axes']
+        name_axes = self._onnx_name() + '_axes'
+        yield numpy_helper.from_array(
+            np.array(axes, dtype=np.int64), name=name_axes)
+        yield helper.make_node(
+            'ReduceSum', [name, name_axes], [self._onnx_name()], keepdims=1)
 
-    def _apply_transpose(self, data):
-        self._check_inputs_(1, True)
-        inp = self.inputs[0]
-        m = self._get_data(data, inp)
-        self._check_shape_(m)
-        output = np.transpose(m, self.kwargs['perm'])
-        self._check_shape_(output)
-        return output
-
-    def _apply_matmul(self, data):
+    def _to_onnx_mul(self, data, **kwargs):
         self._check_inputs_(2)
         inp1 = self.inputs[0]
         inp2 = self.inputs[1]
         m1 = self._get_data(data, inp1)
         m2 = self._get_data(data, inp2)
-        self._check_shape_(m1)
-        self._check_shape_(m2)
-        axes = self.kwargs['axes']
+        yield helper.make_node('Mul', [m1, m2], [self._onnx_name()])
+
+    def _to_onnx_batch_dot(self, names, opset, **kwargs):  # pylint: disable=R0914
+        self._check_inputs_(2)
+        self._check_onnx_opset_(opset, 13)
+        inp1, inp2 = self.inputs[:2]  # pylint: disable=W0632
+        name1 = self._get_data(names, inp1)
+        name2 = self._get_data(names, inp2)
+
+        batch_axes = self.kwargs['batch_axes']
+        keep_axes = self.kwargs['keep_axes']
+        sum_axes = self.kwargs['sum_axes']
         left = self.kwargs['left']
         right = self.kwargs['right']
-        output = numpy_extended_dot(m1, m2, axes, left, right)
-        self._check_shape_(output)
-        return output
+        root = self._onnx_name()
 
-    def _apply_reduce_sum(self, data):
-        self._check_inputs_(1)
-        inp = self.inputs[0]
-        m = self._get_data(data, inp)
-        self._check_shape_(m)
-        axes = self.kwargs['axes']
-        output = np.sum(m, axis=axes, keepdims=True)
-        self._check_shape_(output)
-        return output
+        name_one = root + "_1"
+        name_zero = root + "_0"
+        yield numpy_helper.from_array(
+            np.array([1], dtype=np.int64), name=name_one)
+        yield numpy_helper.from_array(
+            np.array([0], dtype=np.int64), name=name_zero)
 
-    def _apply_squeeze(self, data):
-        self._check_inputs_(1)
-        inp = self.inputs[0]
-        m = self._get_data(data, inp)
-        axes = self.kwargs['axes']
-        output = m
-        for a in axes[::-1]:
-            output = np.squeeze(output, axis=a)
-        return output
+        name_shape1 = root + "_shape1"
+        name_shape2 = root + "_shape2"
+        concat_left = []
+        concat_right = []
+        yield helper.make_node('Shape', [name1], [name_shape1])
+        yield helper.make_node('Shape', [name2], [name_shape2])
 
-    def apply(self, data):
+        if len(batch_axes) > 0:
+            name_batch_axes = root + "_batch_axes"
+            yield numpy_helper.from_array(
+                np.array(batch_axes, dtype=np.int64), name=name_batch_axes)
+
+        if len(sum_axes) > 0:
+            name_sum_axes = root + "_sum_axes"
+            yield numpy_helper.from_array(
+                np.array(sum_axes, dtype=np.int64), name=name_sum_axes)
+
+        # dim0 = int(np.prod([m1.shape[i] for i in batch_axes]))
+        # dim0b = int(np.prod([m2.shape[i] for i in batch_axes]))
+        if len(batch_axes) > 1:
+            name_dim0 = root + "_dim0"
+            name_dim0b = root + "_dim0b"
+            name_dim0g = name_dim0 + 'g'
+            name_dim0bg = name_dim0b + 'g'
+            concat_left.append(name_dim0)
+            concat_right.append(name_dim0b)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_batch_axes], [name_dim0g])
+            yield helper.make_node(
+                'Gather', [name_shape2, name_batch_axes], [name_dim0bg])
+            yield helper.make_node(
+                'ReduceProd', [name_dim0g], [name_dim0], keepdims=1)
+            yield helper.make_node(
+                'ReduceProd', [name_dim0bg], [name_dim0b], keepdims=1)
+        elif len(batch_axes) == 1:
+            name_dim0g = root + "_dim0g"
+            name_dim0bg = root + "_dim0bg"
+            name_dim0 = name_dim0g
+            name_dim0b = name_dim0bg
+            concat_left.append(name_dim0)
+            concat_right.append(name_dim0b)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_batch_axes], [name_dim0g])
+            yield helper.make_node(
+                'Gather', [name_shape2, name_batch_axes], [name_dim0bg])
+        else:
+            name_dim0 = name_one
+            name_dim0b = name_one
+            concat_left.append(name_dim0)
+            concat_right.append(name_dim0b)
+
+        # dimb = int(-1 if keep_axes is None else np.prod(
+        #     [m1.shape[i] for i in keep_axes]))
+        if keep_axes in (-1, None) or len(keep_axes) == 0:
+            name_dimb = root + "__1"
+            concat_left.append(name_dimb)
+            concat_right.append(name_dimb)
+            yield numpy_helper.from_array(
+                np.array([-1], dtype=np.int64), name=name_dimb)
+        elif len(keep_axes) == 1:
+            name_keep_axes = root + "_keep_axes"
+            name_dimb = root + "_dimb"
+            name_dimbg = name_dimb
+            concat_left.append(name_dimb)
+            concat_right.append(name_dimb)
+            yield numpy_helper.from_array(
+                np.array(keep_axes, dtype=np.int64), name=name_keep_axes)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_keep_axes], [name_dimbg])
+        else:
+            name_keep_axes = root + "_keep_axes"
+            name_dimb = root + "_dimb"
+            name_dimbg = name_dimb + 'g'
+            concat_left.append(name_dimb)
+            concat_right.append(name_dimb)
+            yield numpy_helper.from_array(
+                np.array(keep_axes, dtype=np.int64), name=name_keep_axes)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_keep_axes], [name_dimbg])
+            yield helper.make_node(
+                'ReduceProd', [name_dimbg], [name_dimb], keepdims=1)
+
+        # dim1 = int(np.prod([m1.shape[i] for i in sum_axes]))
+        # dim2 = int(np.prod([m2.shape[i] for i in sum_axes]))
+
+        if len(sum_axes) == 0:
+            name_dim1 = name_one
+            name_dim2 = name_one
+            concat_left.append(name_dim1)
+            concat_right.append(name_dim2)
+        elif len(sum_axes) == 1:
+            name_dim1 = root + "_dim1"
+            name_dim2 = root + "_dim2"
+            name_dim1g = name_dim1
+            name_dim2g = name_dim2
+            concat_left.append(name_dim1)
+            concat_right.append(name_dim2)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_sum_axes], [name_dim1g])
+            yield helper.make_node(
+                'Gather', [name_shape2, name_sum_axes], [name_dim2g])
+        else:
+            name_dim1 = root + "_dim1"
+            name_dim2 = root + "_dim2"
+            name_dim1g = name_dim1 + 'g'
+            name_dim2g = name_dim2 + 'g'
+            concat_left.append(name_dim1)
+            concat_right.append(name_dim2)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_sum_axes], [name_dim1g])
+            yield helper.make_node(
+                'Gather', [name_shape2, name_sum_axes], [name_dim2g])
+            yield helper.make_node(
+                'ReduceProd', [name_dim1g], [name_dim1], keepdims=1)
+            yield helper.make_node(
+                'ReduceProd', [name_dim2g], [name_dim2], keepdims=1)
+
+        # *shape1, *shape2
+        name_agg_shape1 = root + "_resh1"
+        name_agg_shape2 = root + "_resh2"
+        yield helper.make_node(
+            'Concat', concat_left, [name_agg_shape1], axis=0)
+        yield helper.make_node(
+            'Concat', concat_right, [name_agg_shape2], axis=0)
+
+        # m1sh = m1.reshape((dim0, dimb, dim1))
+        # m2sh = m2.reshape((dim0b, dimb, dim2))
+        name_agg1 = root + "_aresh1"
+        name_agg2 = root + "_aresh2"
+        yield helper.make_node('Reshape', [name1, name_agg_shape1], [name_agg1])
+        yield helper.make_node('Reshape', [name2, name_agg_shape2], [name_agg2])
+
+        # dot = m1sh @ np.transpose(m2sh, (0, 2, 1))
+        name_agg2_tr = root + "_aresh2_tr"
+        yield helper.make_node(
+            'Transpose', [name_agg2], [name_agg2_tr], perm=[0, 2, 1])
+
+        name_dot = root + "_dot"
+        yield helper.make_node(
+            'MatMul', [name_agg1, name_agg2_tr], [name_dot])
+
+        # new_shape = ([max(m1.shape[i], m2.shape[i]) for i in batch_axes] +
+        #      [m1.shape[i] for i in left if i not in batch_axes] +
+        #      [m2.shape[i] for i in right if i not in batch_axes])
+        concat_final = []
+        if len(batch_axes) > 0:
+            name_max_dim = root + "_max_dim"
+            concat_final.append(name_max_dim)
+            yield helper.make_node(
+                'Max', [name_dim0g, name_dim0bg], [name_max_dim])
+
+        left_set = list(sorted(set(left) - (set(batch_axes) & set(left))))
+        if len(left_set) > 0:
+            name_left_dim = root + "_left_dim"
+            name_left_set = root + "_left_set"
+            yield numpy_helper.from_array(
+                np.array(left_set, dtype=np.int64), name=name_left_set)
+            yield helper.make_node(
+                'Gather', [name_shape1, name_left_set], [name_left_dim])
+            concat_final.append(name_left_dim)
+
+        right_set = list(sorted(set(right) - (set(batch_axes) & set(right))))
+        if len(right_set) > 0:
+            name_right_dim = root + "_right_dim"
+            name_right_set = root + "_right_set"
+            yield numpy_helper.from_array(
+                np.array(right_set, dtype=np.int64), name=name_right_set)
+            yield helper.make_node(
+                'Gather', [name_shape2, name_right_set], [name_right_dim])
+            concat_final.append(name_right_dim)
+
+        name_new_shape = root + '_new_shape'
+        diff = (
+            self.full_dim -
+            (len(batch_axes) + len(left_set) + len(right_set)))
+        if diff > 0:
+            names_ones = root + "_ones"
+            yield numpy_helper.from_array(
+                np.array([1 for i in range(diff)], dtype=np.int64),
+                name=names_ones)
+            concat_final.append(names_ones)
+
+        yield helper.make_node(
+            'Concat', concat_final, [name_new_shape], axis=0)
+
+        name_final = root + '_final'
+        yield helper.make_node(
+            'Reshape', [name_dot, name_new_shape], [name_final])
+
+    def to_onnx(self, names, opset=None, **kwargs):
         """
-        Applies one operator on the data.
+        Converts this node into ONNX. Enumerates all ONNX node
+        which participate to the conversion. The last one
+        is the final output.
 
-        :param data: dictionary storing the results
+        :param names: dictionary where to find already converted name
+        :param opset: opset
+        :param kwargs: additional parameter for the conversion
+        :return: output
         """
-        method_name = "_apply_%s" % self.name
+        if opset is None:
+            opset = get_opset_number_from_onnx()
+        method_name = "_to_onnx_%s" % self.name
         meth = getattr(self, method_name, None)
         if meth is None:
+            if self.name.endswith("_mm"):
+                raise NotImplementedError(
+                    "to_onnx not implemented for %r."
+                    "You should call method simplify_mm_nodes "
+                    "to remove it." % self.name)
             raise NotImplementedError(
-                "apply not implemented for %r." % self.name)
-        output = meth(data)
-
-        data[id(self)] = output
-        return output
+                "to_onnx not implemented for %r." % self.name)
+        for node in meth(names, opset=opset, **kwargs):
+            if hasattr(node, 'output'):
+                names[id(self)] = node.output[0]
+            yield node
 
 
 class GraphEinsumSubOp:
     """
     Class gathering all nodes produced to explicit einsum
     operators.
+
+    :param letters: list of distinct letters
+    :param mat: matrix, see *analyse_einsum_equation*
+    :param lengths: lengths of every input
+    :param duplicates: see *analyse_einsum_equation*
     """
 
     def __init__(self, letters, mat, lengths, duplicates):
         self._nodes = {}
         self._mark = {}
         self._ops = []
+        self._inputs = {}
         self.last_op = None
         self.last_added_op = None
         self.metadata = dict(
@@ -476,7 +662,7 @@ class GraphEinsumSubOp:
         """
         Adds one input or result.
 
-        :param op: integer (an input) or an instance of *EinsumSubOp*.
+        :param op: integer (an input) or an instance of class *EinsumSubOp*.
         :return: op or None if op is an integer
         """
         if isinstance(op, int):
@@ -484,6 +670,7 @@ class GraphEinsumSubOp:
                 raise RuntimeError("Key %d already added." % op)
             self._nodes[op] = op
             self.last_added_op = op
+            self._inputs[op] = op
             return None
         if isinstance(op, EinsumSubOp):
             if op in self._nodes:
@@ -495,15 +682,26 @@ class GraphEinsumSubOp:
             return op
         raise TypeError("Unexpected type %r." % type(op))
 
+    def mark_last_node(self):
+        """
+        Marks the last node as the final output.
+        """
+        if self.last_added_op is None:
+            raise RuntimeError("last_added_op is None.")
+        self.mark(-1, self.last_added_op)
+
     def mark(self, i, op):
         """
         Marks one input or result as an intermediate result
         after a full einsum step.
 
-        :param op: integer (an input) or an instance of *EinsumSubOp*.
+        :param op: integer (an input) or an instance of class *EinsumSubOp*.
         """
         if not isinstance(i, int):
             raise TypeError("i must an integer not %r." % type(i))
+        if i != -1 and i not in self._inputs:
+            raise RuntimeError(
+                "Input %d was not registered in %r." % (i, self._inputs))
         if isinstance(op, EinsumSubOp):
             if id(op) not in self._nodes:
                 raise RuntimeError(
@@ -596,21 +794,122 @@ class GraphEinsumSubOp:
         rows.append("}")
         return "\n".join(rows)
 
-    def apply_sequence(self, *inputs):
+    def clean_unused_nodes(self):
         """
-        Applies a sequence of operations on a list of inputs.
+        Cleans nodes with unused outputs.
+        """
 
-        :param inputs: inputs:
-        :return: output
+        def iteration(it):
+            # Walks through all nodes.
+            is_used = {}
+            for node in self._ops:
+                if not isinstance(node, EinsumSubOp):
+                    continue
+                if id(node) not in is_used:
+                    is_used[id(node)] = []
+                for inp in node.inputs:
+                    if not isinstance(inp, EinsumSubOp):
+                        continue
+                    idn = id(inp)
+                    if idn not in is_used:
+                        is_used[idn] = []
+                    is_used[idn].append(id(node))
+
+            # Remove unused nodes.
+            removed = []
+            for k, v in is_used.items():
+                if len(v) == 0:
+                    removed.append(k)
+            removed = set(removed)
+            i_rem = []
+            for i, op in enumerate(self._ops):
+                if not isinstance(op, EinsumSubOp):
+                    continue
+                if id(op) in removed and id(op) not in self._mark:
+                    i_rem.append((i, id(op)))
+            for i, idn in reversed(i_rem):
+                del self._ops[i]
+                del self._nodes[idn]
+            return len(i_rem) > 0
+
+        it = 1
+        while iteration(it):
+            it += 1
+
+        self.last_op = None
+        self.last_added_op = None
+
+    def simplify_mm_nodes(self):
         """
-        data = {i: inp for i, inp in enumerate(inputs)}
-        last = None
+        Node name suffixed by `mm` are an artifact to keep
+        the graph consistent while building it. They can
+        now be replaced by the equivalent node without suffix `mm`.
+        """
         for op in self:
-            last = op.apply(data)
-        if last is None:
-            raise RuntimeError(
-                "Sequence of operations is empty.")
-        return last
+            if not isinstance(op, EinsumSubOp):
+                continue
+            if op.name.endswith('_mm'):
+                if len(op.inputs) != 2:
+                    raise RuntimeError(
+                        "Expecting 2 inputs for node %r not %r id=%r." % (
+                            op.name, len(op.inputs), id(op)))
+                op.name = op.name[:-3]
+                op.inputs = op.inputs[:1]
+
+    def to_onnx(self, output, *inputs, proto_type=None, opset=None, **kwargs):
+        """
+        Converts the graph into ONNX.
+
+        :param output: output name
+        :param inputs: input names
+        :param proto_type: type used for all operators
+        :param opset: desired opset, None for the last one
+        :param kwargs: additional parameter to use when building
+            the ONNX graph
+        :return: ONNX graph
+        """
+        # inputs
+        if opset is None:
+            opset = onnx_opset_version()
+        onx_inputs = []
+        if proto_type is None:
+            proto_type = TensorProto.FLOAT
+        lengths = self.metadata['lengths']
+        for inp, le in zip(inputs, lengths):
+            onx_inputs.append(helper.make_tensor_value_info(
+                inp, proto_type, [None for i in range(le)]))
+
+        # output
+        onx_output = helper.make_tensor_value_info(
+            output, proto_type, [None for i in range(lengths[-1])])
+
+        # nodes
+        names = {i: name for i, name in enumerate(inputs)}
+        nodes = []
+        inits = []
+        for op in self:
+            for onx_node in op.to_onnx(names, opset=opset):
+                if hasattr(onx_node, 'output'):
+                    nodes.append(onx_node)
+                else:
+                    inits.append(onx_node)
+
+        # last node
+        last_node = nodes[-1]
+        nodes.append(helper.make_node(
+            'Identity', [last_node.output[0]], [output]))
+
+        # Builds the graph
+        model = helper.make_model(
+            opset_imports=[helper.make_operatorsetid('', opset)],
+            ir_version=kwargs.get('ir_version', OPSET_TO_IR_VERSION.get(opset, 6)),
+            producer_name=kwargs.get('producer_name', 'tensorflow-onnx'),
+            producer_version=kwargs.get('producer_version', "0.0.dev"),
+            graph=helper.make_graph(
+                name=kwargs.get('name', 'einsum'),
+                inputs=onx_inputs, outputs=[onx_output],
+                initializer=inits, nodes=nodes))
+        return model
 
 
 def analyse_einsum_equation(equation):
@@ -683,7 +982,7 @@ def analyse_einsum_equation(equation):
     return "".join(letters), mat, lengths, duplicates
 
 
-def decompose_einsum_equation(equation, *shapes, strategy="simple"):
+def decompose_einsum_equation(equation, *shapes):
     """
     Decomposes an equation used in :epkg:`numpy:einsum` knowing
     the input shapes. It returns a sequence of operations
@@ -691,67 +990,31 @@ def decompose_einsum_equation(equation, *shapes, strategy="simple"):
 
     :param equation: a string
     :param shapes: sequence of input shapes
-    :param strategy: there are different way to decompose the equation,
-        this parameters defines the way to do it (see below)
-    :return: instance of *GraphEinsumSubOp*
-
-    About *strategy*:
-    * `'simple'`: align all dimensions in the alphabetical order
+    :return: instance of class *GraphEinsumSubOp*
 
     Available operations: *expand_dims*, *transpose*, *matmul*, *reduce_sum*,
     *id*, *squeeze*, *diagonal*. It analyses an equation and produces a graph
     where node are instance of class *EinsumSubOp*.
-
-    ::
-
-        seq = decompose_einsum_equation(
-            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
-        for op in seq:
-            print(op)
-
-    It can be better displayed as follows.
-    
-    ::
-
-        seq = decompose_einsum_equation(
-            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
-        print(seq.to_dot())
     """
-    if len(shapes) == 0:
-        raise ValueError("No input shapes.")
-    for sh in shapes:
-        if not isinstance(sh, tuple):
-            raise TypeError(
-                "All shapes must be tuples for %r is not." % sh)
-    if strategy == "simple":
-        return _decompose_einsum_equation_simple(equation, *shapes)
-    raise ValueError("Unknown strategy %r." % strategy)
+    graph = _decompose_einsum_equation(
+        equation, *shapes, op_matmul='batch_dot')
+
+    # Last step: clean unused nodes.
+    graph.mark_last_node()
+    graph.simplify_mm_nodes()
+    graph.clean_unused_nodes()
+    return graph
 
 
-def apply_einsum_sequence(seq, *inputs):
+
+def is_transpose_identity(perm):
     """
-    Applies a sequence of operations on a list of inputs.
-    The sequence of operations is produced by function
-    *decompose_einsum_equation*.
+    Tells if the permutation *perm* does nothing (itentity).
 
-    :param seq: sequence of operations
-    :param inputs: inputs:
-    :return: output
-
-    ::
-
-        m1 = np.arange(2 * 2 * 2).reshape((2, 2, 2)) + 10
-        m2 = np.arange(4).reshape((2, 2)) + 100
-        m3 = np.arange(2 * 2).reshape((2, 2)) + 1000
-
-        seq = decompose_einsum_equation(
-            "bac,cd,def->ebc", (2, 2, 2), (2, 2), (2, 2, 2))
-        res = apply_einsum_sequence(seq, m1, m2)
-        print(res)
-
-    See notebook :ref:`einsumdecompositionrst`.
+    :param perm: permutation
+    :return: boolean
     """
-    return seq.apply_sequence(*inputs)
+    return list(perm) == list(range(len(perm)))
 
 
 def _basic_verification(lengths, shapes, equation):
@@ -783,9 +1046,8 @@ def _apply_transpose_reshape(op, row):
         else:
             p += 1
             perm.append((r, i))
-    for a in reversed(axes):
-        op = EinsumSubOp(len(row), 'expand_dims', op, axis=a)
-        yield op
+    op = EinsumSubOp(len(row), 'expand_dims', op, axes=tuple(axes))
+    yield op
     perm.sort()
     p = 0
     new_perm = np.arange(len(row))
@@ -794,8 +1056,9 @@ def _apply_transpose_reshape(op, row):
             continue
         new_perm[perm[p][1]] = i
         p += 1
-    op = EinsumSubOp(len(row), 'transpose', op, perm=tuple(new_perm))
-    yield op
+    if not is_transpose_identity(new_perm):
+        op = EinsumSubOp(len(row), 'transpose', op, perm=tuple(new_perm))
+        yield op
 
 
 def _apply_squeeze_transpose(op, row_last, row_output):
@@ -818,29 +1081,133 @@ def _apply_squeeze_transpose(op, row_last, row_output):
         new_perm[i] = perm[p][1]
         p += 1
     perm = [p[1] for p in perm]
-    op = EinsumSubOp(len(row_last), 'transpose', op, perm=tuple(new_perm))
-    yield op
+    if not is_transpose_identity(new_perm):
+        op = EinsumSubOp(len(row_last), 'transpose', op,
+                         perm=tuple(new_perm))
+        yield op
     if len(sq) > 0:
         op = EinsumSubOp(len(row_last), 'squeeze', op, axes=tuple(sq))
         yield op
 
 
-def _decompose_einsum_equation_simple(equation, *shapes):
+def _apply_einsum_matmul(fd, op1, op2, axes, left, right, ndim,
+                         op_matmul, row1, row2):
     """
-    Applies strategy simple of function *decompose_einsum_equation*.
+    Decomposes the generic matrix multiplication into numpy operations
+    depending on the operator to use for matrix multiplication
+    *op_matmul* (see *decompose_einsum_equation*).
+    """
+    allowed = {'matmul', 'batch_dot', 'dot'}
+    if op_matmul not in allowed:
+        raise ValueError(
+            "Unknown operator op_matmul=%r not in %r." % (op_matmul, allowed))
+    if op_matmul == 'matmul':
+        yield EinsumSubOp(fd, 'matmul', op1, op2,
+                          axes=axes, left=left, right=right, ndim=ndim)
+
+    elif len(axes) == 0 and len(set(left) & set(right)) == 0:
+        yield EinsumSubOp(fd, 'mul', op1, op2)
+
+    elif (len(set(axes) & set(left)) == 0 and
+            len(set(axes) & set(right)) == 0):
+
+        # No intersection between axes and right: matrix multiplication
+        all_axes = set(left) | set(right) | set(axes)
+        common_axes = list(set(left) & set(right))
+        for i in range(ndim):
+            if i not in all_axes:
+                common_axes.append(i)
+        common_axes.sort()
+
+        # ReduceSum*
+        has_dim = set(i for i in range(len(row1)) if row1[i] >= 0)
+        right_no_left = (set(right) & has_dim) - \
+            (set(right) & (set(left) | set(axes)))
+        if right_no_left:
+            op1 = EinsumSubOp(fd, 'reduce_sum_mm', op1, op2,
+                              axes=tuple(sorted(right_no_left)))
+            yield op1
+
+        has_dim = set(i for i in range(len(row2)) if row2[i] >= 0)
+        left_no_right = (set(left) & has_dim) - \
+            (set(left) & (set(right) | set(axes)))
+        if left_no_right:
+            op2 = EinsumSubOp(fd, 'reduce_sum', op2,
+                              axes=tuple(sorted(left_no_right)))
+            yield op2
+
+        # Transpose
+        i_axes = [(-1 if i in common_axes
+                   else (1 if i in axes else 0), i)
+                  for i in range(ndim)]
+        i_axes.sort()
+        perm = [_[1] for _ in i_axes]
+        perm_left = [i for i in range(len(perm)) if perm[i] in left]
+        perm_right = [i for i in range(len(perm)) if perm[i] in right]
+        if not is_transpose_identity(perm):
+            op1 = EinsumSubOp(fd, 'transpose_mm', op1, op2, perm=tuple(perm))
+            yield op1
+            op2 = EinsumSubOp(fd, 'transpose', op2, perm=tuple(perm))
+            yield op2
+
+        # Reshape
+        all_axes = list(range(0, ndim))
+        new_axes = all_axes[-len(axes):] if len(axes) > 0 else []
+        new_common_axes = all_axes[:len(common_axes)]
+        not_in_both = []
+        for i in range(0, ndim):
+            if i not in left and i not in right and i not in common_axes:
+                not_in_both.append(i)
+
+        op = EinsumSubOp(fd, 'batch_dot', op1, op2,
+                         batch_axes=tuple(new_common_axes),
+                         keep_axes=None, sum_axes=tuple(new_axes),
+                         left=tuple(perm_left), right=tuple(perm_right),
+                         ndim=ndim)
+        yield op
+
+        # Transpose again
+        ordered_axes = (common_axes +
+                        list(i for i in left if i not in right) +
+                        list(i for i in right if i not in left) +
+                        not_in_both)
+        rev_perm = [(a, i) for i, a in enumerate(ordered_axes)]
+        rev_perm.sort()
+        rev_perm = [p[1] for p in rev_perm]
+
+        if not is_transpose_identity(rev_perm):
+            op_unused = EinsumSubOp(fd, 'transpose_mm', op1,
+                                    op, perm=tuple(rev_perm))
+            yield op_unused
+            op = EinsumSubOp(fd, 'transpose', op, perm=tuple(rev_perm))
+            yield op
+    else:
+        raise NotImplementedError(
+            "axes and right or left have axes in common, "
+            "axes=%r left=%r right=%r ndim=%r." % (
+                axes, left, right, ndim))
+
+
+def _decompose_einsum_equation(equation, *shapes, op_matmul='batch_dot'):
+    """
+    :param op_matmul: which operator to use for matrix multiplication,
+        a single operator *matmul*, or *batch_dot* with *transposes*,
+        *reduce_sum*, or just *dot*
     """
     letters, mat, lengths, duplicates = analyse_einsum_equation(equation)
     if len(letters) != mat.shape[1]:
         raise RuntimeError(  # pragma: no cover
             "Unexpected number of letters %r, shape=%r." % (
                 letters, mat.shape))
-    _basic_verification(lengths, shapes, equation)
+    if len(shapes) > 0:
+        _basic_verification(lengths, shapes, equation)
+    else:
+        shapes = [(2,) * le for le in lengths[:-1]]
 
     # last_row, current_row (row = shape)
     rows = np.full((2, mat.shape[1]), -1)
     graph = GraphEinsumSubOp(letters, mat, lengths, duplicates)
     fd = mat.shape[1]
-
     for i, sh in enumerate(shapes):
         graph.append(i)
 
@@ -888,21 +1255,24 @@ def _decompose_einsum_equation_simple(equation, *shapes):
             right = []
             for d in range(0, mat.shape[1]):
                 if rows[:, d].min() >= 0:
-                    common_dims.append(d)
                     if mat[i + 1:, d].max() >= 0:
                         left.append(d)
                         right.append(d)
+                    else:
+                        common_dims.append(d)
                 else:
                     if rows[0, d] >= 0:
                         left.append(d)
                     if rows[1, d] >= 0:
                         right.append(d)
-            op = EinsumSubOp(fd, 'matmul', graph.last_op, op,
-                             axes=tuple(common_dims),
-                             left=tuple(left), right=tuple(right),
-                             ndim=rows.shape[1])
-            op.compute_output_row(rows[0, :], rows[1, :])
-            marked = graph.append(op)
+            for iop in _apply_einsum_matmul(
+                    fd, graph.last_op, op, axes=tuple(common_dims),
+                    left=tuple(left), right=tuple(right),
+                    ndim=rows.shape[1], op_matmul=op_matmul,
+                    row1=rows[0, :], row2=rows[1, :]):
+                op = iop
+                op.compute_output_row(rows[0, :], rows[1, :], ab=True)
+                marked = graph.append(op)
 
         # End
         graph.mark(i, marked)


### PR DESCRIPTION
This code decompose an einsum equation into an ONNX graph. There are still some limitations:

* expression `...`  is not supported yet
* diagonal is not suppoted (example `ii->i`)
* output must be specified (no expression such as `ab,bc`
* the graph is not always optimized (consecutive transpose are still remaining)

*Note:*

operator MatMul is not the most efficient way to decompose the einsum summation (MatMul = `ijo,iok->ijk`) which is equivalent to i matrix multiplications. Operator Gemm is more appropriate to do less transpose (Gemm = `jo,ko->jk`) but multiple Gemm cannot be done with the current implementation. Gemm could still be used to do `ajo,bko->abjk` by merging the two first dimensions on each input.

Benchmark (on a Windows Surface):

**Model small_bert_bert_uncased_L-8_H-512_A-8_2**

Goes from 0.06657s to 0.05109s (~20% faster)

**Model expert_bert_wiki_books**

Goes from 0.77959s to 0.67123s (~14% faster).

**Inputs:**

same inputs for both models 

```
def get_input():
    return {"input_type_ids": get_small_rand_int32([1, 512]),
                "input_mask": get_ones_int32([1, 512]),
                "input_word_ids": get_zeros_then_ones([1, 512])}
```

**Example for equation `bsnh,btnh->bnts`**

![image](https://user-images.githubusercontent.com/22452781/116728204-ea649f80-a9e5-11eb-9442-371a34427115.png)
