### PR TITLE
Replace all occurences of np.str by builtin python str

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -525,7 +525,7 @@ class Test(object):
                         inputs[k] = np_value.astype(expected_dtype)
                     else:
                         if expected_dtype == "string":
-                            inputs[k] = self.make_input(v).astype(np.str).astype(object)
+                            inputs[k] = self.make_input(v).astype(str).astype(object)
                         else:
                             inputs[k] = self.make_input(v).astype(expected_dtype)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,7 +103,7 @@ class ApiTests(Tf2OnnxBackendTestBase):
         model.compile(optimizer='adam', loss=tf.keras.losses.mean_squared_error)
 
         inp1 = np.array([[2.], [3.]], dtype=np.float32)
-        inp2 = np.array([["a"], ["b"]], dtype=np.str)
+        inp2 = np.array([["a"], ["b"]], dtype=str)
         if not is_tf2():
             tf.keras.backend.get_session().run(tf.tables_initializer(name='init_all_tables'))
         k_res = model.predict([inp1, inp2])

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1648,8 +1648,8 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2, "input3:0": x_val3})
 
     def test_concat_const_string(self):
-        x_val1 = np.array([["Hello world", "abc"], ["def", "♦♥♠♣"]], dtype=np.str)
-        const_val = np.array([["Hello there", "wxyz"], ["", "π"]], dtype=np.str)
+        x_val1 = np.array([["Hello world", "abc"], ["def", "♦♥♠♣"]], dtype=str)
+        const_val = np.array([["Hello there", "wxyz"], ["", "π"]], dtype=str)
         def func(x1):
             x_ = tf.concat([x1, const_val], 0)
             return tf.identity(x_, name=_TFOUTPUT)
@@ -3513,9 +3513,9 @@ class BackendTests(Tf2OnnxBackendTestBase):
     def test_where_string(self):
         x_val = np.array([1, 2, -3, 4, -5, -6, -7, 8, 9, 0], dtype=np.float32)
         true_result = np.array([111, 222, 333, 444, 555, 666, 777, 888, 999, 1000],
-                               dtype=np.str)
+                               dtype=str)
         false_result = np.array([-111, -222, -333, -444, -555, -666, -777, -888, -999, -1000],
-                                dtype=np.str)
+                                dtype=str)
         def func(x):
             picks = tf.where(x > -1, true_result, false_result)
             return tf.identity(picks, name=_TFOUTPUT)
@@ -3613,7 +3613,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_tf_min_version("1.14", "tf.strings.lower")
     @check_opset_min_version(10, "StringNormalizer")
     def test_string_lower(self):
-        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=np.str)
+        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=str)
         def func(text1):
             x = tf.strings.lower(text1)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -3623,7 +3623,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_tf_min_version("1.14", "tf.strings.lower")
     @check_opset_min_version(10, "StringNormalizer")
     def test_string_lower_flat(self):
-        text_val1 = np.array(["a", "Test 1 2 3", "♠♣", "Hi there", "test test", "♥♦"], dtype=np.str)
+        text_val1 = np.array(["a", "Test 1 2 3", "♠♣", "Hi there", "test test", "♥♦"], dtype=str)
         def func(text1):
             x = tf.strings.lower(text1)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -3633,7 +3633,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_tf_min_version("1.14", "tf.strings.lower")
     @check_opset_min_version(10, "StringNormalizer")
     def test_string_upper(self):
-        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=np.str)
+        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=str)
         def func(text1):
             x = tf.strings.upper(text1)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -4709,9 +4709,9 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_opset_min_version(11, "ScatterND")
     @skip_tflite("Conversion crashes")
     def test_tensor_scatter_update_str(self):
-        x_val = np.array(['A', '♠♣♥♦', 'B', 'C'], dtype=np.str).reshape((4))
+        x_val = np.array(['A', '♠♣♥♦', 'B', 'C'], dtype=str).reshape((4))
         y_val = np.array([0, 2], dtype=np.int64).reshape((2, 1))
-        z_val = np.array(['☺', '11'], dtype=np.str).reshape((2))
+        z_val = np.array(['☺', '11'], dtype=str).reshape((2))
 
         def func(x, y, z):
             x_ = tf.tensor_scatter_nd_update(x, y, z)
@@ -4722,9 +4722,9 @@ class BackendTests(Tf2OnnxBackendTestBase):
     @check_opset_min_version(11, "ScatterND")
     @skip_tflite("Conversion crashes")
     def test_tensor_scatter_update_str_const(self):
-        x_val = np.array(['A', '♠♣♥♦', 'B', 'C'], dtype=np.str).reshape((4))
+        x_val = np.array(['A', '♠♣♥♦', 'B', 'C'], dtype=str).reshape((4))
         y_val = np.array([0, 2], dtype=np.int64).reshape((2, 1))
-        z_val = np.array(['☺', '11'], dtype=np.str).reshape((2))
+        z_val = np.array(['☺', '11'], dtype=str).reshape((2))
 
         def func(x, y):
             z = tf.constant(z_val)

--- a/tests/test_string_ops.py
+++ b/tests/test_string_ops.py
@@ -35,7 +35,7 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
 
     @requires_custom_ops("StringRegexReplace")
     def test_static_regex_replace(self):
-        text_val = np.array([["Hello world!", "Test 1 2 3"], ["Hi there", "test test"]], dtype=np.str)
+        text_val = np.array([["Hello world!", "Test 1 2 3"], ["Hi there", "test test"]], dtype=str)
         def func(text):
             x_ = tf.strings.regex_replace(text, " ", "_", replace_global=True)
             return tf.identity(x_, name=_TFOUTPUT)
