### PR TITLE
Fix an ort version issue and update flatbuffers install requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author='ONNX',
     author_email='onnx-technical-discuss@lists.lfaidata.foundation',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers>=1.12'],
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers<3.0,>=1.12'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/keras2onnx_unit_tests/test_utils.py
+++ b/tests/keras2onnx_unit_tests/test_utils.py
@@ -312,7 +312,8 @@ def is_bloburl_access(url):
 def get_max_opset_supported_by_ort():
     try:
         import onnxruntime as ort
-        ort_ver = Version(ort.__version__).base_version
+        ort_ver = Version(ort.__version__)
+        ort_ver = Version("{}.{}.0".format(ort_ver.major, ort_ver.minor)).base_version
 
         if ort_ver in ORT_OPSET_VERSION.keys():
             return ORT_OPSET_VERSION[ort_ver]


### PR DESCRIPTION
1. Update the ORT version logic to get the proper supported opset version.
2. Update the flatbuffers install requirement so that it won't exceed 3.0 which is also a requirement of other dependencies.

Signed-off-by: Jay Zhang <jiz@microsoft.com>