### PR TITLE
Update protobuf version in ci

### DIFF
--- a/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
@@ -19,6 +19,8 @@ steps:
       python -m pip install --upgrade pip
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
+      pip uninstall -y protobuf
+      pip install protobuf==3.20.1
       pip install h5py==2.9.0
       pip install parameterized
       $(INSTALL_TENSORFLOW)
@@ -81,7 +83,7 @@ steps:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install protobuf
+      pip install protobuf==3.20.1
       pip install h5py==2.9.0
       pip install parameterized
       %INSTALL_TENSORFLOW%

--- a/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
@@ -20,7 +20,7 @@ steps:
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
       pip uninstall -y protobuf
-      pip install protobuf==3.20.1
+      pip install "protobuf<4.21.0"
       pip install h5py==2.9.0
       pip install parameterized
       $(INSTALL_TENSORFLOW)
@@ -83,7 +83,7 @@ steps:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install protobuf==3.20.1
+      pip install "protobuf<4.21.0"
       pip install h5py==2.9.0
       pip install parameterized
       %INSTALL_TENSORFLOW%

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -19,6 +19,8 @@ steps:
       python -m pip install --upgrade pip
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
+      pip uninstall -y protobuf
+      pip install protobuf==3.20.1
       pip install h5py==2.9.0
       pip install parameterized
       pip install $(TENSORFLOW_PATH)
@@ -71,7 +73,7 @@ steps:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install protobuf
+      pip install protobuf==3.20.1
       pip install h5py==2.9.0
       pip install parameterized
       pip install %TENSORFLOW_PATH%

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -20,7 +20,7 @@ steps:
       conda config --set always_yes yes --set changeps1 no
       pip install $(ONNX_PATH)
       pip uninstall -y protobuf
-      pip install protobuf==3.20.1
+      pip install "protobuf<4.21.0"
       pip install h5py==2.9.0
       pip install parameterized
       pip install $(TENSORFLOW_PATH)
@@ -73,7 +73,7 @@ steps:
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install protobuf==3.20.1
+      pip install "protobuf<4.21.0"
       pip install h5py==2.9.0
       pip install parameterized
       pip install %TENSORFLOW_PATH%

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -6,6 +6,10 @@ steps:
     pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME)
 
+    # protobuf release version 4.21.0 has some Python changes which is not compatible with tensorflow so far.
+    pip uninstall -y protobuf
+    pip install "protobuf<4.21.0"
+
     # TF < 2.7 reuires numpy <= 1.19, but onnxruntime >= 1.11 requires numpy >= 1.21
     if [[ $CI_TF_VERSION < 2.7 ]] && [[ $CI_ONNX_BACKEND == "onnxruntime" ]] ;
     then 


### PR DESCRIPTION
Protobuf new release version [`4.21.0`](https://pypi.org/project/protobuf/#history) has some [Python changes](https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates) which is not compatible with tensorflow so far. Set specific version in ci.

Signed-off-by: Deyu Huang <deyhuang@microsoft.com>