### PR TITLE
Remove python 3.6 support, upgrade CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ __Note: tensorflow.js support was just added. While we tested it with many tfjs 
 
 TensorFlow has many more ops than ONNX and occasionally mapping a model to ONNX creates issues.
 
-You find a list of supported Tensorflow ops and their mapping to ONNX [here](support_status.md).
+You find a list of supported TensorFlow ops and their mapping to ONNX [here](support_status.md).
 
 The common issues we run into we try to document here [Troubleshooting Guide](Troubleshooting.md).
 
 <br/>
 
-| Build Type | OS | Python | Tensorflow | ONNX opset | Status |
+| Build Type | OS | Python | TensorFlow | ONNX opset | Status |
 | ---        | ---    | ---    | ---        | ---        | ---    |
-| Unit Test - Basic | Linux, MacOS<sup>\*</sup>, Windows<sup>\*</sup> | 3.6-3.9 | 1.12-1.15, 2.1-2.8 | 9-15 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=16&branchName=main) |
-| Unit Test - Full | Linux, MacOS, Windows | 3.6-3.9 | 1.12-1.15, 2.1-2.8 | 9-15 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test-matrix?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=18&branchName=main) | |
+| Unit Test - Basic | Linux, MacOS<sup>\*</sup>, Windows<sup>\*</sup> | 3.7-3.9 | 1.13-1.15, 2.1-2.8 | 9-15 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=16&branchName=main) |
+| Unit Test - Full | Linux, MacOS, Windows | 3.7-3.9 | 1.13-1.15, 2.1-2.8 | 9-15 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test-matrix?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=18&branchName=main) | |
 <br/>
 
 ## Supported Versions
@@ -34,7 +34,7 @@ If you want the graph to be generated with a specific opset, use ```--opset``` i
 
 ### TensorFlow
 
-We support ```tf-1.x graphs``` and ```tf-2.x```. To keep our test matrix manageable we test tf2onnx running on top of ```tf-1.12 or better```.
+We support ```tf-1.x graphs``` and ```tf-2.x```. To keep our test matrix manageable we test tf2onnx running on top of ```tf-1.13 or better```.
 
 When running under tf-2.x tf2onnx will use the tensorflow V2 controlflow.
 
@@ -42,7 +42,7 @@ You can install tf2onnx on top of tf-1.x or tf-2.x.
 
 ### Python
 
-We support Python ```3.6-3.9```.
+We support Python ```3.7-3.9```.
 Note that on windows for Python > 3.7 the protobuf package doesn't use the cpp implementation and is very slow - we recommend to use Python 3.7 for that reason.
 
 ## Prerequisites

--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python36-onnx1.5:
-        python.version: '3.6'
+      Python37-onnx1.5:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.5.0
         INSTALL_KERAS: pip install keras==2.2.4
         UNINSTALL_KERAS:
@@ -79,8 +79,8 @@ jobs:
     vmImage: 'windows-2019'
   strategy:
     matrix:
-      Python36-onnx1.5:
-        python.version: '3.6'
+      Python37-onnx1.5:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.5.0
         INSTALL_KERAS: pip install keras==2.2.4
         UNINSTALL_KERAS:

--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -9,8 +9,8 @@ jobs:
     matrix:
 
       ############ TF Keras Unit Tests ############
-      Python36-tf1.15:
-        python.version: '3.6'
+      Python37-tf1.15:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
@@ -45,8 +45,8 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
 
       ############ Pure Keras Unit Tests ############
-      Keras-Py36-tf1.15.0:
-        python.version: '3.6'
+      Keras-Py37-tf1.15.0:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         KERAS: keras==2.2.5
         TENSORFLOW_PATH: tensorflow==1.15.0
@@ -88,8 +88,8 @@ jobs:
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############
-      Python36-tf-1.15:
-        python.version: '3.6'
+      Python37-tf-1.15:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
@@ -123,8 +123,8 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
 
       ############ Pure Keras Unit Tests ############
-      Keras-Py36-tf1.15.0:
-        python.version: '3.6'
+      Keras-Py37-tf1.15.0:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         KERAS: keras==2.2.5
         TENSORFLOW_PATH: tensorflow==1.15.0

