### PR TITLE
Add masked LSTM support

### DIFF
--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -793,5 +793,164 @@ class LSTMTests(Tf2OnnxBackendTestBase):
             return tf.identity(y[0], name="output")
         self.run_test_case(func, {"input:0": x_val}, [], ["output:0"], rtol=1e-05, atol=1e-06)
 
+    @check_tf_min_version("2.0")
+    @skip_tf_versions("2.1", "Bug in TF 2.1")
+    def test_keras_masked_lstm_embedding_unidirectional(self):
+        for go_backwards in [True, False]:
+            timesteps = 4
+            # Note: masked LSTM only support post-padded input after conversion
+            # test case sequence_lens = [4, 2, 0]
+            x_val = np.array([
+                [1, 2, 3, 4],
+                [5, 6, 0, 0],
+                [0, 0, 0, 0]
+            ], dtype=np.int32)
+
+            model_in = tf.keras.layers.Input((timesteps,), dtype="int32")
+            x_embedding = tf.keras.layers.Embedding(
+                input_dim=10,
+                output_dim=5,
+                mask_zero=True,
+                embeddings_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=41),
+            )(model_in)
+
+            # RNN layer inherits the mask propagated from above embedding layer
+            model_out = tf.keras.layers.LSTM(
+                units=5,
+                go_backwards=go_backwards,
+                return_state=True,
+                kernel_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=42),
+                bias_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=43),
+                recurrent_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=44),
+            )(x_embedding)
+            model = tf.keras.models.Model(inputs=model_in, outputs=model_out)
+
+            def func(x):
+                y = model(x)
+                # skiping output Y: https://github.com/microsoft/onnxruntime/issues/12492
+                return(tf.identity(y[1], name="output_yh"),
+                       tf.identity(y[2], name="output_yc"))
+
+            output_list = ["output_yh:0", "output_yc:0"]
+            self.run_test_case(func, {"input:0": x_val}, [], output_list, rtol=1e-05, atol=1e-06)
+
+    @check_tf_min_version("2.0")
+    @skip_tf_versions("2.1", "Bug in TF 2.1")
+    def test_keras_masked_lstm_embedding_bidirectional(self):
+        timesteps = 4
+        # Note: masked LSTM only support post-padded input after conversion
+        # test case sequence_lens = [4, 2, 0]
+        x_val = np.array([
+            [1, 2, 3, 4],
+            [5, 6, 0, 0],
+            [0, 0, 0, 0]
+        ], dtype=np.int32)
+
+        model_in = tf.keras.layers.Input((timesteps,), dtype="int32")
+        x_embedding = tf.keras.layers.Embedding(
+            input_dim=10,
+            output_dim=5,
+            mask_zero=True,
+            embeddings_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=41),
+        )(model_in)
+
+        # RNN layer inherits the mask propagated from above embedding layer
+        lstm_layer = tf.keras.layers.LSTM(
+            units=5,
+            go_backwards=False,
+            return_state=True,
+            kernel_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=42),
+            bias_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=43),
+            recurrent_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=44),
+        )
+        model_out = tf.keras.layers.Bidirectional(lstm_layer)(x_embedding)
+        model = tf.keras.models.Model(inputs=model_in, outputs=model_out)
+
+        def func(x):
+            y = model(x)
+            # skiping output Y: https://github.com/microsoft/onnxruntime/issues/12492
+            return(tf.identity(y[1], name="output_yh_f"),
+                   tf.identity(y[2], name="output_yc_f"),
+                   tf.identity(y[3], name="output_yh_r"),
+                   tf.identity(y[4], name="output_yc_r"))
+
+        output_list = ["output_yh_f:0", "output_yc_f:0", "output_yh_r:0", "output_yc_r:0"]
+        self.run_test_case(func, {"input:0": x_val}, [], output_list, rtol=1e-05, atol=1e-06,
+                           require_lstm_count=2)
+
+    @check_tf_min_version("2.0")
+    @skip_tf_versions("2.1", "Bug in TF 2.1")
+    def test_keras_masked_lstm_unidirectional(self):
+        for go_backwards in [True, False]:
+            batch_size, timesteps, feat = 3, 4, 5
+            in_shape = (timesteps, feat)
+            x_val = np.random.uniform(size=[batch_size, timesteps, feat]).astype(np.float32)
+            # Note: masked LSTM only support post-padded input after conversion
+            # test case sequence_lens = [4, 2, 0]
+            x_val[1, 2:, :] = 0.
+            x_val[2, :, :] = 0.
+
+            model_in = tf.keras.layers.Input(shape=in_shape, dtype="float32")
+            x_masked = tf.keras.layers.Masking(mask_value=0.)(model_in)
+
+            # RNN layer inherits the mask propagated from above mask layer
+            model_out = tf.keras.layers.LSTM(
+                units=5,
+                go_backwards=go_backwards,
+                return_state=True,
+                kernel_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=42),
+                bias_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=43),
+                recurrent_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=44),
+            )(x_masked)
+            model = tf.keras.models.Model(inputs=model_in, outputs=model_out)
+
+            def func(x):
+                y = model(x)
+                # skiping output Y: https://github.com/microsoft/onnxruntime/issues/12492
+                return(tf.identity(y[1], name="output_yh"),
+                       tf.identity(y[2], name="output_yc"))
+
+            output_list = ["output_yh:0", "output_yc:0"]
+            self.run_test_case(func, {"input:0": x_val}, [], output_list, rtol=1e-05, atol=1e-06)
+
+    @check_tf_min_version("2.0")
+    @skip_tf_versions("2.1", "Bug in TF 2.1")
+    def test_keras_masked_lstm_bidirectional(self):
+        batch_size, timesteps, feat = 3, 4, 5
+        in_shape = (timesteps, feat)
+        x_val = np.random.uniform(size=[batch_size, timesteps, feat]).astype(np.float32)
+        # Note: masked LSTM only support post-padded input after conversion
+        # test case sequence_lens = [4, 2, 0]
+        x_val[1, 2:, :] = 0.
+        x_val[2, :, :] = 0.
+
+        model_in = tf.keras.layers.Input(shape=in_shape, dtype="float32")
+        x_masked = tf.keras.layers.Masking(mask_value=0.)(model_in)
+
+        # RNN layer inherits the mask propagated from above mask layer
+        lstm_layer = tf.keras.layers.LSTM(
+            units=5,
+            go_backwards=False,
+            return_state=True,
+            kernel_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=42),
+            bias_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=43),
+            recurrent_initializer=tf.random_uniform_initializer(0.0, 1.0, seed=44),
+        )
+        model_out = tf.keras.layers.Bidirectional(lstm_layer)(x_masked)
+        model = tf.keras.models.Model(inputs=model_in, outputs=model_out)
+
+        def func(x):
+            y = model(x)
+            # skiping output Y: https://github.com/microsoft/onnxruntime/issues/12492
+            return (tf.identity(y[1], name="output_yh_f"),
+                    tf.identity(y[2], name="output_yc_f"),
+                    tf.identity(y[3], name="output_yh_r"),
+                    tf.identity(y[4], name="output_yc_r"))
+
+        output_list = ["output_yh_f:0", "output_yc_f:0", "output_yh_r:0", "output_yc_r:0"]
+        self.run_test_case(func, {"input:0": x_val}, [], output_list, rtol=1e-05, atol=1e-06,
+                           require_lstm_count=2)
+
+
 if __name__ == '__main__':
     unittest_main()

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -2260,15 +2260,24 @@ class ReverseV2:
                 const_axis_name = utils.make_name(f'const_{axis}')
                 const_axis = ctx.make_const(name=const_axis_name, np_val=np.array([axis], dtype=np.int64))
 
