### PR TITLE
feat: For QDQ models, disable constant folding and ensure the conv weights are transposed without using an explicit op

### DIFF
--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -138,7 +138,7 @@ def make_default_custom_op_handler(domain):
 
 
 def _convert_common(frozen_graph, name="unknown", large_model=False, output_path=None,
-                    output_frozen_graph=None, custom_ops=None, custom_op_handlers=None, **kwargs):
+                    output_frozen_graph=None, custom_ops=None, custom_op_handlers=None, optimizers=None, **kwargs):
     """Common processing for conversion."""
 
     model_proto = None
@@ -165,7 +165,7 @@ def _convert_common(frozen_graph, name="unknown", large_model=False, output_path
             catch_errors = constants.ENV_TF2ONNX_CATCH_ERRORS.upper() == "TRUE"
         else:
             catch_errors = not large_model
-        onnx_graph = optimizer.optimize_graph(g, catch_errors)
+        onnx_graph = optimizer.optimize_graph(g, catch_errors, optimizers=optimizers)
         model_proto = onnx_graph.make_model("converted from {}".format(name),
                                             external_tensor_storage=external_tensor_storage)
     if output_path:

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -139,12 +139,25 @@ def conv_convert_inputs(ctx, node, with_kernel=False, new_kernel_shape=None,
 
         # If kernel is a constant, transpose that one if we are the only consumer.
         need_transpose = True
-        if kernel_node.is_const() and len(ctx.find_output_consumers(kernel_name)) == 1:
-            val = kernel_node.get_tensor_value(as_list=False)
-            val = np.transpose(val, permutation)
-
-            kernel_node.set_tensor_value(val)
-            need_transpose = False
+        if (kernel_node.is_const() or kernel_node.op.op_type == "DequantizeLinear") \
+            and len(ctx.find_output_consumers(kernel_name)) == 1:
+            if kernel_node.op.op_type == 'DequantizeLinear':
+                # Assuming the model was trained in NHWC in TF,
+                # the weights would be in [fH, fW, C_in, C_out].
+                # orig_conv_weights -> Q -> DQ -> new_conv_weights -> conv
+                weights_node = kernel_node.inputs[0].inputs[0]
+                val = weights_node.get_tensor_value(as_list=False)
+                val = np.transpose(val, permutation)
+                weights_node.set_tensor_value(val)
+                need_transpose = False
+                # Change the quantization axis for Q and DQ node accordingly
+                kernel_node.set_attr("axis", 0) # DQ node
+                kernel_node.inputs[0].set_attr("axis", 0) # Q node
+            else:
+                val = kernel_node.get_tensor_value(as_list=False)
+                val = np.transpose(val, permutation)
+                kernel_node.set_tensor_value(val)
+                need_transpose = False
 
         if need_transpose:
             transpose = ctx.insert_new_node_on_input(node, "Transpose", kernel_name)

--- a/tf2onnx/tf_loader.py
+++ b/tf2onnx/tf_loader.py
@@ -686,6 +686,11 @@ def tf_optimize_grappler(input_names, output_names, graph_def, fold_constant=Non
         # 'pruning', 'constfold', 'arithmetic', 'dependency', 'function',
         'constfold', 'function'
     ]
+
+    if LooseVersion(tf.__version__) >= "2.5":
+        # This flag disables folding QDQ nodes around constants in the network (eg: around conv/FC weights)
+        rewrite_options.experimental_disable_folding_quantization_emulation = True
+
     meta_graph = tf.compat.v1.train.export_meta_graph(graph_def=graph_def)
     fetch_collection = meta_graph_pb2.CollectionDef()
     for t in input_names + output_names:

--- a/tf2onnx/tf_utils.py
+++ b/tf2onnx/tf_utils.py
@@ -219,7 +219,8 @@ def compute_const_folding_using_tf(g, const_node_values, graph_outputs):
                     outputs_to_dtypes[node.outputs[0].name] = node.outputs[0].dtype
                     progress = True
             can_fold = node.type not in ['Enter', 'Placeholder', 'PlaceholderWithDefault', 'Switch', 'Merge',
-                                         'NextIteration', 'Exit']
+                                         'NextIteration', 'Exit', 'QuantizeAndDequantizeV2', 'QuantizeAndDequantizeV3',
+                                         'QuantizeAndDequantizeV4']
             can_fold = can_fold and not node.type.startswith('Random')
             can_fold = can_fold and len(input_names) > 0 and all(inp in outputs_to_values for inp in input_names)
             # We can only fold nodes with a single output


### PR DESCRIPTION
 cleaned up version of https://github.com/onnx/tensorflow-onnx/pull/1839
Signed-off-by: Dheeraj Peri <peri.dheeraj@gmail.com>