### PR TITLE
Fix a test issue in keras2onnx_application_tests.yml.

### DIFF
--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -115,16 +115,16 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python38-onnx1.11-tf2.5:
+      Python38-onnx1.11-tf2.9:
         python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
-        UNINSTALL_KERAS: pip uninstall keras -y
-        INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
+        UNINSTALL_KERAS:
+        INSTALL_TENSORFLOW: pip install tensorflow==2.9.0
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
-        INSTALL_NUMPY: pip install numpy==1.19.0
+        INSTALL_NUMPY:
         NIGHTLY_BUILD_TEST: python run_all_v2.py
 
   steps:

--- a/ci_build/azure_pipelines/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/keras2onnx_application_tests.yml
@@ -56,7 +56,7 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py
 
-      Python38-onnx1.11-tf2.8:
+      Python37-onnx1.11-tf2.8:
         python.version: '3.7'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
@@ -115,17 +115,17 @@ jobs:
         INSTALL_NUMPY: pip install numpy==1.19.0
         NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
 
-      Python38-tf2.x:
+      Python38-onnx1.11-tf2.5:
         python.version: '3.8'
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
         UNINSTALL_KERAS: pip uninstall keras -y
         INSTALL_TENSORFLOW: pip install tensorflow==2.5.0
-        INSTALL_ORT: pip install onnxruntime==1.9.0
+        INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0
         INSTALL_NUMPY: pip install numpy==1.19.0
-        NIGHTLY_BUILD_TEST: python run_all_v2.py --exclude "test_keras_applications_v2.py"
+        NIGHTLY_BUILD_TEST: python run_all_v2.py
 
   steps:
   - template: 'templates/keras2onnx_application_tests.yml'


### PR DESCRIPTION
This is an extension of PR #1980 to enable keras CI pipeline to support tf version > 2.6.0.

Fix #1912 

Signed-off-by: Jay Zhang <jiz@microsoft.com>