### PR TITLE
Add support for Python310 and ORT 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The common issues we run into we try to document here [Troubleshooting Guide](Tr
 
 | Build Type | OS | Python | TensorFlow | ONNX opset | Status |
 | ---        | ---    | ---    | ---        | ---        | ---    |
-| Unit Test - Basic | Linux, MacOS<sup>\*</sup>, Windows<sup>\*</sup> | 3.7-3.9 | 1.13-1.15, 2.1-2.8 | 9-16 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=16&branchName=main) |
-| Unit Test - Full | Linux, MacOS, Windows | 3.7-3.9 | 1.13-1.15, 2.1-2.8 | 9-16 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test-matrix?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=18&branchName=main) | |
+| Unit Test - Basic | Linux, MacOS<sup>\*</sup>, Windows<sup>\*</sup> | 3.7-3.10 | 1.13-1.15, 2.1-2.8 | 9-16 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=16&branchName=main) |
+| Unit Test - Full | Linux, MacOS, Windows | 3.7-3.10 | 1.13-1.15, 2.1-2.8 | 9-16 | [![Build Status](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_apis/build/status/unit_test-matrix?branchName=main)](https://dev.azure.com/tensorflow-onnx/tensorflow-onnx/_build/latest?definitionId=18&branchName=main) | |
 <br/>
 
 ## Supported Versions
@@ -42,7 +42,7 @@ You can install tf2onnx on top of tf-1.x or tf-2.x.
 
 ### Python
 
-We support Python ```3.7-3.9```.
+We support Python ```3.7-3.10```.
 Note that on windows for Python > 3.7 the protobuf package doesn't use the cpp implementation and is very slow - we recommend to use Python 3.7 for that reason.
 
 ## Prerequisites

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -40,7 +40,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows']
-    python_versions: ['3.9', '3.10']
+    python_versions: ['3.8']
     tf_versions: ['2.8.0']
     job:
       steps:

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -40,7 +40,7 @@ jobs:
 - template: 'templates/job_generator.yml'
   parameters:
     platforms: ['linux', 'windows']
-    python_versions: ['3.8']
+    python_versions: ['3.9', '3.10']
     tf_versions: ['2.8.0']
     job:
       steps:

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -30,3 +30,12 @@ jobs:
     job:
       steps:
       - template: 'pretrained_model_test.yml'
+
+- template: 'templates/job_generator.yml'
+  parameters:
+    # 2.8, tf 3.10
+    python_versions: ['3.10']
+    tf_versions: ['2.9.0']
+    job:
+      steps:
+      - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -15,7 +15,7 @@ jobs:
 
 - template: 'templates/job_generator.yml'
   parameters:
-    # 2.7, tf
+    # 2.8, tf
     python_versions: ['3.7']
     tf_versions: ['1.15.5','2.8.0']
     job:
@@ -24,7 +24,7 @@ jobs:
 
 - template: 'templates/job_generator.yml'
   parameters:
-    # 2.8, tf
+    # 2.9, tf
     python_versions: ['3.9']
     tf_versions: ['2.9.1']
     job:
@@ -33,7 +33,7 @@ jobs:
 
 - template: 'templates/job_generator.yml'
   parameters:
-    # 2.8, tf 3.10
+    # 2.9, tf; 3.10, py 
     python_versions: ['3.10']
     tf_versions: ['2.9.0']
     job:

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -30,12 +30,3 @@ jobs:
     job:
       steps:
       - template: 'pretrained_model_test.yml'
-
-- template: 'templates/job_generator.yml'
-  parameters:
-    # 2.9, tf; 3.10, py 
-    python_versions: ['3.10']
-    tf_versions: ['2.9.0']
-    job:
-      steps:
-      - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -6,7 +6,7 @@ parameters:
   tf_versions: ['']
   onnx_versions: ['']
   onnx_opsets: ['16', '15', '14', '13', '12', '11', '10', '9']
-  onnx_backends: {onnxruntime: ['1.11.0']}
+  onnx_backends: {onnxruntime: ['1.12.0']}
   job: {}
   run_setup: 'True'
   report_coverage: 'False'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -42,7 +42,12 @@ steps:
 
     if [[ $CI_TF_VERSION == 2.* ]] ;
     then
-      pip install onnxruntime-extensions==0.3.1
+      # onnxruntime-extensions is not supported Python 3.10 so far.
+      # https://github.com/microsoft/onnxruntime-extensions/issues/273
+      if [[ $CI_PYTHON_VERSION != 3.10 ]] ;
+      then
+        pip install onnxruntime-extensions==0.3.1
+      fi
       if [[ $CI_TF_VERSION == 2.3* ]] ;
       then
         pip install tensorflow-text==${CI_TF_VERSION}

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -6,9 +6,11 @@ steps:
     pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized sympy coloredlogs flatbuffers
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME)
 
