### PR TITLE
Add the absolute path condition when loads the tf custom op library

### DIFF
--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -221,10 +221,9 @@ def main():
 
     if args.load_op_libraries:
         for op_filepath in args.load_op_libraries:
-            # the path in tf.load_op_library() must be absolute path.
-            if os.path.exists(op_filepath) and not os.path.isabs(op_filepath) and filename.endswith(".so"):
+            # change relative path to absolute path to satisfy the tf.load_op_library().
+            if not os.path.isabs(op_filepath):
                 op_filepath = os.getcwd() + "/" + op_filepath
-            logger.info("Load the tensorflow custom ops library so file from: %s", format(op_filepath))
             tf.load_op_library(op_filepath)
     if args.graphdef:
         graph_def, inputs, outputs = tf_loader.from_graphdef(args.graphdef, args.inputs, args.outputs)

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -220,8 +220,12 @@ def main():
                        "See https://github.com/onnx/tensorflow-onnx/issues/1557")
 
     if args.load_op_libraries:
-        for op_path in args.load_op_libraries:
-            tf.load_op_library(op_path)
+        for op_filepath in args.load_op_libraries:
+            # the path in tf.load_op_library() must be absolute path.
+            if os.path.exists(op_filepath) and not os.path.isabs(op_filepath) and filename.endswith(".so"):
+                op_filepath = os.getcwd() + "/" + op_filepath
+            logger.info("Load the tensorflow custom ops library so file from: %s", format(op_filepath))
+            tf.load_op_library(op_filepath)
     if args.graphdef:
         graph_def, inputs, outputs = tf_loader.from_graphdef(args.graphdef, args.inputs, args.outputs)
         model_path = args.graphdef


### PR DESCRIPTION
The path in `tf.load_op_library()` must be absolute path.

Signed-off-by: Deyu Huang <deyhuang@microsoft.com>