### PR TITLE
Add newly required dependencies for latest ORT version.

### DIFF
--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -3,7 +3,7 @@
 steps:
 - bash: |
     set -ex
-    pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized
+    pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized sympy coloredlogs flatbuffers
     pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME)
 
     # protobuf release version 4.21.0 has some Python changes which is not compatible with tensorflow so far.


### PR DESCRIPTION
The latest ORT night build needs some new dependencies, so install them manually in test scripts.

Fix: #2011 

Signed-off-by: Jay Zhang <jiz@microsoft.com>