-                # Add a Constant node (seq_len) for ReverseSequence.
-                # Index 1 for the shape should not return 0, since rank(input) >=2
-                input_shape = ctx.make_node("Shape", [inputs[-1]], op_name_scope=rv2_node_name)
-                batch_size = ctx.make_node("Gather", [input_shape.output[0], const_one.output[0]],
-                                           op_name_scope=rv2_node_name)
-                axis_dim = ctx.make_node("Gather", [input_shape_node.output[0], const_axis.output[0]],
-                                         op_name_scope=rv2_node_name)
-                seq_array = ctx.make_node("Expand", [axis_dim.output[0], batch_size.output[0]])
-                inputs.append(seq_array.output[0])
+                # Add sequence_lens as ReverseSequence input
+                has_sequence_lens = node.get_attr_value("has_sequence_lens", False)
+                if not has_sequence_lens:
+                    # Add a Constant node (seq_len) for ReverseSequence.
+                    # Index 1 for the shape should not return 0, since rank(input) >=2
+                    input_shape = ctx.make_node("Shape", [inputs[-1]], op_name_scope=rv2_node_name)
+                    batch_size = ctx.make_node("Gather", [input_shape.output[0], const_one.output[0]],
+                                               op_name_scope=rv2_node_name)
+                    axis_dim = ctx.make_node("Gather", [input_shape_node.output[0], const_axis.output[0]],
+                                             op_name_scope=rv2_node_name)
+                    seq_array = ctx.make_node("Expand", [axis_dim.output[0], batch_size.output[0]])
+                    inputs.append(seq_array.output[0])
+                else:
+                    # masked backward LSTM:
+                    # sequence_lens is appended to ReverseV2's input by lstm_tf2_rewriter
+                    # to keep tensor post-padded after reverse
+                    seq_lens_casted = ctx.make_node("Cast", [node.input[-1]], attr={'to': TensorProto.INT64}).output[0]
+                    inputs.append(seq_lens_casted)
 
                 # Add a ReverseSequence node.
 


