### PR TITLE
Update Keras related tests to support latest TF version.

### DIFF
--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -57,7 +57,7 @@ jobs:
         NIGHTLY_BUILD_TEST: python run_all_v2.py
 
       Python38-onnx1.11-tf2.8:
-        python.version: '3.8'
+        python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
         UNINSTALL_KERAS:
@@ -115,28 +115,16 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python37-onnx1.11-tf2.5:
-        python.version: '3.7'
+      Python38-tf2.x:
+        python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
         UNINSTALL_KERAS: pip uninstall keras -y
         INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
-        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_ORT: pip install onnxruntime==1.9.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
         INSTALL_NUMPY: pip install numpy==1.19.0
-        NIGHTLY_BUILD_TEST: python run_all_v2.py
-
-      Python38-tf2.8:
-        python.version: '3.8'
-        ONNX_PATH: onnx==1.11.0
-        INSTALL_KERAS: 
-        UNINSTALL_KERAS:
-        INSTALL_TENSORFLOW: pip install tensorflow==2.8.0
-        INSTALL_ORT: pip install onnxruntime==1.11.0
-        INSTALL_KERAS_RESNET: pip install keras-resnet
-        INSTALL_TRANSFORMERS: pip install transformers==3.4.0
-        INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
   steps:

--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -8,18 +8,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python37-onnx1.5:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.5.0
-        INSTALL_KERAS: pip install keras==2.2.4
-        UNINSTALL_KERAS:
-        INSTALL_TENSORFLOW: pip install tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.8.0
-        INSTALL_KERAS_RESNET: pip install keras-resnet
-        INSTALL_TRANSFORMERS:
-        INSTALL_NUMPY:
-        NIGHTLY_BUILD_TEST: python run_all.py --exclude "test_keras_applications_v2.py"
-
       Python37-onnx1.6:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
@@ -44,7 +32,7 @@ jobs:
         INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all.py --exclude "test_keras_applications_v2.py"
 
-      Python37-onnx1.11:
+      Python37-onnx1.11-tf1.15:
         python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS: pip install keras==2.3.1
@@ -56,16 +44,28 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python38-tf2.x:
-        python.version: '3.8'
+      Python37-onnx1.11-tf2.5:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
-        INSTALL_KERAS: 
+        INSTALL_KERAS:
         UNINSTALL_KERAS: pip uninstall keras -y
         INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
         INSTALL_NUMPY: pip install numpy==1.19.0
+        NIGHTLY_BUILD_TEST: python run_all_v2.py
+
+      Python38-onnx1.11-tf2.8:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        INSTALL_KERAS:
+        UNINSTALL_KERAS:
+        INSTALL_TENSORFLOW: pip install tensorflow==2.8.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_KERAS_RESNET: pip install keras-resnet
+        INSTALL_TRANSFORMERS: pip install transformers==3.4.0
+        INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all_v2.py
 
   steps:
@@ -79,17 +79,6 @@ jobs:
     vmImage: 'windows-2019'
   strategy:
     matrix:
-      Python37-onnx1.5:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.5.0
-        INSTALL_KERAS: pip install keras==2.2.4
-        UNINSTALL_KERAS:
-        INSTALL_TENSORFLOW: pip install tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.8.0
-        INSTALL_KERAS_RESNET: pip install keras-resnet
-        INSTALL_TRANSFORMERS:
-        NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
-
       Python37-onnx1.6:
         python.version: '3.7'
         ONNX_PATH: onnx==1.6.0
@@ -114,7 +103,7 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python37-onnx1.11:
+      Python37-onnx1.11-tf1.15:
         python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS: pip install keras==2.3.1
@@ -126,16 +115,28 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python38-tf2.x:
-        python.version: '3.8'
+      Python37-onnx1.11-tf2.5:
+        python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
-        INSTALL_KERAS: 
+        INSTALL_KERAS:
         UNINSTALL_KERAS: pip uninstall keras -y
         INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
         INSTALL_NUMPY: pip install numpy==1.19.0
