### PR TITLE
Improve ZerosLike implementation and optimize for opset >= 9

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3887,6 +3887,19 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
         self._run_test_case(func, [_OUTPUT], {_INPUT: input_x > 0.5, _INPUT1: input_y})
 
+    @check_opset_min_version(9, "ConstantOfShape")
+    def test_zeros_like_opset9(self):
+        input_x = np.random.random_sample([3, 16, 16]).astype(np.float32)
+        input_y = np.array([16, 16, 3]).astype(np.int64)
+
+        def func(x, y):
+            z = tf.reshape(x, y)
+            return tf.zeros_like(z, name=_TFOUTPUT)
+
+        self._run_test_case(func, [_OUTPUT], {_INPUT: input_x, _INPUT1: input_y})
+        self._run_test_case(func, [_OUTPUT], {_INPUT: input_x.astype(np.int32), _INPUT1: input_y}, as_session=True,
+                                graph_validator=lambda g: check_op_count(g, "ConstantOfShape", 1, disabled=False))
+
     @check_opset_min_version(9, "is_nan")
     def test_isnan(self):
         # only compatible with dtype `float32`

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3898,7 +3898,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
         self._run_test_case(func, [_OUTPUT], {_INPUT: input_x, _INPUT1: input_y})
         self._run_test_case(func, [_OUTPUT], {_INPUT: input_x.astype(np.int32), _INPUT1: input_y}, as_session=True,
-                                graph_validator=lambda g: check_op_count(g, "ConstantOfShape", 1, disabled=False))
+                            graph_validator=lambda g: check_op_count(g, "ConstantOfShape", 1, disabled=False))
 
     @check_opset_min_version(9, "is_nan")
     def test_isnan(self):

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1927,7 +1927,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
         self.run_merge_duplicated_nodes_compare(["OUT"], {}, model_proto, op_type="Constant", remaining_op_num=0,
-                                                graph_validator=lambda g: self._check_initializer_num(g, 2))
+                                                graph_validator=lambda g: self._check_initializer_num(g, 3))
 
     def test_duplicated_node_is_graph_output(self):
         node0 = helper.make_node('Add', inputs=["X", "X"], outputs=["value0"])
@@ -2240,6 +2240,72 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         model_proto = self.make_model(graph, producer_name="onnx-tests")
         self.run_and_compare(["res"], {"X": np.random.randn(*shape).astype(np.int64)}, model_proto,
                              "Cast", 0)
+
+    def test_const_fold_add(self):
+        shape = (6, 6)
+        const_tensor1 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        const_tensor2 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        node1 = helper.make_node("Constant", [], ["const1"], value=const_tensor1)
+        node2 = helper.make_node("Constant", [], ["const2"], value=const_tensor2)
+        node3 = helper.make_node("Add", ["const1", "const2"], ["add"])
+        node4 = helper.make_node("Add", ["add", "X"], ["res"])
+
+        graph = helper.make_graph(
+            [node1, node2, node3, node4],
+            "test_const_fold_add",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)],
+            [helper.make_tensor_value_info("res", TensorProto.FLOAT, shape)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_and_compare(["res"], {"X": np.random.randn(*shape).astype(np.float32)}, model_proto,
+                             "Add", 1)
+
+    def test_const_fold_sub(self):
+        shape = (6, 6)
+        const_tensor1 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        const_tensor2 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        node1 = helper.make_node("Constant", [], ["const1"], value=const_tensor1)
+        node2 = helper.make_node("Constant", [], ["const2"], value=const_tensor2)
+        node3 = helper.make_node("Sub", ["const1", "const2"], ["sub"])
+        node4 = helper.make_node("Sub", ["sub", "X"], ["res"])
+
+        graph = helper.make_graph(
+            [node1, node2, node3, node4],
+            "test_const_fold_sub",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)],
+            [helper.make_tensor_value_info("res", TensorProto.FLOAT, shape)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_and_compare(["res"], {"X": np.random.randn(*shape).astype(np.float32)}, model_proto,
+                             "Sub", 1)
+
+    def test_const_fold_mul(self):
+        shape = (6, 6)
+        const_tensor1 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        const_tensor2 = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
+                                           vals=np.random.randn(*shape).flatten().astype(np.float32))
+        node1 = helper.make_node("Constant", [], ["const1"], value=const_tensor1)
+        node2 = helper.make_node("Constant", [], ["const2"], value=const_tensor2)
+        node3 = helper.make_node("Mul", ["const1", "const2"], ["mul"])
+        node4 = helper.make_node("Mul", ["mul", "X"], ["res"])
+
+        graph = helper.make_graph(
+            [node1, node2, node3, node4],
+            "test_const_fold_mul",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, shape)],
+            [helper.make_tensor_value_info("res", TensorProto.FLOAT, shape)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_and_compare(["res"], {"X": np.random.randn(*shape).astype(np.float32)}, model_proto,
+                             "Mul", 1)
 
     def test_const_fold_split(self):
         shape = (2, 6, 1)

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -253,6 +253,7 @@ class ZerosLike:
                       name=node.name, outputs=node.output,
                       dtypes=dtypes)
 
+
 @tf_op(["IteratorV2", "FIFOQueueV2"])
 class Iterator:
     @classmethod

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -8,7 +8,7 @@ generator
 import logging
 
 import numpy as np
-from onnx import onnx_pb, numpy_helper
+from onnx import onnx_pb, numpy_helper, helper
 from tf2onnx import utils
 from tf2onnx.handler import tf_op
 from tf2onnx.graph_builder import GraphBuilder
