### PR TITLE
Upgrade Windows image to windows-2019.

### DIFF
--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -60,7 +60,7 @@ jobs:
 - job: 'Win'
   timeoutInMinutes: 180
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   strategy:
     matrix:
       Python36-onnx1.5:

--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -60,7 +60,7 @@ jobs:
 - job: 'Win'
   timeoutInMinutes: 180
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       Python36-onnx1.5:

--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -76,7 +76,7 @@ jobs:
 
 - job: 'Win'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############

--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -76,7 +76,7 @@ jobs:
 
 - job: 'Win'
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -35,9 +35,9 @@ jobs:
                         ${{ if eq(platform, 'linux') }}:
                           CI_VM_IMAGE: 'ubuntu-latest'
                         ${{ if eq(platform, 'windows') }}:
-                          CI_VM_IMAGE: 'vs2017-win2016'
+                          CI_VM_IMAGE: 'windows-2022'
                         ${{ if eq(platform, 'mac') }}:
-                          CI_VM_IMAGE: 'macOS-10.13'
+                          CI_VM_IMAGE: 'macOS-11'
                         CI_PLATFORM: '${{ platform }}'
                         CI_PYTHON_VERSION: '${{ python_version }}'
                         CI_TF_VERSION: '${{ tf_version }}'

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -35,7 +35,7 @@ jobs:
                         ${{ if eq(platform, 'linux') }}:
                           CI_VM_IMAGE: 'ubuntu-latest'
                         ${{ if eq(platform, 'windows') }}:
-                          CI_VM_IMAGE: 'windows-2022'
+                          CI_VM_IMAGE: 'windows-2019'
                         ${{ if eq(platform, 'mac') }}:
                           CI_VM_IMAGE: 'macOS-11'
                         CI_PLATFORM: '${{ platform }}'

--- a/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
@@ -101,6 +101,7 @@ steps:
       pip install keras-self-attention
       pip install pytest pytest-cov pytest-runner
       pip install numpy==1.19
+      pip freeze --all
     displayName: 'Install dependencies'
 
   - script: |

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -32,6 +32,7 @@ steps:
       pip install pytest pytest-cov pytest-runner
       $(INSTALL_ORT)
       pip install numpy==1.19
+      pip freeze --all
     displayName: 'Install dependencies'
 
   - script: |

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -62,8 +62,6 @@ steps:
       # onnx-weekly won't satisfy onnx requirement so uninstallation must happen here
       pip uninstall -y onnx
       pip install --index-url https://test.pypi.org/simple/ ${PIP_ONNX_NAME:-onnx}
-      pip uninstall -y typing-extensions
-      pip install typing-extensions>4.0.0
     fi
 
     pip freeze --all

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -44,7 +44,7 @@ jobs:
 
 - job: 'Win'
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -44,7 +44,7 @@ jobs:
 
 - job: 'Win'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############


### PR DESCRIPTION
1. The current windows image is going to be retired so replace it with a latest one.
2. Remove some unnecessary changes for recovering onnx-weekly CI job.
3. List pip packages for some CI jobs.
4. Python 3.6 is not supported by windows-2022, so upgrade to windows-2019.

Signed-off-by: Jay Zhang <jiz@microsoft.com>