### PR TITLE
Fix transpose split optimize attr when opset >=13

### DIFF
--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -145,7 +145,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((1, -1), (1, 1710), (1710,), [1, 0]),
         ((3, 1, 1, 5, -1), (3, 1, 1, 5, 6), (3, 5, 6), [0, 2, 3, 4, 1]),
     ])
-    @check_opset_max_version(12, "split attribute changed to input in opset 13")
+    @check_opset_max_version(12, "split attribute changed to input since opset 13")
     def test_transpose_with_split_dynamic_shape(self, input_shape, specific_input, output_shape, perm):
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
         node2 = helper.make_node("Split", ["Y"], ["Z"], axis=1, split=[1], name="split")
@@ -166,7 +166,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 1, 1), (1, 1, 3), (1), [0, 2, 3, 1]),
         ((256, 1, 1), (1, 1, 256), (1), [0, 2, 3, 1])
     ])
-    @check_opset_min_version(13, "split attribute changed to input in opset 13")
+    @check_opset_min_version(13, "split attribute changed to input since opset 13")
     def test_transpose_with_split_opset13(self, input_shape, output_shape, split_val, perm):
         unsqueeze_axes = self._make_onnx_const(np.array([0], dtype=np.int64), "axes1")
         unsqueeze = helper.make_node("Unsqueeze", ["X", "axes1"], ["Y"], name="unsqueeze")
@@ -742,7 +742,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((1, 3, 4, 5), (4, 5, 3), [0, 2, 3, 1], [1, 2, 0]),
         ((1, 3, 4, 5, 6), (4, 5, 6, 3), [0, 2, 3, 4, 1], [1, 2, 3, 0]),
     ])
-    @check_opset_max_version(12, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_max_version(12, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze1(self, input_shape, output_shape, perm, expected_perm):
         # squeeze the first dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -793,7 +793,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((1, 3, 4, 5), (4, 5, 3), [0, 2, 3, 1], [1, 2, 0]),
         ((1, 3, 4, 5, 6), (4, 5, 6, 3), [0, 2, 3, 4, 1], [1, 2, 3, 0]),
     ])
-    @check_opset_min_version(13, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_min_version(13, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze1_13(self, input_shape, output_shape, perm, expected_perm):
         # squeeze the first dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -816,7 +816,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 4, 1, 5), (3, 5, 4), [0, 2, 3, 1], [0, 2, 1]),
         ((3, 4, 1, 5, 6), (3, 5, 6, 4), [0, 2, 3, 4, 1], [0, 2, 3, 1]),
     ])
-    @check_opset_max_version(12, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_max_version(12, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze2(self, input_shape, output_shape, perm, expected_perm):
         # squeeze the second dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -838,7 +838,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 4, 1, 5), (3, 5, 4), [0, 2, 3, 1], [0, 2, 1]),
         ((3, 4, 1, 5, 6), (3, 5, 6, 4), [0, 2, 3, 4, 1], [0, 2, 3, 1]),
     ])
-    @check_opset_min_version(13, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_min_version(13, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze2_13(self, input_shape, output_shape, perm, expected_perm):
         # squeeze the second dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -861,7 +861,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 1, 4, 5), (3, 4, 5), [0, 2, 3, 1]),
         ((3, 1, 4, 5, 6), (3, 4, 5, 6), [0, 2, 3, 4, 1]),
     ])
-    @check_opset_max_version(12, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_max_version(12, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze3(self, input_shape, output_shape, perm):
         # squeeze the last dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -882,7 +882,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 1, 4, 5), (3, 4, 5), [0, 2, 3, 1]),
         ((3, 1, 4, 5, 6), (3, 4, 5, 6), [0, 2, 3, 4, 1]),
     ])
-    @check_opset_min_version(13, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_min_version(13, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze3_13(self, input_shape, output_shape, perm):
         # squeeze the last dim
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -904,7 +904,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 1, 1, 5), (3, 5), [0, 2, 3, 1]),
         ((3, 1, 1, 5, 4), (3, 5, 4), [0, 2, 3, 4, 1]),
     ])
