### PR TITLE
Fix bug in transpose optimizer where node is deleted twice

### DIFF
--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -176,7 +176,8 @@ class TransposeOptimizer(GraphOptimizerBase):
                         # referencing already deleted elements
                         break
 
-                if is_useless_transpose(n):
+                # Make sure node wasn't already deleted in _handle_nhwc_tranpose
+                if graph.get_node_by_name(n.name) is not None and is_useless_transpose(n):
                     no_action = False
                     iteration_cnt += 1
                     self._remove_useless_tranpose(n)


### PR DESCRIPTION
Signed-off-by: Tom Wildenhain <tomwi@microsoft.com>