@@ -242,6 +242,18 @@ class ZerosLike:
                       name=node.name, outputs=node.output,
                       shapes=shapes, dtypes=dtypes)
 
+    @classmethod
+    def version_9(cls, ctx, node, **kwargs):
+        shapes = node.output_dtypes
+        dtypes = node.output_dtypes
+        ctx.remove_node(node.name)
+        shape = ctx.make_node("Shape", node.input).output[0]
+        dtype = ctx.get_dtype(shape)
+        zero_tensor = helper.make_tensor("value", dtypes[0], [1], vals=[0])
+        ctx.make_node("ConstantOfShape", inputs=[shape],
+                              attr={'value': zero_tensor},
+                              name=node.name, outputs=node.output,
+                              dtypes=dtypes)
 
 @tf_op(["IteratorV2", "FIFOQueueV2"])
 class Iterator:

--- a/tf2onnx/onnx_opset/generator.py
+++ b/tf2onnx/onnx_opset/generator.py
@@ -244,16 +244,14 @@ class ZerosLike:
 
     @classmethod
     def version_9(cls, ctx, node, **kwargs):
-        shapes = node.output_dtypes
         dtypes = node.output_dtypes
         ctx.remove_node(node.name)
         shape = ctx.make_node("Shape", node.input).output[0]
-        dtype = ctx.get_dtype(shape)
         zero_tensor = helper.make_tensor("value", dtypes[0], [1], vals=[0])
         ctx.make_node("ConstantOfShape", inputs=[shape],
-                              attr={'value': zero_tensor},
-                              name=node.name, outputs=node.output,
-                              dtypes=dtypes)
+                      attr={'value': zero_tensor},
+                      name=node.name, outputs=node.output,
+                      dtypes=dtypes)
 
 @tf_op(["IteratorV2", "FIFOQueueV2"])
 class Iterator:

--- a/tf2onnx/optimizer/const_fold_optimizer.py
+++ b/tf2onnx/optimizer/const_fold_optimizer.py
@@ -99,33 +99,6 @@ class ConstFoldOptimizer(GraphOptimizerBase):
         graph.remove_node(node.name)
 
     @staticmethod
-    @_register_func("Mul")
-    def _fold_mul(node, graph):
-        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
-        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
-        print("_fold_mul:", const_val1, const_val2)
-        const_val_after_nul = np.multiply(const_val1, const_val2)
-        return [const_val_after_nul]
-
-    @staticmethod
-    @_register_func("Add")
-    def _fold_mul(node, graph):
-        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
-        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
-        print("_fold_add:", const_val1, const_val2)
-        const_val_after_nul = np.add(const_val1, const_val2)
-        return const_val_after_nul
-
-    @staticmethod
-    @_register_func("Sub") 
-    def _fold_mul(node, graph):
-        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
-        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
-        print("_fold_sub:", const_val1, const_val2)
-        const_val_after_nul = np.subtract(const_val1, const_val2)
-        return const_val_after_nul
-
-    @staticmethod
     @_register_func("Cast")
     def _fold_cast(node, graph):
         const_val = node.inputs[0].get_tensor_value(as_list=False)
@@ -188,6 +161,30 @@ class ConstFoldOptimizer(GraphOptimizerBase):
 
         const_val_after_unsqueeze = const_val.reshape(shape_out)
         return [const_val_after_unsqueeze]
+
+    @staticmethod
+    @_register_func("Mul")
+    def _fold_mul(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        const_val_after_nul = np.multiply(const_val1, const_val2)
+        return [const_val_after_nul]
+
+    @staticmethod
+    @_register_func("Add")
+    def _fold_add(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        const_val_after_add = np.add(const_val1, const_val2)
+        return [const_val_after_add]
+
+    @staticmethod
+    @_register_func("Sub")
+    def _fold_sub(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        const_val_after_sub = np.subtract(const_val1, const_val2)
+        return [const_val_after_sub]
 
     @staticmethod
     @_register_func("Split")

--- a/tf2onnx/optimizer/const_fold_optimizer.py
+++ b/tf2onnx/optimizer/const_fold_optimizer.py
@@ -99,6 +99,33 @@ class ConstFoldOptimizer(GraphOptimizerBase):
         graph.remove_node(node.name)
 
     @staticmethod
+    @_register_func("Mul")
+    def _fold_mul(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        print("_fold_mul:", const_val1, const_val2)
+        const_val_after_nul = np.multiply(const_val1, const_val2)
+        return [const_val_after_nul]
+
+    @staticmethod
+    @_register_func("Add")
+    def _fold_mul(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        print("_fold_add:", const_val1, const_val2)
+        const_val_after_nul = np.add(const_val1, const_val2)
+        return const_val_after_nul
+
+    @staticmethod
+    @_register_func("Sub") 
+    def _fold_mul(node, graph):
+        const_val1 = node.inputs[0].get_tensor_value(as_list=False)
+        const_val2 = node.inputs[1].get_tensor_value(as_list=False)
+        print("_fold_sub:", const_val1, const_val2)
+        const_val_after_nul = np.subtract(const_val1, const_val2)
+        return const_val_after_nul
+
+    @staticmethod
     @_register_func("Cast")
     def _fold_cast(node, graph):
         const_val = node.inputs[0].get_tensor_value(as_list=False)


### PR DESCRIPTION
Replace `cast + mul(value 0) + cast` to `shape + ConstantShape(value 0)` when opset >= 9 [ConstantShape](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#ConstantOfShape-9), which can get a better inference performance.

fixes https://github.com/onnx/tensorflow-onnx/issues/1997