### PR TITLE
Fix the Broken CI

### DIFF
--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -80,7 +80,7 @@ stages:
       parameters:
         platforms: ['linux']
         python_versions: ['3.9']
-        tf_versions: ['2.6.1']
+        tf_versions: ['2.6.2']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -41,7 +41,7 @@ jobs:
   parameters:
     platforms: ['linux', 'windows']
     python_versions: ['3.9']
-    tf_versions: ['2.6.1']
+    tf_versions: ['2.6.2']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -15,7 +15,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     python_versions: ['3.7']
-    tf_versions: ['1.15.5','2.6.1']
+    tf_versions: ['1.15.5','2.6.2']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -51,7 +51,7 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.8']
-        tf_versions: ['2.6.1']
+        tf_versions: ['2.6.2']
         onnx_opsets: ['']
         job:
           steps:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -7,7 +7,7 @@ stages:
       parameters:
         # TFJS tf 2.6
         python_versions: ['3.9']
-        tf_versions: ['2.6.1']
+        tf_versions: ['2.6.2']
         onnx_opsets: ['']
         skip_tfjs_tests: 'False'
         skip_tf_tests: 'True'
@@ -20,7 +20,7 @@ stages:
       parameters:
         # TFLite tf 2.6
         python_versions: ['3.8']
-        tf_versions: ['2.6.1']
+        tf_versions: ['2.6.2']
         onnx_opsets: ['']
         skip_tflite_tests: 'False'
         skip_tf_tests: 'True'
@@ -33,7 +33,7 @@ stages:
       parameters:
         # tf 2.6
         python_versions: ['3.8']
-        tf_versions: ['2.6.1']
+        tf_versions: ['2.6.2']
         onnx_opsets: ['']
         job:
           steps:

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -38,7 +38,7 @@ except:  # pylint: disable=bare-except
 
 try:
     import tensorflow_text  # pylint: disable=unused-import
-except ModuleNotFoundError:
+except Exception as err:
     pass
 
 from tf2onnx import tf_loader, logging, optimizer, utils, tf_utils, constants

--- a/tests/run_pretrained_models.yaml
+++ b/tests/run_pretrained_models.yaml
@@ -458,7 +458,7 @@ keras_mobilenet_v2:
 ssd_mobilenet_v2_300_float_tflite:
   tf_min_version: 2.1
   disabled: false
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/ssd_mobilenet_v2_300_float.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/ssd_mobilenet_v2_300_float.tflite
   model: "ssd_mobilenet_v2_300_float.tflite"
   model_type: tflite
   input_get: get_car
@@ -476,7 +476,7 @@ ssd_mobilenet_v2_300_float_tflite:
 deeplabv3_mnv2_ade20k_float_tflite:
   tf_min_version: 2.1
   disabled: false
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/deeplabv3_mnv2_ade20k_float.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/deeplabv3_mnv2_ade20k_float.tflite
   model: "deeplabv3_mnv2_ade20k_float.tflite"
   model_type: tflite
   input_get: get_ade20k
@@ -489,7 +489,7 @@ deeplabv3_mnv2_ade20k_float_tflite:
 deeplabv3_mnv2_ade20k_uint8_tflite_dequantize:
   tf_min_version: 2.1
   disabled: false
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite
   model: "deeplabv3_mnv2_ade20k_uint8.tflite"
   model_type: tflite
   input_get: get_ade20k_uint8
@@ -503,7 +503,7 @@ deeplabv3_mnv2_ade20k_uint8_tflite_dequantize:
 deeplabv3_mnv2_ade20k_uint8_tflite:
   tf_min_version: 2.1
   disabled: true   # Requires ORT nightly for dequantize of int32
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/deeplabv3_mnv2_ade20k_uint8.tflite
   model: "deeplabv3_mnv2_ade20k_uint8.tflite"
   model_type: tflite
   input_get: get_ade20k_uint8
@@ -520,7 +520,7 @@ deeplabv3_mnv2_ade20k_uint8_tflite:
 deeplabv3_mnv2_ade20k_int8_tflite_dequantize:
   tf_min_version: 2.1
   disabled: false
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/deeplabv3_mnv2_ade20k_int8.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/deeplabv3_mnv2_ade20k_int8.tflite
   model: "deeplabv3_mnv2_ade20k_int8.tflite"
   model_type: tflite
   input_get: get_ade20k_uint8   # the input is uint8 despite the model name
@@ -534,7 +534,7 @@ deeplabv3_mnv2_ade20k_int8_tflite_dequantize:
 deeplabv3_mnv2_ade20k_int8_tflite:
   tf_min_version: 2.1
   disabled: true   # Requires ORT nightly for dequantize of int32
-  url: https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/deeplabv3_mnv2_ade20k_int8.tflite
+  url: https://github.com/mlcommons/mobile_models/raw/9c7b31ce63ff0331bd659ac2609c4e68b6b4ec0f/v0_7/tflite/deeplabv3_mnv2_ade20k_int8.tflite
   model: "deeplabv3_mnv2_ade20k_int8.tflite"
   model_type: tflite
   input_get: get_ade20k_uint8   # the input is uint8 despite the model name
@@ -571,7 +571,7 @@ mobilebert_tflite:
 palm_detection_tflite:
   tf_min_version: 2.1
   disabled: false
-  url: https://github.com/google/mediapipe/raw/master/mediapipe/modules/palm_detection/palm_detection.tflite
+  url: https://github.com/google/mediapipe/raw/v0.8.8/mediapipe/modules/palm_detection/palm_detection.tflite
   model: "palm_detection.tflite"
   model_type: tflite
   input_get: get_beach


### PR DESCRIPTION
1. Fixed the fragile URLs used for CI testing.
2. Fixed the exception handling for `tensorflow_text` import failings.
3. Try TF 2.6.2.