### PR TITLE
Update the way to check input_signature in from_function().

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -187,7 +187,7 @@ class ApiTests(Tf2OnnxBackendTestBase):
         model_proto, _ = tf2onnx.convert.from_function(func, input_signature=spec,
                                                        opset=self.config.opset, output_path=output_path)
         output_names = [n.name for n in model_proto.graph.output]
-        res_onnx = self.run_onnxruntime(output_path, {'x' : x}, output_names)
+        res_onnx = self.run_onnxruntime(output_path, {'x': x}, output_names)
         self.assertAllClose(res_tf, res_onnx[0], rtol=1e-5, atol=1e-5)
 
     @check_tf_min_version("1.15")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,6 +173,23 @@ class ApiTests(Tf2OnnxBackendTestBase):
         res_onnx = self.run_onnxruntime(output_path, {"x": x, "w": w}, output_names)
         self.assertAllClose(res_tf, res_onnx[0], rtol=1e-5, atol=1e-5)
 
+    @check_tf_min_version("2.0")
+    def test_function_nparray(self):
+        @tf.function
+        def func(x):
+            return tf.math.sqrt(x)
+
+        output_path = os.path.join(self.test_data_directory, "model.onnx")
+        x = np.asarray([1.0, 2.0])
+
+        res_tf = func(x)
+        spec = np.asarray([[1.0, 2.0]])
+        model_proto, _ = tf2onnx.convert.from_function(func, input_signature=spec,
+                                                       opset=self.config.opset, output_path=output_path)
+        output_names = [n.name for n in model_proto.graph.output]
+        res_onnx = self.run_onnxruntime(output_path, {'x' : x}, output_names)
+        self.assertAllClose(res_tf, res_onnx[0], rtol=1e-5, atol=1e-5)
+
     @check_tf_min_version("1.15")
     def _test_graphdef(self):
         def func(x, y):

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -535,7 +535,8 @@ def from_function(function, input_signature=None, opset=None, custom_ops=None, c
     if LooseVersion(tf.__version__) < "2.0":
         raise NotImplementedError("from_function requires tf-2.0 or newer")
 
-    if not input_signature:
+    if input_signature is None:
+    # if not input_signature:
         raise ValueError("from_function requires input_signature")
 
     concrete_func = function.get_concrete_function(*input_signature)

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -536,7 +536,6 @@ def from_function(function, input_signature=None, opset=None, custom_ops=None, c
         raise NotImplementedError("from_function requires tf-2.0 or newer")
 
     if input_signature is None:
-    # if not input_signature:
         raise ValueError("from_function requires input_signature")
 
     concrete_func = function.get_concrete_function(*input_signature)


### PR DESCRIPTION
When a function was converted to an ONNX model, the input_signature will be checked. The logic is we want to check if the input_signature is None, but the current way may make a mistake for some inputs which are not TensorSpec but still valid, so correct it.