### PR TITLE
Add used opset into opset_imports argument to create an onnx model.

### DIFF
--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -21,6 +21,9 @@ PREFERRED_OPSET = 9
 # Default opset for custom ops
 TENSORFLOW_OPSET = helper.make_opsetid("ai.onnx.converters.tensorflow", 1)
 
+# Built-in supported opset
+AI_ONNX_ML_OPSET = helper.make_opsetid(AI_ONNX_ML_DOMAIN, 2)
+
 # Target for the generated onnx graph. It possible targets:
 # onnx-1.1 = onnx at v1.1 (winml in rs4 is based on this)
 # caffe2 = include some workarounds for caffe2 and winml

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1193,10 +1193,8 @@ class Graph(object):
                       "producer_version": __version__}
 
         if "opset_imports" not in kwargs:
-            opsets = []
-            imp = OperatorSetIdProto()
-            imp.version = self._opset
-            opsets.append(imp)
+            opsets = [helper.make_opsetid(constants.ONNX_DOMAIN, self._opset)]
+            opsets.append(constants.AI_ONNX_ML_OPSET)
             if self.extra_opset is not None:
                 opsets.extend(self.extra_opset)
             kwargs["opset_imports"] = opsets

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -11,7 +11,7 @@ import logging
 import six
 import numpy as np
 
-from onnx import helper, numpy_helper, shape_inference, OperatorSetIdProto, AttributeProto, TensorProto
+from onnx import helper, numpy_helper, shape_inference, AttributeProto, TensorProto
 from tf2onnx import utils, __version__
 from tf2onnx.utils import make_name, port_name, find_opset
 from tf2onnx import optimizer


### PR DESCRIPTION
In latest ONNX version, there is an enhancement that if the used domain of a node doesn't exist in the model.opset_import, it will result in an exception and stop processing.

To align with this enhancement, we add current used domain and opset version into model.opset_import property by appending them into "opset_imports" argument in make_model() method.

Signed-off-by: Jay Zhang <jiz@microsoft.com>