### PR TITLE
Update left tests in test_subclassing for the opset version issue.

### DIFF
--- a/tests/keras2onnx_unit_tests/test_subclassing.py
+++ b/tests/keras2onnx_unit_tests/test_subclassing.py
@@ -4,7 +4,7 @@ import pytest
 import mock_keras2onnx
 import numpy as np
 import tensorflow as tf
-from tf2onnx.keras2onnx_api import convert_keras
+from test_utils import convert_keras_for_test as convert_keras
 from mock_keras2onnx.proto import is_tensorflow_older_than
 
 if (not mock_keras2onnx.proto.is_tf_keras) or (not mock_keras2onnx.proto.tfcompat.is_tf2):


### PR DESCRIPTION
If ONNX version > ONNXRuntime version, there is a problem caused by opset version. Fix this issue in test_subclassing file.


Signed-off-by: Jay Zhang <jiz@microsoft.com>