### PR TITLE
Process TFL_VARIABLE ops from tflite graph.

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -232,7 +232,7 @@ class Node(object):
 
         if self.output:
             for name in self.output:
-                lines.append("Outpus:")
+                lines.append("Output:")
                 lines.append("\t{}={}, {}".format(name, g.get_shape(name), g.get_dtype(name)))
 
         return '\n'.join(lines)


### PR DESCRIPTION
(Fix #2059 issue.)

For some tflite model, its graph contains some variable ops, like:

TFL_READ_VARIABLE
TFL_VAR_HANDLE

These ops are designed for training and the conversion doesn't work for them. We need to remove them from the frozen tflite graph. And for some of them, we need to keep its output because it might be used an input by other validate tflite ops in the graph.