### PR TITLE
Add more tests for tf 2.9.x into CI pipelines.

### DIFF
--- a/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
+++ b/ci_build/azure_pipelines/onnxruntime_nightly_test.yml
@@ -20,7 +20,7 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.7']
-        tf_versions: ['1.13.1', '1.14.0']
+        tf_versions: ['1.14.0']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:
@@ -43,8 +43,8 @@ stages:
     - template: 'templates/job_generator.yml'
       parameters:
         platforms: ['linux']
-        python_versions: ['3.7']
-        tf_versions: ['2.4.1']
+        python_versions: ['3.9']
+        tf_versions: ['2.9.1']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:
@@ -57,6 +57,18 @@ stages:
         platforms: ['linux']
         python_versions: ['3.9']
         tf_versions: ['2.8.0']
+        onnx_opsets: ['']
+        onnx_backends: {onnxruntime: ['nightly']}
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        platforms: ['linux']
+        python_versions: ['3.8']
+        tf_versions: ['2.7.3']
         onnx_opsets: ['']
         onnx_backends: {onnxruntime: ['nightly']}
         job:

--- a/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test-matrix.yml
@@ -5,7 +5,7 @@ jobs:
   parameters:
     platforms: ['linux', 'windows']
     python_versions: ['3.7']
-    tf_versions: ['1.13.1', '1.14.0']
+    tf_versions: ['1.14.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'
@@ -42,6 +42,15 @@ jobs:
     platforms: ['linux', 'windows']
     python_versions: ['3.8']
     tf_versions: ['2.8.0']
+    job:
+      steps:
+      - template: 'pretrained_model_test.yml'
+
+- template: 'templates/job_generator.yml'
+  parameters:
+    platforms: ['linux', 'windows']
+    python_versions: ['3.9']
+    tf_versions: ['2.9.1']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/pretrained_model_test.yml
+++ b/ci_build/azure_pipelines/pretrained_model_test.yml
@@ -17,7 +17,7 @@ jobs:
   parameters:
     # 2.7, tf
     python_versions: ['3.7']
-    tf_versions: ['1.15.5','2.7.0']
+    tf_versions: ['1.15.5','2.8.0']
     job:
       steps:
       - template: 'pretrained_model_test.yml'
@@ -26,7 +26,7 @@ jobs:
   parameters:
     # 2.8, tf
     python_versions: ['3.9']
-    tf_versions: ['2.8.0']
+    tf_versions: ['2.9.1']
     job:
       steps:
       - template: 'pretrained_model_test.yml'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -34,7 +34,7 @@ steps:
 
     if [[ $CI_SKIP_TFJS_TESTS == "False" ]] ;
     then
-      pip install tensorflowjs
+      pip install tensorflowjs==3.18.0
       npm install @tensorflow/tfjs
     fi
 

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -64,6 +64,8 @@ steps:
       if [[ $CI_TF_VERSION == 2.8* ]] ;
       then
         pip install "tensorflow-text>=2.8,<2.9"
+      else
+        pip install tensorflow-text
       fi
     fi
 

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
@@ -25,7 +25,7 @@ jobs:
         ONNX_PATH: onnx==1.11.0
         INSTALL_KERAS:
         UNINSTALL_KERAS:
-        INSTALL_TENSORFLOW: pip install tensorflow==2.9.0
+        INSTALL_TENSORFLOW: pip install tensorflow==2.9.1
         INSTALL_ORT: pip install onnxruntime==1.11.0
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==3.4.0

--- a/ci_build/azure_pipelines/unit_test-matrix.yml
+++ b/ci_build/azure_pipelines/unit_test-matrix.yml
@@ -7,17 +7,6 @@ stages:
       parameters:
         platforms: ['linux', 'windows']
         python_versions: ['3.7']
-        tf_versions: ['1.13.1']
-        onnx_opsets: ['']
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-    
-    - template: 'templates/job_generator.yml'
-      parameters:
-        platforms: ['linux', 'windows']
-        python_versions: ['3.7']
         tf_versions: ['1.14.0']
         onnx_opsets: ['']
         job:
@@ -63,6 +52,17 @@ stages:
         platforms: ['linux', 'windows']
         python_versions: ['3.9']
         tf_versions: ['2.8.0']
+        onnx_opsets: ['']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        platforms: ['linux', 'windows']
+        python_versions: ['3.9']
+        tf_versions: ['2.9.0']
         onnx_opsets: ['']
         job:
           steps:

--- a/ci_build/azure_pipelines/unit_test.yml
+++ b/ci_build/azure_pipelines/unit_test.yml
@@ -79,9 +79,9 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
-        # TFJS tf 2.6
+        # TFJS tf 2.9
         python_versions: ['3.9']
-        tf_versions: ['2.6.2']
+        tf_versions: ['2.9.1']
         onnx_opsets: ['']
         skip_tfjs_tests: 'False'
         skip_tf_tests: 'True'
@@ -92,9 +92,9 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
-        # TFLite tf 2.6
+        # TFLite tf 2.9
         python_versions: ['3.8']
-        tf_versions: ['2.6.2']
+        tf_versions: ['2.9.1']
         onnx_opsets: ['']
         skip_tflite_tests: 'False'
         skip_tf_tests: 'True'
@@ -105,9 +105,9 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
-        # tf 2.6
+        # tf 2.9
         python_versions: ['3.8']
-        tf_versions: ['2.6.2']
+        tf_versions: ['2.9.1']
         onnx_opsets: ['']
         job:
           steps:
@@ -120,17 +120,6 @@ stages:
         python_versions: ['3.7']
         tf_versions: ['1.15.2','2.5.0']
         onnx_opsets: ['']
-        job:
-          steps:
-          - template: 'unit_test.yml'
-        report_coverage: 'True'
-
-    - template: 'templates/job_generator.yml'
-      parameters:
-        # tf 1.13
-        python_versions: [3.7']
-        tf_versions: ['1.13.1']
-        onnx_opsets: ['9']
         job:
           steps:
           - template: 'unit_test.yml'
@@ -159,9 +148,20 @@ stages:
 
     - template: 'templates/job_generator.yml'
       parameters:
-        python_versions: ['3.9']
+        python_versions: ['3.8']
         platforms: ['windows']
         tf_versions: ['2.8.1']
+        onnx_opsets: ['15']
+        job:
+          steps:
+          - template: 'unit_test.yml'
+        report_coverage: 'True'
+
+    - template: 'templates/job_generator.yml'
+      parameters:
+        python_versions: ['3.9']
+        platforms: ['windows']
+        tf_versions: ['2.9.1']
         onnx_opsets: ['15']
         job:
           steps:


### PR DESCRIPTION
Update both PR CI jobs and nightly CI jobs to add tests to cover tensorflow latest 2.9.x version.