### PR TITLE
Fix keras2onnx_unit_test nightly job opset version failures.

### DIFF
--- a/ci_build/azure_pipelines/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/keras2onnx_unit_test.yml
@@ -68,7 +68,7 @@ jobs:
         ONNX_PATH: -i onnx==1.12.0
         KERAS: keras==2.9.0
         TENSORFLOW_PATH: tensorflow==2.9.0
-        INSTALL_ORT: pip install onnxruntime==1.11.0
+        INSTALL_ORT: pip install onnxruntime==1.12.0
         INSTALL_NUMPY: pip install numpy==1.23.0
 
   steps:

--- a/tests/keras2onnx_unit_tests/test_layers.py
+++ b/tests/keras2onnx_unit_tests/test_layers.py
@@ -7,7 +7,7 @@ from mock_keras2onnx.proto.tfcompat import is_tf2, tensorflow as tf
 from mock_keras2onnx.proto import (keras, is_tf_keras,
                                    is_tensorflow_older_than, is_tensorflow_later_than,
                                    is_keras_older_than, is_keras_later_than, python_keras_is_deprecated)
-from test_utils import no_loops_in_tf2, all_recurrents_should_bidirectional
+from test_utils import no_loops_in_tf2, all_recurrents_should_bidirectional, convert_keras_for_test as convert_keras
 
 K = keras.backend
 Activation = keras.layers.Activation
@@ -88,9 +88,6 @@ if is_tf_keras and is_tensorflow_later_than("1.14.0") and not python_keras_is_de
 def _asarray(*a):
     return np.array([a], dtype='f')
 
-########################
-from tf2onnx.keras2onnx_api import convert_keras
-##########################
 
 def test_keras_lambda(runner):
     model = Sequential()

--- a/tests/keras2onnx_unit_tests/test_utils.py
+++ b/tests/keras2onnx_unit_tests/test_utils.py
@@ -17,7 +17,7 @@ import urllib
 
 # Mapping opset to ONNXRuntime version.
 ORT_OPSET_VERSION = {
-    "1.6.0": 13, "1.8.0": 14, "1.9.0": 15, "1.11.0": 16, "1.12.0": 17
+    "1.6.0": 13, "1.7.0": 13, "1.8.0": 14, "1.9.0": 15, "1.10.0": 15, "1.11.0": 16, "1.12.0": 17
 }
 
 working_path = os.path.abspath(os.path.dirname(__file__))

--- a/tests/keras2onnx_unit_tests/test_utils.py
+++ b/tests/keras2onnx_unit_tests/test_utils.py
@@ -317,7 +317,8 @@ def get_max_opset_supported_by_ort():
         if ort_ver in ORT_OPSET_VERSION.keys():
             return ORT_OPSET_VERSION[ort_ver]
         else:
-            raise ValueError("Given onnxruntime version doesn't exist in ORT_OPSET_VERSION: {}".format(ort_ver)) 
+            print("Given onnxruntime version doesn't exist in ORT_OPSET_VERSION: {}".format(ort_ver))
+            return None
     except ImportError:
         return None
 
@@ -326,6 +327,6 @@ def convert_keras_for_test(model, name=None, target_opset=None, **kwargs):
     if target_opset is None:
         target_opset = get_max_opset_supported_by_ort()
 
-    print("Test is running with opset version: {}".format(target_opset))
+    print("Trying to run test with opset version: {}".format(target_opset))
 
     return convert_keras(model=model, name=name, target_opset=target_opset, **kwargs)

--- a/tests/keras2onnx_unit_tests/test_utils.py
+++ b/tests/keras2onnx_unit_tests/test_utils.py
@@ -8,9 +8,17 @@ import numpy as np
 import mock_keras2onnx
 from mock_keras2onnx.proto import keras, is_keras_older_than
 from mock_keras2onnx.proto.tfcompat import is_tf2
+from packaging.version import Version
+from tf2onnx.keras2onnx_api import convert_keras
 import time
 import json
 import urllib
+
+
+# Mapping opset to ONNXRuntime version.
+ORT_OPSET_VERSION = {
+    "1.6.0": 13, "1.8.0": 14, "1.9.0": 15, "1.11.0": 16, "1.12.0": 17
+}
 
 working_path = os.path.abspath(os.path.dirname(__file__))
 tmp_path = os.path.join(working_path, 'temp')
@@ -299,3 +307,25 @@ def is_bloburl_access(url):
         return response.getcode() == 200
     except urllib.error.URLError:
         return False
+
+
+def get_max_opset_supported_by_ort():
+    try:
+        import onnxruntime as ort
+        ort_ver = Version(ort.__version__).base_version
+
+        if ort_ver in ORT_OPSET_VERSION.keys():
+            return ORT_OPSET_VERSION[ort_ver]
+        else:
+            raise ValueError("Given onnxruntime version doesn't exist in ORT_OPSET_VERSION: {}".format(ort_ver)) 
+    except ImportError:
+        return None
+
+
+def convert_keras_for_test(model, name=None, target_opset=None, **kwargs):
+    if target_opset is None:
+        target_opset = get_max_opset_supported_by_ort()
+
+    print("Test is running with opset version: {}".format(target_opset))
+
+    return convert_keras(model=model, name=name, target_opset=target_opset, **kwargs)


### PR DESCRIPTION
1. Python 3.10 doesn't support onnxruntime 1.11, so update the target ort version to 1.12.
2. If ONNX version > ONNXRuntime version, there is a problem caused by opset version. Fix this issue.


Signed-off-by: Jay Zhang <jiz@microsoft.com>