### PR TITLE
The from_tflite() function should accept None as default value of input_names and output_names.

### DIFF
--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -663,10 +663,6 @@ def from_tflite(tflite_path, input_names=None, output_names=None, opset=None, cu
     """
     if not tflite_path:
         raise ValueError("tflite_path needs to be provided")
-    if not input_names:
-        input_names = []
-    if not output_names:
-        output_names = []
 
     with tf.device("/cpu:0"):
         model_proto, external_tensor_storage = _convert_common(


### PR DESCRIPTION
When converting a tflite model to an onnx ModelProto using from_tflite() function, if the output_names argument is not specified, it defaults to an empty list instead of None.

However, in the tf2onnx.tflite_utils.graphs_from_tflite function, if the output_names argument is not None, the output names retrieved automatically by the tf2onnx.tflite_utils.parse_tflite_graph function are overwritten, resulting in a ModelProto with no output which causes a bug.

So the function should not change None to an empty list for both input_names and output_names arguments. This PR fixes this problem. Add related tests as well.

System information

Signed-off-by: Jay Zhang <jiz@microsoft.com>