### PR TITLE
Bug-fix to skip keras LSTM test for TF2.1

### DIFF
--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -729,6 +729,7 @@ class LSTMTests(Tf2OnnxBackendTestBase):
                            require_lstm_count=2)
 
     @check_tf_min_version("2.0")
+    @skip_tf_versions("2.1", "Bug in TF 2.1")
     def test_keras_lstm(self):
         in_shape = [10, 3]
         x_val = np.random.uniform(size=[2, 10, 3]).astype(np.float32)


### PR DESCRIPTION
Signed-off-by: congyc <congyc@amazon.com>

Skipping one keras LSTM test case for TF2.1. Refer to issue described [here](https://github.com/onnx/tensorflow-onnx/pull/1752#issuecomment-952597129).