+        NIGHTLY_BUILD_TEST: python run_all_v2.py
+
+      Python38-tf2.8:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        INSTALL_KERAS: 
+        UNINSTALL_KERAS:
+        INSTALL_TENSORFLOW: pip install tensorflow==2.8.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_KERAS_RESNET: pip install keras-resnet
+        INSTALL_TRANSFORMERS: pip install transformers==3.4.0
+        INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
   steps:

--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -16,13 +16,6 @@ jobs:
         INSTALL_ORT: pip install onnxruntime==1.9.0
         INSTALL_NUMPY: pip install numpy==1.19.0
 
-      Python37-tf2.1:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.11.0
-        TENSORFLOW_PATH: tensorflow-cpu==2.1.0
-        INSTALL_ORT: pip install onnxruntime==1.11.0
-        INSTALL_NUMPY: pip install numpy==1.19.0
-
       Python38-tf2.2:
         python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
@@ -44,14 +37,14 @@ jobs:
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
 
-      ############ Pure Keras Unit Tests ############
-      Keras-Py37-tf1.15.0:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.10.2
-        KERAS: keras==2.2.5
-        TENSORFLOW_PATH: tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+      Python38-tf2.8:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        TENSORFLOW_PATH: tensorflow-cpu==2.8.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_NUMPY:
 
+      ############ Pure Keras Unit Tests ############
       Keras-Py37-tf1.15.0:
         python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
@@ -94,13 +87,6 @@ jobs:
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
 
-      Python37-tf2.1:
-        python.version: '3.7'
-        ONNX_PATH: onnx==1.11.0
-        TENSORFLOW_PATH: tensorflow-cpu==2.1.0
-        INSTALL_ORT: pip install onnxruntime==1.11.0
-        INSTALL_NUMPY: pip install numpy==1.19.0
-
       Python37-tf2.2:
         python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
@@ -121,6 +107,13 @@ jobs:
         TENSORFLOW_PATH: tensorflow-cpu==2.5.0
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
+
+      Python37-tf2.8:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        TENSORFLOW_PATH: tensorflow-cpu==2.8.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_NUMPY:
 
       ############ Pure Keras Unit Tests ############
       Keras-Py37-tf1.15.0:

--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -86,6 +86,7 @@ jobs:
         ONNX_PATH: onnx==1.10.2
         TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_NUMPY: pip install numpy==1.19.0
 
       Python37-tf2.2:
         python.version: '3.7'

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -69,7 +69,7 @@ steps:
 
   - script: |
       call activate py$(python.version)
-      python -m pip install --upgrade pip numpy==1.19
+      python -m pip install --upgrade pip numpy
       echo Test numpy installation... && python -c "import numpy"
       pip install %ONNX_PATH%
       pip uninstall -y protobuf

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
@@ -10,26 +10,26 @@ jobs:
     matrix:
       Python37-onnx1.10:
         python.version: '3.7'
-        ONNX_PATH: onnx==1.10.2
+        ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS: pip install keras==2.2.4
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all.py --exclude "test_keras_applications_v2.py"
 
-      Python38-tf2:
+      Python38-tf2.x:
         python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
-        UNINSTALL_KERAS: pip uninstall keras -y
-        INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
+        UNINSTALL_KERAS:
+        INSTALL_TENSORFLOW: pip install tensorflow==2.9.0
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
-        INSTALL_NUMPY: pip install numpy==1.19.0
+        INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all_v2.py
 
   steps:

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -11,17 +11,17 @@ jobs:
       ############ TF Keras Unit Tests ############
       Python37-tf1.15:
         python.version: '3.7'
-        ONNX_PATH: onnx==1.10.2
-        TENSORFLOW_PATH: tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
-        INSTALL_NUMPY: pip install numpy==1.19.0
-
-      Python38-tf2.5:
-        python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
-        TENSORFLOW_PATH: tensorflow-cpu==2.5.0
+        TENSORFLOW_PATH: tensorflow==1.15.0
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
+
+      Python38-tf2.9:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        TENSORFLOW_PATH: tensorflow-cpu==2.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_NUMPY:
 
       ############ Pure Keras Unit Tests ############
       Keras-Py37-tf1.15.0:
