### PR TITLE
Increase unit test timeout for windows job that often fails

### DIFF
--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -17,6 +17,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.job.name }}
+    timeoutInMinutes: 100
     pool:
         vmImage: $(CI_VM_IMAGE)
 


### PR DESCRIPTION
Signed-off-by: Tom Wildenhain <tomwi@microsoft.com>