### PR TITLE
Update the url to install ORT nightly job.

### DIFF
--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -31,7 +31,7 @@ steps:
       pip uninstall -y onnxruntime
       # install numpy upfront since it is not on https://test.pypi.org/simple/
       pip install 'numpy>=1.18'
-      pip install --index-url https://test.pypi.org/simple/ ort-nightly
+      pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly
     fi
 
     if [[ $CI_SKIP_TFJS_TESTS == "False" ]] ;


### PR DESCRIPTION
Considering the security and file size limitation, ORT team has moved the nightly job into ADO Artifacts, so change the installation URL accordingly.

Signed-off-by: Jay Zhang <jiz@microsoft.com>