--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -19,20 +19,8 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux', 'windows']
-        python_versions: ['3.7', '3.6']
-        tf_versions: ['1.13.1']
-        onnx_opsets: ['']
-        onnx_backends: {onnxruntime: ['nightly']}
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-
-    - template: 'templates/job_generator.yml'
-      parameters:
-        platforms: ['linux', 'windows']
-        python_versions: [3.7', '3.6']
-        tf_versions: ['1.14.0']
+        python_versions: ['3.7']
+        tf_versions: ['1.13.1', '1.14.0']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -4,17 +4,8 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows']
-    python_versions: ['3.6']
-    tf_versions: ['1.13.1', '1.12.3']
-    job:
-      steps:
-      - template: 'pretrained_model_test.yml'
-
-- template: 'templates/job_generator.yml'
-  parameters:
-    platforms: ['linux', 'windows']
-    python_versions: ['3.7', '3.6']
-    tf_versions: ['1.14.0']
+    python_versions: ['3.7']
+    tf_versions: ['1.13.1', '1.14.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/templates/combine_test_coverage.yml
+++ b/ci_build/azure_pipelines/templates/combine_test_coverage.yml
@@ -24,7 +24,7 @@ stages:
       inputs:
         createCustomEnvironment: 'true'
         environmentName: 'tf2onnx'
-        packageSpecs: 'python=3.6'
+        packageSpecs: 'python=3.7'
         updateConda: 'false'
   
     - bash: |

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python36-onnx1.10:
-        python.version: '3.6'
+      Python37-onnx1.10:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         INSTALL_KERAS: pip install keras==2.2.4
         UNINSTALL_KERAS:

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -9,8 +9,8 @@ jobs:
     matrix:
 
       ############ TF Keras Unit Tests ############
-      Python36-tf1.15:
-        python.version: '3.6'
+      Python37-tf1.15:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
@@ -51,8 +51,8 @@ jobs:
   strategy:
     matrix:
       ############ TF Keras Unit Tests ############
-      Python36-tf-1.15:
-        python.version: '3.6'
+      Python37-tf-1.15:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -14,6 +14,7 @@ jobs:
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_NUMPY: pip install numpy==1.19.0
 
       Python38-tf2.5:
         python.version: '3.8'
@@ -56,6 +57,7 @@ jobs:
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_NUMPY: pip install numpy==1.19.0
 
       Python37-tf2.3:
         python.version: '3.7'

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -7,7 +7,7 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.7']
-        tf_versions: ['1.13.3']
+        tf_versions: ['1.13.1']
         onnx_opsets: ['']
         job:
           steps:

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -6,8 +6,8 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux', 'windows']
-        python_versions: ['3.6']
-        tf_versions: ['1.12.3']
+        python_versions: ['3.7']
+        tf_versions: ['1.13.3']
         onnx_opsets: ['']
         job:
           steps:
@@ -17,7 +17,7 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux', 'windows']
-        python_versions: ['3.7', '3.6']
+        python_versions: ['3.7']
         tf_versions: ['1.14.0']
         onnx_opsets: ['']
         job:
@@ -61,7 +61,7 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux', 'windows']
-        python_versions: ['3.8']
+        python_versions: ['3.9']
         tf_versions: ['2.8.0']
         onnx_opsets: ['']
         job:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -129,7 +129,7 @@ stages:
       parameters:
         # tf 1.13
         python_versions: [3.7']
-        tf_versions: ['1.13.3']
+        tf_versions: ['1.13.1']
         onnx_opsets: ['9']
         job:
           steps:
@@ -152,6 +152,17 @@ stages:
         platforms: ['windows']
         tf_versions: ['2.4.1']
         onnx_opsets: ['13']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        python_versions: ['3.9']
+        platforms: ['windows']
+        tf_versions: ['2.8.1']
+        onnx_opsets: ['15']
         job:
           steps:
           - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -127,9 +127,9 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
-        # tf 1.12
-        python_versions: [3.6']
-        tf_versions: ['1.12.3']
+        # tf 1.13
+        python_versions: [3.7']
+        tf_versions: ['1.13.3']
         onnx_opsets: ['9']
         job:
           steps:

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9']


### PR DESCRIPTION
- Remove Python 3.6, tf1.12 in all CIs
- Upgrade some CIs for newer version.
- Update doc

fixes https://github.com/onnx/tensorflow-onnx/issues/1884
[Python 3.6 has reached end-of-life](https://www.python.org/dev/peps/pep-0494/)
Fewer and fewer people use python3.6. [PyPI Download Stats (pypistats.org)](https://pypistats.org/packages/tf2onnx)
