### PR TITLE
Fix the axis of inserted QDQ for ConvTranspose

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -284,7 +284,10 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
             # tflite sometimes converts from tf but produces an invalid model
             return None, None
 
-    def assert_shapes_correct(self, graph, allow_missing=False, run_checker=True):
+    def assert_shapes_correct(self, graph, allow_missing=False, run_checker=True, check_shape=True):
+        if not check_shape:
+            return None
+
         model_proto = graph.make_model("test")
 
         if run_checker and not any(graph.get_shape(out) is None for out in graph.outputs + graph.input_names):
@@ -402,8 +405,10 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
                     i = output_names_with_port.index(output_name)
                     actual[i] = np.transpose(actual[i], constants.NCHW_TO_NHWC)
 
-            self.assert_results_equal(expected, actual, rtol, atol, mtol, check_value, check_shape, check_dtype)
-            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker)
+            self.assert_results_equal(expected, actual, rtol, atol, mtol, check_value, check_shape,
+                                      check_dtype)
+            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker,
+                                       check_shape)
 
             if graph_validator:
                 self.assertTrue(graph_validator(g))
@@ -441,7 +446,8 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
                     onnx_tfl_res[i] = np.transpose(onnx_tfl_res[i], constants.NCHW_TO_NHWC)
 
             self.assert_results_equal(tfl_res, onnx_tfl_res, rtol, atol, mtol, check_value, check_shape, check_dtype)
-            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker)
+            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker,
+                                       check_shape)
 
             if graph_validator:
                 self.assertTrue(graph_validator(g))
@@ -475,7 +481,8 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
 
             self.assert_results_equal(tfjs_res, onnx_tfjs_res, rtol, atol, mtol, check_value, check_shape,
                                       check_dtype=False)
-            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker)
+            self.assert_shapes_correct(g, self.config.allow_missing_shapes, not self.config.skip_onnx_checker,
+                                       check_shape)
 
             if graph_validator:
                 self.assertTrue(graph_validator(g))

--- a/tests/common.py
+++ b/tests/common.py
@@ -51,6 +51,7 @@ __all__ = [
     "check_op_count",
     "check_gru_count",
     "check_lstm_count",
+    "check_quantization_axis",
     "timeout",
 ]
 
@@ -471,6 +472,8 @@ def check_lstm_count(graph, expected_count):
 def check_gru_count(graph, expected_count):
     return check_op_count(graph, "GRU", expected_count)
 
+def check_quantization_axis(graph, op_type, expected_axis):
+    return np.all(np.array([n.get_attr_int("axis") for n in group_nodes_by_type(graph)[op_type]]) == expected_axis)
 
 _MAX_MS_OPSET_VERSION = 1
 


### PR DESCRIPTION
Hi, I noticed a problem in the tf2onnx converter. This is regarding ConvTranspose converter (https://github.com/onnx/tensorflow-onnx/blob/main/tf2onnx/onnx_opset/nn.py#L428). When ConvTranspose is quantized, the converter should take a ConvTranspose layer and convert it as follows.
```
X --->  ConvTranspose
W -----^

now becomes

X ----Q_x -> DQ_x ----->  ConvTranspose
W --> Q_w -> DQ_w -> ----------^
```

These Q_w/DQ_w nodes that are inserted have the wrong axis set when they are modified by the tf2onnx converter. For ConvTranspose, the axis should be set to 1. This is the number of filters, which is Cout. (The kernel shape here is Cin x Cout x kH x kW)

For Conv, the axis should be (and is correctly) set to 0. (The kernel shape here is Cout x Cin x kH x kW)

Instead, this axis is unconditionally set to 0 for all conv layers that use the `conv_convert_inputs()` routine. 

I've provided a fix in this PR. I had some trouble with the tests I added so I needed to add a mechanism to skip checking shapes in `Tf2OnnxBackendTestBase.run_test_case`; it seems that no other test sets `check_shape=False` so this shouldn't change the behavior of anything else.