@@ -41,6 +41,13 @@ jobs:
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
 
+      Keras-Py38-tf2.9.0:
+        python.version: '3.8'
+        ONNX_PATH: -i onnx==1.11.0
+        TENSORFLOW_PATH: tensorflow==2.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_NUMPY:
+
   steps:
   - template: 'templates/keras2onnx_unit_test.yml'
     parameters:
@@ -54,9 +61,9 @@ jobs:
       ############ TF Keras Unit Tests ############
       Python37-tf-1.15:
         python.version: '3.7'
-        ONNX_PATH: onnx==1.10.2
+        ONNX_PATH: onnx==1.11.0
         TENSORFLOW_PATH: tensorflow==1.15.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
 
       Python37-tf2.3:
@@ -65,6 +72,13 @@ jobs:
         TENSORFLOW_PATH: tensorflow-cpu==2.3.0
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_NUMPY: pip install numpy==1.19.0
+
+      Python38-tf2.9:
+        python.version: '3.8'
+        ONNX_PATH: onnx==1.11.0
+        TENSORFLOW_PATH: tensorflow-cpu==2.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_NUMPY:
 
       ############ Pure Keras Unit Tests ############
       Keras-Py37-tf2.2.0:

--- a/tests/keras2onnx_unit_tests/mock_keras2onnx/proto/__init__.py
+++ b/tests/keras2onnx_unit_tests/mock_keras2onnx/proto/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 import tensorflow
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 # Rather than using ONNX protobuf definition throughout our codebase, we import ONNX protobuf definition here so that
 # we can conduct quick fixes by overwriting ONNX functions without changing any lines elsewhere.
@@ -22,11 +22,15 @@ _check_onnx_version()
 
 
 def is_tensorflow_older_than(version_str):
-    return StrictVersion(tensorflow.__version__.split('-')[0]) < StrictVersion(version_str)
+    return Version(tensorflow.__version__.split('-')[0]) < Version(version_str)
 
 
 def is_tensorflow_later_than(version_str):
-    return StrictVersion(tensorflow.__version__.split('-')[0]) > StrictVersion(version_str)
+    return Version(tensorflow.__version__.split('-')[0]) > Version(version_str)
+
+
+def python_keras_is_deprecated():
+    return is_tensorflow_later_than("2.5.0")
 
 
 is_tf_keras = False
@@ -38,7 +42,10 @@ else:
     is_tf_keras = str_tk_keras != '0'
 
 if is_tf_keras:
-    from tensorflow.python import keras
+    if python_keras_is_deprecated():
+        from tensorflow import keras
+    else:
+        from tensorflow.python import keras
 else:
     try:
         import keras
@@ -47,12 +54,15 @@ else:
             is_tf_keras = True
     except ImportError:
         is_tf_keras = True
-        from tensorflow.python import keras
+        if python_keras_is_deprecated():
+            from tensorflow import keras
+        else:
+            from tensorflow.python import keras
 
 
 def is_keras_older_than(version_str):
-    return StrictVersion(keras.__version__.split('-')[0]) < StrictVersion(version_str)
+    return Version(keras.__version__.split('-')[0]) < Version(version_str)
 
 
 def is_keras_later_than(version_str):
-    return StrictVersion(keras.__version__.split('-')[0]) > StrictVersion(version_str)
+    return Version(keras.__version__.split('-')[0]) > Version(version_str)

--- a/tests/keras2onnx_unit_tests/test_layers.py
+++ b/tests/keras2onnx_unit_tests/test_layers.py
@@ -6,13 +6,18 @@ from tf2onnx.keras2onnx_api import get_maximum_opset_supported
 from mock_keras2onnx.proto.tfcompat import is_tf2, tensorflow as tf
 from mock_keras2onnx.proto import (keras, is_tf_keras,
                                    is_tensorflow_older_than, is_tensorflow_later_than,
-                                   is_keras_older_than, is_keras_later_than)
+                                   is_keras_older_than, is_keras_later_than, python_keras_is_deprecated)
 from test_utils import no_loops_in_tf2, all_recurrents_should_bidirectional
 
 K = keras.backend
 Activation = keras.layers.Activation
 Add = keras.layers.Add
