### PR TITLE
Skip existing const node in _parse_graph_input

### DIFF
--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1902,7 +1902,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
         self.run_merge_duplicated_nodes_compare(["OUT"], {}, model_proto, op_type="Constant", remaining_op_num=0,
-                                                graph_validator=lambda g: self._check_initializer_num(g, 2))
+                                                graph_validator=lambda g: self._check_initializer_num(g, 1))
 
     def test_duplicated_node_is_graph_output(self):
         node0 = helper.make_node('Add', inputs=["X", "X"], outputs=["value0"])

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -1791,9 +1791,11 @@ class GraphUtil(object):
         # because for subgraphs, the input orders matter.
         for graph_input in graph_proto.input:
             name = graph_input.name
-            shape = shapes[name]
-            dtype = dtypes[name]
-            if name not in const_node_names:
-                g.add_graph_input(name, dtype, shape)
-            else:
-                g.add_graph_input_with_default(name, g.get_node_by_name(name), dtype, shape)
+            const_initializer_node = g.get_node_by_output_in_current_graph(name)
+            if const_initializer_node is None: # is actual input rather than initializer
+                shape = shapes[name]
+                dtype = dtypes[name]
+                if name not in const_node_names:
+                    g.add_graph_input(name, dtype, shape)
+                else:
+                    g.add_graph_input_with_default(name, g.get_node_by_name(name), dtype, shape)


### PR DESCRIPTION
If the Graph object being constructed already contains a node of
the name of a Const node in orginal graph, do not add as input.