-    # protobuf release version 4.21.0 has some Python changes which is not compatible with tensorflow so far.
+    # Protobuf 3.20 results in linker errors on Windows in TF.
+    # Protobuf 4.0 is binary incompatible with what C++ TF uses.
+    # https://github.com/tensorflow/tensorflow/blob/c3337c73306b2b859d82fe130912f18e6a1c5c23/tensorflow/tools/pip_package/setup.py#L88
     pip uninstall -y protobuf
-    pip install "protobuf<4.21.0"
+    pip install "protobuf<3.20.0"
 
     # TF < 2.7 reuires numpy <= 1.19, but onnxruntime >= 1.11 requires numpy >= 1.21
     if [[ $CI_TF_VERSION < 2.7 ]] && [[ $CI_ONNX_BACKEND == "onnxruntime" ]] ;
@@ -64,6 +66,10 @@ steps:
       if [[ $CI_TF_VERSION == 2.8* ]] ;
       then
         pip install "tensorflow-text>=2.8,<2.9"
+      fi
+      if [[ $CI_TF_VERSION == 2.9* ]] ;
+        then
+          pip install "tensorflow-text>=2.9,<2.10"
       else
         pip install tensorflow-text
       fi

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -50,7 +50,7 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux', 'windows']
-        python_versions: ['3.9']
+        python_versions: ['3.9', '3.10']
         tf_versions: ['2.8.0']
         onnx_opsets: ['']
         job:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -127,6 +127,28 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
+        # tf 1.13
+        python_versions: ['3.7']
+        tf_versions: ['1.13.1']
+        onnx_opsets: ['9']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        # tf 2.9
+        python_versions: ['3.10']
+        tf_versions: ['2.9.1']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+  
+    - template: 'templates/job_generator.yml'
+      parameters:
         platforms: ['windows']
         tf_versions: ['1.14.0']
         onnx_opsets: ['14']
@@ -163,6 +185,17 @@ stages:
         platforms: ['windows']
         tf_versions: ['2.9.1']
         onnx_opsets: ['15']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        python_versions: ['3.10']
+        platforms: ['windows']
+        tf_versions: ['2.9.1']
+        onnx_opsets: ['16']
         job:
           steps:
           - template: 'unit_test.yml'

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -106,7 +106,7 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         # tf 2.9
-        python_versions: ['3.8']
+        python_versions: ['3.10']
         tf_versions: ['2.9.1']
         onnx_opsets: ['']
         job:
@@ -125,28 +125,6 @@ stages:
           - template: 'unit_test.yml'
         report_coverage: 'True'
 
-    - template: 'templates/job_generator.yml'
-      parameters:
-        # tf 1.13
-        python_versions: ['3.7']
-        tf_versions: ['1.13.1']
-        onnx_opsets: ['9']
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-
-    - template: 'templates/job_generator.yml'
-      parameters:
-        # tf 2.9
-        python_versions: ['3.10']
-        tf_versions: ['2.9.1']
-        onnx_opsets: ['']
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-  
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['windows']

--- a/setup.py
+++ b/setup.py
@@ -97,5 +97,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9']
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10']
 )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3233,6 +3233,8 @@ class BackendTests(Tf2OnnxBackendTestBase):
             y_val = np.array(i / 10, np.float32)
             self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val}, rtol=1e-6, atol=2e-5)
 
+    # https://github.com/microsoft/onnxruntime/issues/12302
+    @skip_onnxruntime_backend("resize op can't work well under Cubic mode with ORT 1.12")
     @check_tf_min_version("2.0", "Results are slightly different in tf1")
     @check_opset_min_version(11, "resize bicubic")
     def test_resize_bicubic(self):


### PR DESCRIPTION
add tests and change docs for python 310.
onnxruntime version must be 1.12.0 in python 3.10.

- resize op can't work well under Cubic mode with ORT 1.12
https://github.com/microsoft/onnxruntime/issues/12302
- Protobuf incompatible issue with TF
https://github.com/tensorflow/tensorflow/blob/c3337c73306b2b859d82fe130912f18e6a1c5c23/tensorflow/tools/pip_package/setup.py#L88
- onnxruntime-extensions is not supported Python 3.10 so far
https://github.com/microsoft/onnxruntime-extensions/issues/273