### PR TITLE
Force to upgrade typing-extensions to a version above 4.0.0.

### DIFF
--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -62,6 +62,8 @@ steps:
       # onnx-weekly won't satisfy onnx requirement so uninstallation must happen here
       pip uninstall -y onnx
       pip install --index-url https://test.pypi.org/simple/ ${PIP_ONNX_NAME:-onnx}
+      pip uninstall typing-extensions
+      pip install typing-extensions>4.0.0
     fi
 
     pip freeze --all


### PR DESCRIPTION
For onnx-weekly CI job, upgrade the typing-extensions to a version above 4.0.0 to avoid unexpected crash on opset 15.

Signed-off-by: Jay Zhang <jiz@microsoft.com>