-    @check_opset_max_version(12, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_max_version(12, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze4(self, input_shape, output_shape, perm):
         # squeeze the two dims
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -925,7 +925,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((3, 1, 1, 5), (3, 5), [0, 2, 3, 1]),
         ((3, 1, 1, 5, 4), (3, 5, 4), [0, 2, 3, 4, 1]),
     ])
-    @check_opset_min_version(13, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_min_version(13, "Squeeze/Unsqueeze changed since opset 13")
     def test_transpose_with_squeeze4_13(self, input_shape, output_shape, perm):
         # squeeze the two dims
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
@@ -2181,7 +2181,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["res"], {"inp": np.random.randn(6, 12).astype(np.float32)}, model_proto,
                              "Concat", 0)
 
-    @check_opset_max_version(12, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_max_version(12, "Squeeze/Unsqueeze changed since opset 13")
     def test_const_fold_unsqueeze_with_const(self):
         shape = (6, 6)
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
@@ -2201,7 +2201,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["res"], {"X": np.random.randn(1).astype(np.float32)}, model_proto,
                              "Unsqueeze", 0)
 
-    @check_opset_min_version(13, "Squeeze/Unsqueeze changed in opset 13")
+    @check_opset_min_version(13, "Squeeze/Unsqueeze changed since opset 13")
     def test_const_fold_unsqueeze_with_const_13(self):
         shape = (6, 6)
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
@@ -2279,7 +2279,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["out4"], {"inp": np.random.randn(2, 6, 1).astype(np.float32)}, model_proto,
                              "Split", 0)
 
-    @check_opset_min_version(13, "Split changed in opset 13")
+    @check_opset_min_version(13, "Split changed since opset 13")
     def test_const_fold_split_const_splits_13(self):
         shape = (2, 6, 1)
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
@@ -2302,7 +2302,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_and_compare(["out4"], {"inp": np.random.randn(2, 3, 1).astype(np.float32)}, model_proto,
                              "Split", 0)
 
-    @check_opset_max_version(12, "Split changed in opset 13")
+    @check_opset_max_version(12, "Split changed since opset 13")
     def test_const_fold_split_const_splits(self):
         shape = (2, 6, 1)
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -671,11 +671,19 @@ class TransposeOptimizer(GraphOptimizerBase):
 
     def _split_handler(self, trans, node):
         # Todo: need handle cases where Split node has more than 1 outputs.
+        split = None
+        if len(node.input) > 1 and node.inputs[1].is_const():
+            split = node.inputs[1].get_tensor_value(as_list=True)
         if self._handle_node_having_branches(trans, node):
             perm = trans.get_attr_value("perm")
             axis = node.get_attr_value("axis", 0)
             new_axis = perm[axis]
             node.set_attr("axis", new_axis)
+            if self._g.opset >= 13 and split:
+                # in opset 13, split attr is an input not attr
+                new_axes_np = np.array(split, dtype=np.int64)
+                new_axes_const = self._g.make_const(utils.make_name(node.inputs[1].name), new_axes_np)
+                self._g.replace_inputs(node, [node.input[0], new_axes_const.output[0]])
             return True
         return False
 
@@ -747,7 +755,7 @@ class TransposeOptimizer(GraphOptimizerBase):
             shape_after_trans = [input_shape[i] for i in ori_perm]
             output_shape = [shape_after_trans[i] for i in range(n) if i not in ori_squeeze_axes]
             # calculate new_perm
-            # after switch, the output shape should be same, using this condtion we can figure the new perm
+            # after switch, the output shape should be same, using this condition we can figure the new perm
             shape_after_squeeze = [input_shape[i] for i in range(n) if i not in new_squeeze_axes]
             new_perm = [shape_after_squeeze.index(i) for i in output_shape]
 


### PR DESCRIPTION
split is an optional input not attr since opset 13.
transpose optimizer should adapt to ONNX version >= 13 simultaneously.

fixes https://github.com/onnx/tensorflow-onnx/issues/1941