### PR TITLE
Upgrade the required version for flatbuffers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author='ONNX',
     author_email='onnx-technical-discuss@lists.lfaidata.foundation',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers'],
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers>=1.12'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author='ONNX',
     author_email='onnx-technical-discuss@lists.lfaidata.foundation',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers~=1.12'],
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Since tensorflow latest version has requested a higher version of flatbuffers, try to update the required version.

Fix #1977 .

Signed-off-by: Jay Zhang <jiz@microsoft.com>