-advanced_activations = keras.layers.advanced_activations
+if python_keras_is_deprecated():
+    advanced_activations = keras.layers
+    layers_core = keras.layers
+else:
+    advanced_activations = keras.layers.advanced_activations
+    layers_core = keras.layers.core
 AlphaDropout = keras.layers.AlphaDropout
 Average = keras.layers.Average
 AveragePooling1D = keras.layers.AveragePooling1D
@@ -72,7 +77,7 @@ GRU_CLASSES = [(GRU, "v1")]
 LSTM_CLASSES = [(LSTM, LSTMCell, "v1")]
 RNN_CLASSES = [SimpleRNN, GRU, LSTM]
 
-if is_tf_keras and is_tensorflow_later_than("1.14.0"):
+if is_tf_keras and is_tensorflow_later_than("1.14.0") and not python_keras_is_deprecated():
     # Add the TF v2 compatability layers (available after TF 1.14)
     from tensorflow.python.keras.layers import recurrent_v2
     GRU_CLASSES.append((recurrent_v2.GRU, "v2"))
@@ -1259,7 +1264,7 @@ def test_conv3d_transpose(conv3trans_runner):
 
 def test_flatten(runner):
     model = keras.Sequential()
-    model.add(keras.layers.core.Flatten(input_shape=(3, 2)))
+    model.add(layers_core.Flatten(input_shape=(3, 2)))
     model.add(Dense(3))
     onnx_model = convert_keras(model, model.name)
 
@@ -1303,7 +1308,7 @@ def test_flatten2(runner):
 
 def test_reshape(runner):
     model = keras.Sequential()
-    model.add(keras.layers.core.Reshape((2, 3), input_shape=(3, 2)))
+    model.add(layers_core.Reshape((2, 3), input_shape=(3, 2)))
     onnx_model = convert_keras(model, model.name)
 
     data = np.array([[[1, 2], [3, 4], [5, 6]]]).astype(np.float32)
@@ -1314,7 +1319,7 @@ def test_reshape(runner):
 
 def test_permute(runner):
     model = keras.Sequential()
-    model.add(keras.layers.core.Permute((2, 1), input_shape=(3, 2)))
+    model.add(layers_core.Permute((2, 1), input_shape=(3, 2)))
     onnx_model = convert_keras(model, model.name)
 
     data = np.array([[[1, 2], [3, 4], [5, 6]]]).astype(np.float32)
@@ -1325,7 +1330,7 @@ def test_permute(runner):
 
 def test_repeat_vector(runner):
     model = keras.Sequential()
-    model.add(keras.layers.core.RepeatVector(3, input_shape=(4,)))
+    model.add(layers_core.RepeatVector(3, input_shape=(4,)))
     onnx_model = convert_keras(model, model.name)
 
     data = _asarray(1, 2, 3, 4)
@@ -1596,11 +1601,11 @@ def test_crop(misc_conv_runner):
             misc_conv_runner(layer, ishape, opset_)
 
         for data_format_ in ['channels_last', 'channels_first']:
-            ishape = (20, 20, 1)
+            ishape = (20, 20, 10)
             for crop_v in [2, (2, 2), ((1, 2), (2, 3))]:
                 layer = Cropping2D(cropping=crop_v, data_format=data_format_)
                 misc_conv_runner(layer, ishape, opset_)
-            ishape = (20, 20, 20, 1)
+            ishape = (20, 20, 20, 10)
             for crop_v in [2, (2, 3, 4), ((1, 2), (2, 3), (3, 5))]:
                 layer = Cropping3D(cropping=crop_v, data_format=data_format_)
                 misc_conv_runner(layer, ishape, opset_)


### PR DESCRIPTION
Since TF 2.6.0, tensorflow.python.keras namespace will be retired. Some modules and functions are valid after that. So we make some changes to make the test code supports all of TF versions, no matter they are older than 2.6.0, or later than 2.6.0.


Signed-off-by: Jay Zhang <jiz@microsoft.com>