### PR DESCRIPTION
Masking is a intra-layer behavior in TF LSTM [1] but is not a intra-op behavior in ONNX LSTM [2]. When converted to ONNX, masked TF LSTM layer is converted to Loop op. This over-complicates the ONNX model, and has a negative impact on inference performance in ORT without leveraging LSTM optimizations. (issue #1871)

This commit adds support to convert masked LSTM correctly, **under the important assumption that input must be post-padded** - which is the most common use case. The "masking" info is conveyed to ONNX LSTM op as `sequence_lens` which is dynamically computed by summing the number of non-skip timesteps per batch per-LSTM. This behavior is implemented with reference to keras2onnx PR#386 [3]. Additional logic is added for backward LSTM so that the input sequence is reversed correctly given `sequence_lens`.

Note that if mask-enabled, and LSTM input is pre- or randomly padded, the converted ONNX model will behave incorrectly for inference. Unless ONNX add new attribute e.g. `mask_enabled` to RNN ops, converter alone may not be able to handle generic masking while keeping the RNN ops, since masking alters intra-op behavior. With such limitation, I'd like to share this PR for further comment and suggestion.

[1] https://www.tensorflow.org/guide/keras/masking_and_padding#masking
[2] https://github.com/onnx/onnx/blob/main/docs/Operators.md#LSTM
[3] https://github.com/onnx/keras-onnx/pull/386

---
### Details:
#### Forward LSTM
Here's an minimal example with an embedded LSTM (`mask_zeros=True`):
- H5 model:
<img width="947" alt="Screen Shot 2022-08-26 at 6 18 13 PM" src="https://user-images.githubusercontent.com/50014064/187008693-23aec863-ff44-476c-a592-ecca4beaebdd.png">

- tf2onnx-converted ONNX model, **before** proposed change:
<img width="635" alt="Screen Shot 2022-08-26 at 6 17 49 PM" src="https://user-images.githubusercontent.com/50014064/187008685-6e4b120a-8fdf-4d95-bfa8-af35c42dc929.png">

- tf2onnx-converted ONNX model, **after** proposed change:
<img width="571" alt="Screen Shot 2022-08-26 at 6 18 57 PM" src="https://user-images.githubusercontent.com/50014064/187008716-6b573998-fcf1-4380-aed4-dec7d37376d4.png">

#### Reverse LSTM
- Need to alter `tf.raw_op.ReverseV2`->`ReverseSequence` behavior to reverse LSTM input correctly:
<img width="596" alt="reverse_masked_lstm" src="https://user-images.githubusercontent.com/50014064/187008870-fccd8858-5d21-4d2e-8520-77375702d645.png">

