### PR TITLE
Replace  distutils.version with packaging.version namespace.

### DIFF
--- a/tests/keras2onnx_applications/nightly_build/test_acgan.py
+++ b/tests/keras2onnx_applications/nightly_build/test_acgan.py
@@ -10,7 +10,7 @@ from mock_keras2onnx.proto import keras
 from os.path import dirname, abspath
 sys.path.insert(0, os.path.join(dirname(abspath(__file__)), '../../keras2onnx_tests/'))
 from test_utils import run_onnx_runtime
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 Activation = keras.layers.Activation
 BatchNormalization = keras.layers.BatchNormalization
@@ -133,7 +133,7 @@ class TestACGAN(unittest.TestCase):
         for fl in self.model_files:
             os.remove(fl)
 
-    @unittest.skipIf(StrictVersion(onnx.__version__) < StrictVersion("1.5.0"),
+    @unittest.skipIf(Version(onnx.__version__) < Version("1.5.0"),
                      "Not supported before onnx 1.5.0")
     def test_ACGAN(self):
         keras_model = ACGAN().combined

--- a/tests/keras2onnx_applications/nightly_build/test_mask_rcnn.py
+++ b/tests/keras2onnx_applications/nightly_build/test_mask_rcnn.py
@@ -21,7 +21,7 @@ if not os.path.exists(model_file_name):
 keras.backend.clear_session()
 sys.path.insert(0, os.path.join(dirname(abspath(__file__)), '../mask_rcnn/'))
 from mask_rcnn import model
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 working_path = os.path.abspath(os.path.dirname(__file__))
 tmp_path = os.path.join(working_path, 'temp')
@@ -36,7 +36,7 @@ class TestMaskRCNN(unittest.TestCase):
         for fl in self.model_files:
             os.remove(fl)
 
-    @unittest.skipIf(StrictVersion(onnx.__version__.split('-')[0]) < StrictVersion("1.6.0"),
+    @unittest.skipIf(Version(onnx.__version__.split('-')[0]) < Version("1.6.0"),
                      "Mask-rcnn conversion needs contrib op for onnx < 1.6.0.")
     def test_mask_rcnn(self):
         set_converter('CropAndResize', convert_tf_crop_and_resize)

--- a/tests/keras2onnx_applications/nightly_build/test_unet.py
+++ b/tests/keras2onnx_applications/nightly_build/test_unet.py
@@ -8,7 +8,7 @@ import onnxruntime
 from os.path import dirname, abspath
 from mock_keras2onnx.proto import keras, is_keras_older_than
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 sys.path.insert(0, os.path.join(dirname(abspath(__file__)), '../../keras2onnx_tests/'))
 from test_utils import run_image
@@ -126,7 +126,7 @@ class TestUnet(unittest.TestCase):
         res = run_image(model, self.model_files, img_path, color_mode="grayscale", target_size=(img_rows, img_cols))
         self.assertTrue(*res)
 
-    @unittest.skipIf(StrictVersion(onnxruntime.__version__.split('-')[0]) < StrictVersion('1.7.0'),
+    @unittest.skipIf(Version(onnxruntime.__version__.split('-')[0]) < Version('1.7.0'),
                      "ConvTranspose stride > 1 is fixed in onnxruntime 1.7.0.")
     def test_unet_3(self):
         # From https://github.com/yu4u/noise2noise/blob/master/model.py

--- a/tests/keras2onnx_applications/nightly_build/test_unet_plus_plus.py
+++ b/tests/keras2onnx_applications/nightly_build/test_unet_plus_plus.py
@@ -9,7 +9,7 @@ from os.path import dirname, abspath
 from mock_keras2onnx.proto import keras, is_keras_older_than
 from keras.applications.vgg16 import VGG16
 from onnxconverter_common.onnx_ex import get_maximum_opset_supported
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 sys.path.insert(0, os.path.join(dirname(abspath(__file__)), '../../keras2onnx_tests/'))
 from test_utils import run_image
@@ -102,7 +102,7 @@ class TestUnetPlusPlus(unittest.TestCase):
         for fl in self.model_files:
             os.remove(fl)
 
-    @unittest.skipIf(StrictVersion(onnxruntime.__version__.split('-')[0]) < StrictVersion('1.7.0'),
+    @unittest.skipIf(Version(onnxruntime.__version__.split('-')[0]) < Version('1.7.0'),
                      "ConvTranspose stride > 1 is fixed in onnxruntime 1.7.0.")
     def test_unet_plus_plus(self):
         backbone_name = 'vgg16'

--- a/tests/keras2onnx_applications/nightly_build/test_yolov3.py
+++ b/tests/keras2onnx_applications/nightly_build/test_yolov3.py
@@ -13,7 +13,7 @@ import onnx
 import urllib.request
 from yolov3 import YOLO, convert_model
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 import mock_keras2onnx
 from test_utils import is_bloburl_access
 
@@ -45,7 +45,7 @@ class TestYoloV3(unittest.TestCase):
             out_boxes.append(all_boxes[idx_1])
         return [out_boxes, out_scores, out_classes]
 
-    @unittest.skipIf(StrictVersion(onnx.__version__.split('-')[0]) < StrictVersion("1.5.0"),
+    @unittest.skipIf(Version(onnx.__version__.split('-')[0]) < Version("1.5.0"),
                      "NonMaxSuppression op is not supported for onnx < 1.5.0.")
     @unittest.skipIf(not is_bloburl_access(YOLOV3_WEIGHTS_PATH) or not is_bloburl_access(YOLOV3_TINY_WEIGHTS_PATH),
                      "Model blob url can't access.")

--- a/tests/keras2onnx_unit_tests/mock_keras2onnx/proto/tfcompat.py
+++ b/tests/keras2onnx_unit_tests/mock_keras2onnx/proto/tfcompat.py
@@ -3,9 +3,9 @@
 import os
 import tensorflow as _tf
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 
-is_tf2 = StrictVersion(_tf.__version__.split('-')[0]) >= StrictVersion('2.0.0')
+is_tf2 = Version(_tf.__version__.split('-')[0]) >= Version("2.0.0")
 
 
 def normalize_tensor_shape(tensor_shape):

--- a/tests/keras2onnx_unit_tests/test_cgan.py
+++ b/tests/keras2onnx_unit_tests/test_cgan.py
@@ -6,7 +6,7 @@ import mock_keras2onnx
 import numpy as np
 from mock_keras2onnx.proto import keras, is_tf_keras, is_tensorflow_older_than
 from tf2onnx.keras2onnx_api import convert_keras
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 Activation = keras.layers.Activation
 BatchNormalization = keras.layers.BatchNormalization
@@ -116,7 +116,7 @@ class CGAN():
 
 
 @pytest.mark.skipif(mock_keras2onnx.proto.tfcompat.is_tf2 and is_tf_keras, reason="Tensorflow 1.x only tests.")
-@pytest.mark.skipif(is_tf_keras and StrictVersion(tf.__version__.split('-')[0]) < StrictVersion("1.14.0"),
+@pytest.mark.skipif(is_tf_keras and Version(tf.__version__.split('-')[0]) < Version("1.14.0"),
                     reason="Not supported before tensorflow 1.14.0 for tf_keras")
 @pytest.mark.skipif(mock_keras2onnx.proto.tfcompat.is_tf2 and is_tensorflow_older_than('2.2'),
                     reason="Variable freezing fails to replace ResourceGather op")

--- a/tests/keras2onnx_unit_tests/test_layers.py
+++ b/tests/keras2onnx_unit_tests/test_layers.py
@@ -1139,8 +1139,8 @@ def test_conv1d_padding(conv1_runner):
     test_causal = False
     if is_tf_keras:
         import tensorflow
-        from distutils.version import StrictVersion
-        if StrictVersion(tensorflow.__version__.split('-')[0]) >= StrictVersion('1.12.0'):
+        from packaging.version import Version
+        if Version(tensorflow.__version__.split('-')[0]) >= Version('1.12.0'):
             test_causal = True
     else:
         test_causal = True

--- a/tf2onnx/tf_loader.py
+++ b/tf2onnx/tf_loader.py
@@ -74,7 +74,6 @@ if is_tf2():
     tf_gfile = tf.io.gfile
     tf_placeholder = tf.compat.v1.placeholder
     tf_placeholder_with_default = tf.compat.v1.placeholder_with_default
-    extract_sub_graph = tf.compat.v1.graph_util.extract_sub_graph
 elif Version(tf.__version__) >= Version("1.13"):
     # 1.13 introduced the compat namespace
     tf_reset_default_graph = tf.compat.v1.reset_default_graph
@@ -85,7 +84,6 @@ elif Version(tf.__version__) >= Version("1.13"):
     tf_gfile = tf.gfile
     tf_placeholder = tf.compat.v1.placeholder
     tf_placeholder_with_default = tf.compat.v1.placeholder_with_default
-    extract_sub_graph = tf.compat.v1.graph_util.extract_sub_graph
 else:
     # older than 1.13
     tf_reset_default_graph = tf.reset_default_graph
@@ -96,7 +94,6 @@ else:
     tf_gfile = tf.gfile
     tf_placeholder = tf.placeholder
     tf_placeholder_with_default = tf.placeholder_with_default
-    extract_sub_graph = tf.graph_util.extract_sub_graph
 
 
 def inputs_without_resource(sess, input_names):
@@ -708,11 +705,6 @@ def tf_optimize(input_names, output_names, graph_def):
     """Extract inference subgraph and optimize graph."""
     assert isinstance(input_names, list)
     assert isinstance(output_names, list)
-
-    # TODO: is this needed ?
-    needed_names = [utils.node_name(i) for i in input_names] + \
-                   [utils.node_name(i) for i in output_names]
-    graph_def = extract_sub_graph(graph_def, needed_names)
 
     want_grappler = is_tf2() or Version(tf.__version__) >= Version("1.15")
     if want_grappler:


### PR DESCRIPTION
Since distutils.version is going to be deprecated, we replace them with packaging.version. And also replace StrictVersion() with Version().