### PR TITLE
Explicit padding for const shape ConvTranspose

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4706,7 +4706,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         def graph_validator(g):
             for n in g.get_nodes():
                 if n.type == 'ConvTranspose':
-                    return "pads" in n.attr
+                    return "pads" in n.attr or "output_shape" in n.attr
             return False
         self._run_test_case(func, [_OUTPUT], {_INPUT: filters_val, _INPUT1: out_backprop_val, _INPUT2: batch_dim_val},
                             graph_validator=graph_validator)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4706,7 +4706,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         def graph_validator(g):
             for n in g.get_nodes():
                 if n.type == 'ConvTranspose':
-                    return "output_shape" in n.attr
+                    return "pads" in n.attr
             return False
         self._run_test_case(func, [_OUTPUT], {_INPUT: filters_val, _INPUT1: out_backprop_val, _INPUT2: batch_dim_val},
                             graph_validator=graph_validator)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1505,16 +1505,16 @@ class Graph(object):
             a list of nodes
         """
         res_set = set()
-        if not outputs_name:
-            return list(res_set)
 
-        for output in outputs_name:
+        outputs_to_keep = list(outputs_name)
+        if not remove_unused_inputs:
+            # add placeholder nodes even if they are not connected to outputs.
+            # placeholder nodes with defaults can have inputs themselves
+            outputs_to_keep += [inp.output[0] for inp in self.inputs]
+
+        for output in outputs_to_keep:
             node = self.get_node_by_output(output, search_in_parent_graphs=False)
             res_set = res_set.union(self._extract_sub_graph_nodes(node, input_checker))
-
-        if not remove_unused_inputs:
-            # add back placeholder nodes if they are not connected to outputs.
-            res_set = res_set.union(self.inputs)
 
         return list(res_set)
 

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -430,8 +430,6 @@ class ConvTranspose:
         conv_kernel_shape(ctx, node, 1, spatial=spatial)
         input_shape = ctx.get_shape(node.input[2])
         input_batch_dim = input_shape[0]
-        print("\nstarting")
-        print(f"input_shape: {input_shape}")
         output_c_dim = ctx.get_shape(node.input[1])[-2]
         if is_channels_last(node):
             input_dims = input_shape[1:1+spatial]
@@ -442,7 +440,6 @@ class ConvTranspose:
 
         # output_shape is explicitly specified here and then converted to explicit pads.
         output_shape = get_shape_from_const_or_concat(ctx, node.inputs[0])
-        print(f"get_shape: {output_shape}")
         if output_shape is not None:
             if is_channels_last(node):
                 new_output_shape = [output_shape[1], output_shape[2]]
@@ -453,7 +450,6 @@ class ConvTranspose:
                 if spatial == 3:
                     new_output_shape.append(output_shape[4])
 
-            print(f"new_output_shape: {new_output_shape}")
             utils.make_sure(new_output_shape.count(-1) <= 0, "output dims need to be known")
             utils.make_sure(all(new_output_shape[i] >= input_dims[i] for i in range(spatial)),
                             "output dims cannot be smaller than input dims.")
@@ -464,20 +460,15 @@ class ConvTranspose:
                     strides = parse_dims_attr(node, node.get_attr("strides").ints, spatial)
                 else:
                     strides = [1] * spatial
-                print(f"strides: {strides}")
                 if "dilations" in node.attr:
                     dilations = parse_dims_attr(node, node.get_attr("dilations").ints, spatial)
                 else:
                     dilations = [1] * spatial
-                print(f"dilations: {dilations}")
                 if "output_padding" in node.attr:
                     output_padding = parse_dims_attr(node, node.get_attr("output_padding").ints, spatial)
                 else:
                     output_padding = [0] * spatial
-                print(f"output_padding: {output_padding}")
                 kernel_shape = parse_dims_attr(node, node.get_attr("kernel_shape").ints, spatial)
-                print(f"kernel_shape: {kernel_shape}")
-                print(f"input_dims: {input_dims}")
                 total_padding = [-1] * spatial
                 pads = [1] * (spatial * 2)
                 for i in range(spatial):
@@ -488,8 +479,6 @@ class ConvTranspose:
                     end_i = i + spatial
                     pads[start_i] = int(total_padding[i] / 2)
                     pads[end_i] = total_padding[i] - pads[start_i]
-                print(f"total_padding: {total_padding}")
-                print(f"pads: {pads}")
                 node.set_attr("pads", pads)
                 node.set_attr("auto_pad", "NOTSET")
         else:

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -474,8 +474,8 @@ class ConvTranspose:
                                     - new_output_shape[i])
                 start_i = i
                 end_i = i + spatial
-                pads[start_i] = int(total_padding[i] / 2);
-                pads[end_i] = total_padding[i] - pads[start_i];
+                pads[start_i] = int(total_padding[i] / 2)
+                pads[end_i] = total_padding[i] - pads[start_i]
             node.set_attr("pads", pads)
             node.set_attr("auto_pad", "NOTSET")
         else:

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -430,15 +430,19 @@ class ConvTranspose:
         conv_kernel_shape(ctx, node, 1, spatial=spatial)
         input_shape = ctx.get_shape(node.input[2])
         input_batch_dim = input_shape[0]
+        print("\nstarting")
+        print(f"input_shape: {input_shape}")
         output_c_dim = ctx.get_shape(node.input[1])[-2]
         if is_channels_last(node):
             input_dims = input_shape[1:1+spatial]
         else:
             input_dims = input_shape[2:2+spatial]
+        input_dims_known = -1 not in input_dims
         output_shape_orig = node.output_shapes
 
         # output_shape is explicitly specified here and then converted to explicit pads.
         output_shape = get_shape_from_const_or_concat(ctx, node.inputs[0])
+        print(f"get_shape: {output_shape}")
         if output_shape is not None:
             if is_channels_last(node):
                 new_output_shape = [output_shape[1], output_shape[2]]
@@ -449,35 +453,45 @@ class ConvTranspose:
                 if spatial == 3:
                     new_output_shape.append(output_shape[4])
 
+            print(f"new_output_shape: {new_output_shape}")
             utils.make_sure(new_output_shape.count(-1) <= 0, "output dims need to be known")
             utils.make_sure(all(new_output_shape[i] >= input_dims[i] for i in range(spatial)),
                             "output dims cannot be smaller than input dims.")
-
-            if "strides" in node.attr:
-                strides = parse_dims_attr(node, node.get_attr("strides").ints, spatial)
+            if -1 in input_dims:
+                node.set_attr("output_shape", new_output_shape)
             else:
-                strides = [1] * spatial
-            if "dilations" in node.attr:
-                dilations = parse_dims_attr(node, node.get_attr("dilations").ints, spatial)
-            else:
-                dilations = [1] * spatial
-            if "output_padding" in node.attr:
-                output_padding = parse_dims_attr(node, node.get_attr("output_padding").ints, spatial)
-            else:
-                output_padding = [0] * spatial
-            kernel_shape = parse_dims_attr(node, node.get_attr("kernel_shape").ints, spatial)
-            total_padding = [-1] * spatial
-            pads = [1] * (spatial * 2)
-            for i in range(spatial):
-                total_padding[i] = (strides[i] * (input_dims[i] - 1) + output_padding[i]
-                                    + ((kernel_shape[i] - 1) * dilations[i] + 1)
-                                    - new_output_shape[i])
-                start_i = i
-                end_i = i + spatial
-                pads[start_i] = int(total_padding[i] / 2)
-                pads[end_i] = total_padding[i] - pads[start_i]
-            node.set_attr("pads", pads)
-            node.set_attr("auto_pad", "NOTSET")
+                if "strides" in node.attr:
+                    strides = parse_dims_attr(node, node.get_attr("strides").ints, spatial)
+                else:
+                    strides = [1] * spatial
+                print(f"strides: {strides}")
+                if "dilations" in node.attr:
+                    dilations = parse_dims_attr(node, node.get_attr("dilations").ints, spatial)
+                else:
+                    dilations = [1] * spatial
+                print(f"dilations: {dilations}")
+                if "output_padding" in node.attr:
+                    output_padding = parse_dims_attr(node, node.get_attr("output_padding").ints, spatial)
+                else:
+                    output_padding = [0] * spatial
+                print(f"output_padding: {output_padding}")
+                kernel_shape = parse_dims_attr(node, node.get_attr("kernel_shape").ints, spatial)
+                print(f"kernel_shape: {kernel_shape}")
+                print(f"input_dims: {input_dims}")
+                total_padding = [-1] * spatial
+                pads = [1] * (spatial * 2)
+                for i in range(spatial):
+                    total_padding[i] = (strides[i] * (input_dims[i] - 1) + output_padding[i]
+                                        + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                                        - new_output_shape[i])
+                    start_i = i
+                    end_i = i + spatial
+                    pads[start_i] = int(total_padding[i] / 2)
+                    pads[end_i] = total_padding[i] - pads[start_i]
+                print(f"total_padding: {total_padding}")
+                print(f"pads: {pads}")
+                node.set_attr("pads", pads)
+                node.set_attr("auto_pad", "NOTSET")
         else:
             utils.make_sure(ctx.opset >= 10, "Opset 10 needed for Conv Backprop Input with non-constant shape")
             strides = parse_dims_attr(node, node.get_attr('strides').ints, spatial)

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -435,7 +435,6 @@ class ConvTranspose:
             input_dims = input_shape[1:1+spatial]
         else:
             input_dims = input_shape[2:2+spatial]
-        input_dims_known = -1 not in input_dims
         output_shape_orig = node.output_shapes
 
         # output_shape is explicitly specified here and then converted to explicit pads.

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -437,10 +437,9 @@ class ConvTranspose:
             input_dims = input_shape[2:2+spatial]
         output_shape_orig = node.output_shapes
 
-        # ouput_shape is explicitly specified here, in this case pads values are auto generated/calculated.
+        # output_shape is explicitly specified here and then converted to explicit pads.
         output_shape = get_shape_from_const_or_concat(ctx, node.inputs[0])
         if output_shape is not None:
-            #output_shape = ctx.get_shape(node.output[0])
             if is_channels_last(node):
                 new_output_shape = [output_shape[1], output_shape[2]]
                 if spatial == 3:
@@ -454,7 +453,31 @@ class ConvTranspose:
             utils.make_sure(all(new_output_shape[i] >= input_dims[i] for i in range(spatial)),
                             "output dims cannot be smaller than input dims.")
 
-            node.set_attr("output_shape", new_output_shape)
+            if "strides" in node.attr:
+                strides = parse_dims_attr(node, node.get_attr("strides").ints, spatial)
+            else:
+                strides = [1] * spatial
+            if "dilations" in node.attr:
+                dilations = parse_dims_attr(node, node.get_attr("dilations").ints, spatial)
+            else:
+                dilations = [1] * spatial
+            if "output_padding" in node.attr:
+                output_padding = parse_dims_attr(node, node.get_attr("output_padding").ints, spatial)
+            else:
+                output_padding = [0] * spatial
+            kernel_shape = parse_dims_attr(node, node.get_attr("kernel_shape").ints, spatial)
+            total_padding = [-1] * spatial
+            pads = [1] * (spatial * 2)
+            for i in range(spatial):
+                total_padding[i] = (strides[i] * (input_dims[i] - 1) + output_padding[i]
+                                    + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                                    - new_output_shape[i])
+                start_i = i
+                end_i = i + spatial
+                pads[start_i] = int(total_padding[i] / 2);
+                pads[end_i] = total_padding[i] - pads[start_i];
+            node.set_attr("pads", pads)
+            node.set_attr("auto_pad", "NOTSET")
         else:
             utils.make_sure(ctx.opset >= 10, "Opset 10 needed for Conv Backprop Input with non-constant shape")
             strides = parse_dims_attr(node, node.get_attr('strides').ints, spatial)


### PR DESCRIPTION
This creates a ConvTranspose node with constant shape using explicitly-defined padding rather than output_shape-based padding  (issue #1501).