@@ -44,9 +44,9 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
     @requires_custom_ops("StringJoin")
     @check_opset_min_version(8, "Expand")
     def test_string_join(self):
-        text_val1 = np.array([["a", "Test 1 2 3"], ["Hi there", "test test"]], dtype=np.str)
-        text_val2 = np.array([["b", "Test 1 2 3"], ["Hi there", "suits ♠♣♥♦"]], dtype=np.str)
-        text_val3 = np.array("Some scalar text", dtype=np.str)
+        text_val1 = np.array([["a", "Test 1 2 3"], ["Hi there", "test test"]], dtype=str)
+        text_val2 = np.array([["b", "Test 1 2 3"], ["Hi there", "suits ♠♣♥♦"]], dtype=str)
+        text_val3 = np.array("Some scalar text", dtype=str)
         def func(text1, text2, text3):
             x_ = tf.strings.join([text1, text2, text3], separator="±")
             return tf.identity(x_, name=_TFOUTPUT)
@@ -55,7 +55,7 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
     @requires_custom_ops("StringSplit")
     @check_tf_min_version("2.0", "result is sparse not ragged in tf1")
     def test_string_split(self):
-        text_val = np.array([["a", "Test 1 2 3"], ["Hi there", "test test"]], dtype=np.str)
+        text_val = np.array([["a", "Test 1 2 3"], ["Hi there", "test test"]], dtype=str)
         def func(text):
             x = tf.strings.split(text, sep=' ').flat_values
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -64,7 +64,7 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
 
     @requires_custom_ops("StringToHashBucketFast")
     def test_string_to_hash_bucket_fast(self):
-        text_val = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=np.str)
+        text_val = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=str)
         def func(text):
             x = tf.strings.to_hash_bucket_fast(text, 20)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -73,8 +73,8 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
 
     @requires_custom_ops("StringEqual")
     def test_string_equal(self):
-        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=np.str)
-        text_val2 = np.array([["a", "Test 2 4 6", "♠♣"], ["Hello", "test test", "♥ ♦"]], dtype=np.str)
+        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=str)
+        text_val2 = np.array([["a", "Test 2 4 6", "♠♣"], ["Hello", "test test", "♥ ♦"]], dtype=str)
         def func(text1, text2):
             x = tf.equal(text1, text2)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -83,8 +83,8 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
 
     @requires_custom_ops("StringNotEqual")
     def test_string_not_equal(self):
-        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=np.str)
-        text_val2 = np.array([["a", "Test 2 4 6", "♠♣"], ["Hello", "test test", "♥ ♦"]], dtype=np.str)
+        text_val1 = np.array([["a", "Test 1 2 3", "♠♣"], ["Hi there", "test test", "♥♦"]], dtype=str)
+        text_val2 = np.array([["a", "Test 2 4 6", "♠♣"], ["Hello", "test test", "♥ ♦"]], dtype=str)
         def func(text1, text2):
             x = tf.not_equal(text1, text2)
             x_ = tf.identity(x, name=_TFOUTPUT)
@@ -116,7 +116,7 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
         from tensorflow_text.python.ops.regex_split_ops import (
             gen_regex_split_ops as lib_gen_regex_split_ops)
         text_val = np.array(["a Test 1 2 3 ♠♣",
-                             "Hi there test test ♥♦"], dtype=np.str)
+                             "Hi there test test ♥♦"], dtype=str)
         def func(text):
             tokens, begin_offsets, end_offsets, row_splits = lib_gen_regex_split_ops.regex_split_with_offsets(
                 text, "(\\s)", "")
@@ -153,7 +153,7 @@ class StringOpsTests(Tf2OnnxBackendTestBase):
                 init, num_oov, lookup_key_dtype=tf.string)
 
         vocab = _CreateTable(["great", "they", "the", "##'", "##re", "##est"])
-        text_val = np.array(["they're", "the", "greatest"], dtype=np.str)
+        text_val = np.array(["they're", "the", "greatest"], dtype=str)
 
         def func(text):
             inputs = ragged_tensor.convert_to_tensor_or_ragged_tensor(text)

--- a/tests/test_tfjs_runner.py
+++ b/tests/test_tfjs_runner.py
@@ -18,7 +18,7 @@ class TestTfjsRunner(unittest.TestCase):
         float_array = np.array([[1.1, 2.2], [3.3, 4.4]], np.float32)
         int_array = np.array([[1, 2], [3, 4]], np.int32)
         bool_array = np.array([[True, False], [True, True]], bool)
-        string_array = np.array([['Hello world', ''], ['π', 'Tensor']], np.str)
+        string_array = np.array([['Hello world', ''], ['π', 'Tensor']], str)
         complex_array = np.array([[1 + 0.1j, 2 + 0.2j], [3 + 0.3j, 4 + 0.4j]], np.complex64)
 
         arrays = [float_array, int_array, bool_array, string_array, complex_array]

--- a/tf2onnx/tf_utils.py
+++ b/tf2onnx/tf_utils.py
@@ -55,7 +55,7 @@ def tf_to_onnx_tensor(tensor, name=""):
         # in which each item is of str while the whole dtype is of object.
         try:
             # Faster but fails on Unicode
-            np_data = np_data.astype(np.str).astype(object)
+            np_data = np_data.astype(str).astype(object)
         except UnicodeDecodeError:
             decode = np.vectorize(lambda x: x.decode('UTF-8'))
             np_data = decode(np_data).astype(object)


### PR DESCRIPTION
`np.str` is removed in numpy==1.24.0, and is just a redirection to builtin python str.