### PR TITLE
Specify the version scope of tensorflow-text.

### DIFF
--- a/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
@@ -45,6 +45,7 @@ steps:
       $(INSTALL_TRANSFORMERS)
       pip install keras-self-attention
       pip install pytest pytest-cov pytest-runner
+      pip install numpy==1.19
     displayName: 'Install dependencies'
 
   - script: |
@@ -101,6 +102,7 @@ steps:
       %INSTALL_TRANSFORMERS%
       pip install keras-self-attention
       pip install pytest pytest-cov pytest-runner
+      pip install numpy==1.19
     displayName: 'Install dependencies'
 
   - script: |

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -32,6 +32,7 @@ steps:
       pip install -r requirements-dev.txt
       pip install pytest pytest-cov pytest-runner
       $(INSTALL_ORT)
+      pip install numpy==1.19
     displayName: 'Install dependencies'
 
   - script: |
@@ -77,6 +78,7 @@ steps:
       pip install git+https://github.com/microsoft/onnxconverter-common
       pip install pytest pytest-cov pytest-runner
       %INSTALL_ORT%
+      pip install numpy==1.19
     displayName: 'Install dependencies'
 
   - script: |

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -39,15 +39,15 @@ steps:
       fi
       if [[ $CI_TF_VERSION == 2.5* ]] ;
       then
-        pip install tensorflow-text>=2.5
+        pip install "tensorflow-text>=2.5,<2.6"
       fi
       if [[ $CI_TF_VERSION == 2.6* ]] ;
       then
-        pip install tensorflow-text>=2.6
+        pip install "tensorflow-text>=2.6,<2.7"
       fi
       if [[ $CI_TF_VERSION == 2.7* ]] ;
       then
-        pip install tensorflow-text>=2.6
+        pip install "tensorflow-text>=2.7,<2.8"
       fi
     fi
 


### PR DESCRIPTION
By specifying the version scope of tensorflow-text, avoid it was upgraded to latest version which might upgrade its dependencies to latest version unexpectedly.

Signed-off-by: Jay Zhang <jiz@microsoft.com>