### PR TITLE
Fix code to enable opset 18 and latest onnxruntime.

### DIFF
--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -4,7 +4,7 @@ parameters:
   platforms: ['linux']
   python_versions: ['3.7']
   tf_versions: ['']
-  onnx_versions: ['']
+  onnx_versions: ['1.13.1']
   onnx_opsets: ['18', '17', '16', '15', '14', '13']
   onnx_backends: {onnxruntime: ['1.14.1']}
   job: {}

--- a/ci_build/azure_pipelines/templates/job_generator.yml
+++ b/ci_build/azure_pipelines/templates/job_generator.yml
@@ -5,8 +5,8 @@ parameters:
   python_versions: ['3.7']
   tf_versions: ['']
   onnx_versions: ['']
-  onnx_opsets: ['17', '16', '15', '14', '13']
-  onnx_backends: {onnxruntime: ['1.13.1']}
+  onnx_opsets: ['18', '17', '16', '15', '14', '13']
+  onnx_backends: {onnxruntime: ['1.14.1']}
   job: {}
   run_setup: 'True'
   report_coverage: 'False'

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -4,7 +4,8 @@ steps:
 - bash: |
     set -ex
     pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized sympy coloredlogs flatbuffers timeout-decorator
-    pip install $(CI_PIP_TF_NAME) $(CI_PIP_ONNX_NAME)
+    pip install $(CI_PIP_TF_NAME)
+    pip install $(CI_PIP_ONNX_NAME)
 
     # TF < 2.7 reuires numpy <= 1.19, but onnxruntime >= 1.11 requires numpy >= 1.21
     if [[ $CI_TF_VERSION < 2.7 ]] && [[ $CI_ONNX_BACKEND == "onnxruntime" ]] ;

--- a/ci_build/azure_pipelines/templates/unit_test.yml
+++ b/ci_build/azure_pipelines/templates/unit_test.yml
@@ -1,7 +1,7 @@
 # Run unit test
 
 parameters:
-    onnx_opsets: ['17', '16', '15', '14', '13']
+    onnx_opsets: ['18', '17', '16', '15', '14', '13']
     skip_tflite_tests: 'True'
     skip_tfjs_tests: 'True'
     skip_tf_tests: 'False'

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_application_tests.yml
@@ -51,7 +51,7 @@ jobs:
         INSTALL_KERAS:
         UNINSTALL_KERAS:
         INSTALL_TENSORFLOW: pip install tensorflow==2.11.0
-        INSTALL_ORT: pip install onnxruntime==1.13.1
+        INSTALL_ORT: pip install onnxruntime==1.14.1
         INSTALL_KERAS_RESNET: pip install keras-resnet
         INSTALL_TRANSFORMERS: pip install transformers==4.2.0
         INSTALL_NUMPY:

--- a/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/trimmed_keras2onnx_unit_test.yml
@@ -61,14 +61,14 @@ jobs:
         python.version: '3.8'
         ONNX_PATH: onnx==1.12.0
         TENSORFLOW_PATH: tensorflow==2.9.0
-        INSTALL_ORT: pip install onnxruntime==1.12.0
+        INSTALL_ORT: pip install onnxruntime==1.13.1
         INSTALL_NUMPY:
 
       Python310-tf-latest:
         python.version: '3.10'
         ONNX_PATH: onnx==1.13.1
         TENSORFLOW_PATH: tensorflow==2.11.0
-        INSTALL_ORT: pip install onnxruntime==1.13.1
+        INSTALL_ORT: pip install onnxruntime==1.14.1
         INSTALL_NUMPY:
 
       ############ Pure Keras Unit Tests ############

--- a/tests/keras2onnx_unit_tests/test_utils.py
+++ b/tests/keras2onnx_unit_tests/test_utils.py
@@ -20,7 +20,7 @@ import urllib
 # https://github.com/onnx/tensorflow-onnx/issues/2132
 ORT_OPSET_VERSION = {
     "1.6.0": 13, "1.7.0": 13, "1.8.0": 14, "1.9.0": 15, "1.10.0": 15, "1.11.0": 16,
-    "1.12.0": 17, "1.13.0": 17, "1.14.0": 17
+    "1.12.0": 17, "1.13.0": 17, "1.14.0": 18
 }
 
 working_path = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_onnx_shape_inference.py
+++ b/tests/test_onnx_shape_inference.py
@@ -87,7 +87,7 @@ class ONNXShapeInferenceTests(Tf2OnnxBackendTestBase):
         shapes = [[5, 6, 7]]
         dtypes = [TensorProto.FLOAT]
         graph = self._create_empty_graph(inputs, shapes, dtypes)
-        node = graph.make_node("Split", [INPUT1], output_count=2, attr={"axis": 1})
+        node = graph.make_node("Split", [INPUT1], output_count=2, attr={"axis": 1, "num_outputs": 2})
         graph.add_graph_output(node.output[0])
         graph.add_graph_output(node.output[1])
         self._run_test_case(graph, self._generate_random_inputs(inputs, shapes, dtypes))

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -127,7 +127,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         output_shape = [output_before_trans[i] for i in perm]
         for axis in range(len(input_shape)):
             node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=inner_perm, name="trans1")
-            node2 = helper.make_node("Split", ["Y"], ["Z"], axis=axis, name="split")
+            if self.config.opset < 18:
+                node2 = helper.make_node("Split", ["Y"], ["Z"], axis=axis, name="split")
+            else:
+                node2 = helper.make_node("Split", ["Y"], ["Z"], axis=axis, name="split", num_outputs=1)
             node3 = helper.make_node("Transpose", ["Z"], ["res"], perm=perm, name="trans2")
 
             graph = helper.make_graph(
@@ -148,7 +151,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
     @check_opset_max_version(12, "split attribute changed to input since opset 13")
     def test_transpose_with_split_dynamic_shape(self, input_shape, specific_input, output_shape, perm):
         node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm, name="trans")
-        node2 = helper.make_node("Split", ["Y"], ["Z"], axis=1, split=[1], name="split")
+        if self.config.opset < 18:
+            node2 = helper.make_node("Split", ["Y"], ["Z"], axis=1, split=[1], name="split")
+        else:
+            node2 = helper.make_node("Split", ["Y"], ["Z"], axis=1, split=[1], name="split", num_outputs=1)
         node3 = helper.make_node("Squeeze", ["Z"], ["B"], name="squeeze")
 
         graph = helper.make_graph(
@@ -1305,6 +1311,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((1, 3, 4, 5), (1, 3, 1, 1), [0, 2, 3, 1], [0, 3, 1, 2]),
         ((1, 3, 4, 5, 6), (1, 3, 1, 1, 1), [0, 2, 3, 4, 1], [0, 4, 1, 2, 3]),
     ])
+    @check_opset_max_version(17, "ReduceMean from opset <= 17 has axes as an attribute")
     def test_transpose_reducemean(self, input_shape, output_shape, perm_input, perm_output):
         node0 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm_input, name="trans_1")
         node1 = helper.make_node("ReduceMean", ["Y"], ["Z"], axes=list(range(1, len(input_shape) - 1)),
@@ -1316,6 +1323,29 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             "transpose-reducemean-test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
             [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_transpose_compare(["res"], {"X": np.random.randn(*input_shape).astype(np.float32)},
+                                   model_proto, remaining_transpose_num=0)
+
+    @parameterized.expand([
+        ((3, 4, 5), (3, 4, 1), [1], [0, 2, 1], [0, 2, 1]),
+        ((1, 3, 4, 5), (1, 3, 1, 1), [1, 2], [0, 2, 3, 1], [0, 3, 1, 2]),
+        ((1, 3, 4, 5, 6), (1, 3, 1, 1, 1), [1, 2, 3], [0, 2, 3, 4, 1], [0, 4, 1, 2, 3]),
+    ])
+    @check_opset_min_version(18, "ReduceMean from opset > 17 has axes as an input")
+    def test_transpose_reducemean_18(self, input_shape, output_shape, axes, perm_input, perm_output):
+        node0 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm_input, name="trans_1")
+        node1 = helper.make_node("ReduceMean", ["Y", "axes"], ["Z"], keepdims=1, name="reducemean")
+        node2 = helper.make_node("Transpose", ["Z"], ["res"], perm=perm_output, name="trans_2")
+        graph = helper.make_graph(
+                    [node0, node1, node2],
+                    "transpose-reducemean-test-18",
+                    [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
+                    [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
+                    [helper.make_tensor("axes", data_type=TensorProto.INT64,
+                                        dims=[len(axes)], vals=axes)],
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
@@ -1357,6 +1387,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         ((1, 3, 4, 5, 6), (1, 3), [1, 2, 3], [0, 2, 3, 4, 1], [0, 1]),
         ((1, 3, 4, 5, 6), (), [0, 1, 2, 3, 4], [0, 2, 3, 4, 1], []),
     ])
+    @check_opset_max_version(17, "ReduceMax from opset <= 17 has axes as an attribute")
     def test_transpose_reducemax(self, input_shape, output_shape, axes, perm_input, perm_output):
         node0 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm_input, name="trans_1")
         node1 = helper.make_node("ReduceMax", ["Y"], ["Z"], axes=axes,
@@ -1376,6 +1407,30 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         model_proto = self.make_model(graph, producer_name="onnx-tests")
         self.run_transpose_compare(["res"], {"X": np.random.randn(*input_shape).astype(np.float32)},
                                    model_proto, remaining_transpose_num=0)
+
+    @parameterized.expand([
+        ((3, 4, 5), (3, 4, 1), [1], [0, 2, 1], [0, 2, 1]),
+        ((1, 3, 4, 5), (1, 3, 1, 1), [1, 2], [0, 2, 3, 1], [0, 3, 1, 2]),
+        ((1, 3, 4, 5, 6), (1, 3, 1, 1, 1), [1, 2, 3], [0, 2, 3, 4, 1], [0, 4, 1, 2, 3]),
+    ])
+    @check_opset_min_version(18, "ReduceMax from opset > 17 has axes as an input")
+    def test_transpose_reducemax_18(self, input_shape, output_shape, axes, perm_input, perm_output):
+        node0 = helper.make_node("Transpose", ["X"], ["Y"], perm=perm_input, name="trans_1")
+        node1 = helper.make_node("ReduceMax", ["Y", "axes"], ["Z"], keepdims=1, name="reducemax")
+        node2 = helper.make_node("Transpose", ["Z"], ["res"], perm=perm_output, name="trans_2")
+
+        graph = helper.make_graph(
+            [node0, node1, node2],
+            "transpose-reducemax-test-18",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
+            [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
+            [helper.make_tensor("axes", data_type=TensorProto.INT64,
+                    dims=[len(axes)], vals=axes)],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_transpose_compare(["res"], {"X": np.random.randn(*input_shape).astype(np.float32)},
+                                model_proto, remaining_transpose_num=0)
 
     def test_transpose_argmax(self):
         input_shape = [1, 2, 3, 4]
@@ -1858,6 +1913,7 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         self.run_merge_duplicated_nodes_compare(["OUT"], {"X": np.random.randn(5, 5).astype(np.float32)}, model_proto,
                                                 op_type="Add", remaining_op_num=2)
 
+    @check_opset_max_version(17, "ReduceMin from opset <= 17 has axes as an attribute")
     def test_duplicated_duplicated_attributes(self):
         # same attr or not
         node0 = helper.make_node('ReduceMin', inputs=["X"], outputs=["value0"], axes=[0], keepdims=0)
@@ -1871,6 +1927,31 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             "test_duplicated_duplicated_attributes",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (5, 5))],
             [helper.make_tensor_value_info("OUT", TensorProto.FLOAT, (5,))],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        self.run_merge_duplicated_nodes_compare(["OUT"], {"X": np.random.randn(5, 5).astype(np.float32)}, model_proto,
+                                                op_type="ReduceMin", remaining_op_num=2)
+
+    @check_opset_min_version(18, "ReduceMin from opset > 17 has axes as an input")
+    def test_duplicated_duplicated_attributes_18(self):
+        # same attr or not
+        node0 = helper.make_node('ReduceMin', inputs=["X", "axes0"], outputs=["value0"], keepdims=0)
+        node1 = helper.make_node('ReduceMin', inputs=["X", "axes1"], outputs=["value1"], keepdims=0)
+        node2 = helper.make_node('ReduceMin', inputs=["X", "axes2"], outputs=["value2"], keepdims=0)
+        node3 = helper.make_node('Add', inputs=["value0", "value1"], outputs=["value3"])
+        node4 = helper.make_node("Mul", ["value2", "value3"], ["OUT"])
+
+        graph = helper.make_graph(
+            [node0, node1, node2, node3, node4],
+            "test_duplicated_duplicated_attributes_18",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (5, 5))],
+            [helper.make_tensor_value_info("OUT", TensorProto.FLOAT, (5,))],
+            [
+                helper.make_tensor("axes0", data_type=TensorProto.INT64, dims=[1], vals=[0]),
+                helper.make_tensor("axes1", data_type=TensorProto.INT64, dims=[1], vals=[0]),
+                helper.make_tensor("axes2", data_type=TensorProto.INT64, dims=[1], vals=[1]),
+            ]
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
@@ -2062,7 +2143,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         node55 = helper.make_node("Constant", [], ["six"], value=six_tensor)
 
         node6 = helper.make_node("Gather", ["S", "g_indices"], ["dims12"])
-        node7 = helper.make_node("ReduceProd", ["dims12"], ["dims12_prod"], axes=[0])
+        if self.config.opset >= 18:
+            node7 = helper.make_node("ReduceProd", ["dims12", "axes"], ["dims12_prod"])
+        else:
+            node7 = helper.make_node("ReduceProd", ["dims12"], ["dims12_prod"], axes=[0])
         if self.config.opset >= 10:
             node8 = helper.make_node("Slice", ["S", "starts", "ends", ""], ["dim0"])
         else:
@@ -2312,7 +2396,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
                                           vals=np.random.randn(2, 6, 1).flatten().astype(np.float32))
         node0 = helper.make_node("Constant", [], ["const"], value=const_tensor)
-        node1 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1)
+        if self.config.opset < 18:
+            node1 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1)
+        else:
+            node1 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, num_outputs=3)
         node2 = helper.make_node("Sum", ["inp", "out1", "out2", "out3"], ["out4"])
 
         graph = helper.make_graph(
@@ -2331,7 +2418,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
                                           vals=np.random.randn(2, 6, 1).flatten().astype(np.float32))
         node0 = helper.make_node("Constant", [], ["const"], value=const_tensor)
-        node1 = helper.make_node("Split", ["const"], ["out1"], axis=1)
+        if self.config.opset < 18:
+            node1 = helper.make_node("Split", ["const"], ["out1"], axis=1)
+        else:
+            node1 = helper.make_node("Split", ["const"], ["out1"], axis=1, num_outputs=1)
         node2 = helper.make_node("Sum", ["inp", "out1"], ["out4"])
 
         graph = helper.make_graph(
@@ -2374,7 +2464,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         const_tensor = helper.make_tensor(name='const_tensor', data_type=TensorProto.FLOAT, dims=shape,
                                           vals=np.random.randn(2, 6, 1).flatten().astype(np.float32))
         node0 = helper.make_node("Constant", [], ["const"], value=const_tensor)
-        node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2])
+        if self.config.opset < 18:
+            node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2])
+        else:
+            node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2], num_outputs=3)
         node3 = helper.make_node("Sum", ["inp", "out2"], ["out4"])
 
         graph = helper.make_graph(

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1340,12 +1340,12 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         node1 = helper.make_node("ReduceMean", ["Y", "axes"], ["Z"], keepdims=1, name="reducemean")
         node2 = helper.make_node("Transpose", ["Z"], ["res"], perm=perm_output, name="trans_2")
         graph = helper.make_graph(
-                    [node0, node1, node2],
-                    "transpose-reducemean-test-18",
-                    [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
-                    [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
-                    [helper.make_tensor("axes", data_type=TensorProto.INT64,
-                                        dims=[len(axes)], vals=axes)],
+            [node0, node1, node2],
+            "transpose-reducemean-test-18",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
+            [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
+            [helper.make_tensor("axes", data_type=TensorProto.INT64,
+                                dims=[len(axes)], vals=axes)],
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
@@ -1425,12 +1425,12 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
             [helper.make_tensor_value_info("res", TensorProto.FLOAT, output_shape)],
             [helper.make_tensor("axes", data_type=TensorProto.INT64,
-                    dims=[len(axes)], vals=axes)],
+                                dims=[len(axes)], vals=axes)],
         )
 
         model_proto = self.make_model(graph, producer_name="onnx-tests")
         self.run_transpose_compare(["res"], {"X": np.random.randn(*input_shape).astype(np.float32)},
-                                model_proto, remaining_transpose_num=0)
+                                   model_proto, remaining_transpose_num=0)
 
     def test_transpose_argmax(self):
         input_shape = [1, 2, 3, 4]
@@ -2467,7 +2467,8 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         if self.config.opset < 18:
             node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2])
         else:
-            node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2], num_outputs=3)
+            node2 = helper.make_node("Split", ["const"], ["out1", "out2", "out3"], axis=1, split=[1, 3, 2],
+                                     num_outputs=3)
         node3 = helper.make_node("Sum", ["inp", "out2"], ["out4"])
 
         graph = helper.make_graph(

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -55,5 +55,5 @@ ENV_TF2ONNX_CATCH_ERRORS = "TF2ONNX_CATCH_ERRORS"
 # Note: opset 7 and opset 8 came out with IR3 but we need IR4 because of PlaceholderWithDefault
 # Refer from https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
 OPSET_TO_IR_VERSION = {
-    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7, 13: 7, 14: 7, 15: 8, 16: 8, 17: 8
+    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7, 13: 7, 14: 7, 15: 8, 16: 8, 17: 8, 18: 8
 }

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -1110,7 +1110,8 @@ class SampleDistortedBoundingBox:
 
         rand_attr['shape'] = [max_attempts, 4]
         random_nums = ctx.make_node("RandomUniform", [], attr=rand_attr, op_name_scope=node.name).output[0]
-        r1, r2, r3, r4 = ctx.make_node("Split", [random_nums], attr={'axis': 1, 'num_outputs': 4}, output_count=4).output
+        r1, r2, r3, r4 = ctx.make_node("Split", [random_nums], attr={'axis': 1, 'num_outputs': 4},
+                                       output_count=4).output
 
         # Use r1 to sample the aspect ratio
         scaled_r1 = ctx.make_node("Mul", [r1, ratio_range_node]).output[0]
@@ -1525,7 +1526,7 @@ class AdjustContrastv2:
         # Reduce height and width only
         axes_to_reduce = list(range(rank))[-3:-1]
         mean = GraphBuilder(ctx).make_reduce_mean({"data": images, "axes": axes_to_reduce, "keepdims": True},
-                                                   op_name_scope=node.name)
+                                                  op_name_scope=node.name)
         diff = ctx.make_node("Sub", [images, mean], op_name_scope=node.name).output[0]
         scaled = ctx.make_node("Mul", [diff, contrast_factor], op_name_scope=node.name).output[0]
         result = ctx.make_node("Add", [scaled, mean], op_name_scope=node.name).output[0]
@@ -1543,7 +1544,8 @@ class AdjustSaturation:
         k = ctx.make_const(utils.make_name("three"), np.array([3], np.int64)).output[0]
         ordered, indices = ctx.make_node("TopK", [images, k], attr={'axis': -1}, output_count=2).output
         # Sorted and separated into channels
-        max_c, mid_c, min_c = ctx.make_node("Split", [ordered], attr={'axis': -1, 'num_outputs': 3}, output_count=3).output
+        max_c, mid_c, min_c = ctx.make_node("Split", [ordered], attr={'axis': -1, 'num_outputs': 3},
+                                            output_count=3).output
         delta = ctx.make_node("Sub", [max_c, min_c]).output[0]
         scaled_delta = ctx.make_node("Mul", [delta, factor], op_name_scope=node.name).output[0]
         new_delta = ctx.make_node("Min", [scaled_delta, max_c]).output[0]
@@ -1580,7 +1582,8 @@ class AdjustHue:
         ordered, indices = ctx.make_node("TopK", [images, k], attr={'axis': -1},
                                          output_count=2, op_name_scope=node.name).output
         # Sorted and separated into channels
-        max_c, mid_c, min_c = ctx.make_node("Split", [ordered], attr={'axis': -1, 'num_outputs': 3}, output_count=3).output
+        max_c, mid_c, min_c = ctx.make_node("Split", [ordered], attr={'axis': -1, 'num_outputs': 3},
+                                            output_count=3).output
         delta = ctx.make_node("Sub", [max_c, min_c]).output[0]
         delta2 = ctx.make_node("Sub", [mid_c, min_c]).output[0]
         delta_z = ctx.make_node("Equal", [delta, const_zero]).output[0]
@@ -2001,7 +2004,8 @@ class CTCGreedyDecoder:
         merge_repeated = node.get_attr_value("merge_repeated", False)
 
         inp_shape = ctx.make_node("Shape", [inp]).output[0]
-        max_time_unsq, num_batch_unsq, num_classes_unsq = ctx.make_node("Split", [inp_shape], attr={'num_outputs': 3}, output_count=3).output
+        max_time_unsq, num_batch_unsq, num_classes_unsq = ctx.make_node("Split", [inp_shape], attr={'num_outputs': 3},
+                                                                        output_count=3).output
         max_time = GraphBuilder(ctx).make_squeeze({"data": max_time_unsq, "axes": [0]})
         num_batch = GraphBuilder(ctx).make_squeeze({"data": num_batch_unsq, "axes": [0]})
         num_classes = GraphBuilder(ctx).make_squeeze({"data": num_classes_unsq, "axes": [0]})
@@ -2065,9 +2069,10 @@ class CTCGreedyDecoder:
         sparse_idx = ctx.make_node("Concat", [batch_flat, time_flat], attr={'axis': 1}).output[0]
         idx_compress = ctx.make_node("Compress", [idx_flat, keep_idx_flat], attr={'axis': 0}, shapes=[[-1]],
                                      op_name_scope=node.name).output[0]
-        sparse_idx_compress = ctx.make_node("Compress", [sparse_idx, keep_idx_flat], attr={'axis': 0}, shapes=[[-1, 2]],
-                                            op_name_scope=node.name).output[0]
-        max_sparse_idx = GraphBuilder(ctx).make_reduce_max({"data": sparse_idx_compress, "axes": [0], "keepdims": False})
+        sparse_idx_compress = ctx.make_node("Compress", [sparse_idx, keep_idx_flat], attr={'axis': 0},
+                                            shapes=[[-1, 2]], op_name_scope=node.name).output[0]
+        max_sparse_idx = GraphBuilder(ctx).make_reduce_max({"data": sparse_idx_compress, "axes": [0],
+                                                            "keepdims": False})
         max_time = GraphBuilder(ctx).make_slice(
             {"data": max_sparse_idx, "starts": [1], "ends": [2], "axes": [0]})
         max_time_inc = ctx.make_node("Add", [max_time, const_one]).output[0]

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -19,11 +19,11 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,missing-docstring
 
-@tf_op("Min", onnx_op="ReduceMin")
 @tf_op("Max", onnx_op="ReduceMax")
 @tf_op("Mean", onnx_op="ReduceMean")
-@tf_op("Sum", onnx_op="ReduceSum")
+@tf_op("Min", onnx_op="ReduceMin")
 @tf_op("Prod", onnx_op="ReduceProd")
+@tf_op("Sum", onnx_op="ReduceSum")
 class ReduceOpBase:
     @classmethod
     def version_1(cls, ctx, node, **kwargs):
@@ -66,6 +66,20 @@ class ReduceOpBase:
                 ctx.insert_new_node_on_input(node, "Reshape", [node.input[1], new_shape.output[0]])
         else:
             cls.version_11(ctx, node, **kwargs)
+
+    @classmethod
+    def version_18(cls, ctx, node, **kwargs):
+        keep_dims = node.get_attr_value("keep_dims", 0)
+        node.set_attr("keepdims", keep_dims)
+        del node.attr['keep_dims']
+        node.set_attr("noop_with_empty_axes", 1)
+        if ctx.get_dtype(node.input[1]) != onnx_pb.TensorProto.INT64:
+            ctx.insert_new_node_on_input(node, "Cast", node.input[1], to=onnx_pb.TensorProto.INT64)
+        input_shape = ctx.get_shape(node.input[1])
+        input_rank = len(input_shape) if input_shape is not None else None
+        if input_rank != 1:
+            new_shape = ctx.make_const(utils.make_name("reshape_const"), np.array([-1], np.int64))
+            ctx.insert_new_node_on_input(node, "Reshape", [node.input[1], new_shape.output[0]])
 
 @tf_op(["ArgMax", "ArgMin"])
 class ArgMax:
@@ -240,9 +254,9 @@ class SegmentSum():
                 identity_value = np.iinfo(data_np_dtype).max
 
         if not num_segments_specified:
-            max_segment = ctx.make_node("ReduceMax", [segment_inp], attr={'axes': [0], 'keepdims': 0})
+            max_segment = GraphBuilder(ctx).make_reduce_max({"data": segment_inp, "axes": [0], "keepdims": 0})
             one_const = ctx.make_const(utils.make_name("const_one"), np.array(1, dtype=seg_np_dtype))
-            num_segments = ctx.make_node("Add", [max_segment.output[0], one_const.output[0]]).output[0]
+            num_segments = ctx.make_node("Add", [max_segment, one_const.output[0]]).output[0]
         num_segments_unsq = GraphBuilder(ctx).make_unsqueeze({'data': num_segments, 'axes': [0]})
 
         seg_shape = ctx.make_node("Shape", [segment_inp]).output[0]
@@ -255,7 +269,7 @@ class SegmentSum():
         seg_unique_node.output[1] = ""
         seg_values, _, inv_indices, seg_cnts_sorted = seg_unique_node.output
 
-        max_cnt = ctx.make_node("ReduceMax", [seg_cnts_sorted], attr={'axes': [0], 'keepdims': True}).output[0]
+        max_cnt = GraphBuilder(ctx).make_reduce_max({"data": seg_cnts_sorted, "axes": [0], "keepdims": True})
 
         if node.type in ["SegmentMean", "SegmentSqrtN"]:
             zero_tensor = helper.make_tensor("value", onnx_pb.TensorProto.INT64, dims=[1], vals=[0])
@@ -307,10 +321,10 @@ class SegmentSum():
         data_grid = ctx.make_node("Gather", [data_with_id, scatted_grid]).output[0]
         if onnx_op == "ReduceSum":
             reduction_result = GraphBuilder(ctx).make_reduce_sum(
-                {'data': data_grid, 'axes': [1], "keepdims": False}, op_name_scope=node.name)
+                {"data": data_grid, "axes": [1], "keepdims": False}, op_name_scope=node.name)
         else:
-            reduction_result = ctx.make_node(
-                onnx_op, [data_grid], attr={'axes': [1], 'keepdims': False}, op_name_scope=node.name).output[0]
+            reduction_result = GraphBuilder(ctx)._make_reduce_op(
+                onnx_op, 18, {"data": data_grid, "axes": [1], "keepdims": False}, op_name_scope=node.name)
         if scaling_amt is not None:
             if data_rank is None:
                 # Left pad scale to match data rank

--- a/tf2onnx/onnx_opset/reduction.py
+++ b/tf2onnx/onnx_opset/reduction.py
@@ -17,7 +17,7 @@ from tf2onnx.graph_builder import GraphBuilder
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument,missing-docstring
+# pylint: disable=unused-argument,missing-docstring,protected-access
 
 @tf_op("Max", onnx_op="ReduceMax")
 @tf_op("Mean", onnx_op="ReduceMean")

--- a/tf2onnx/onnx_opset/rnn.py
+++ b/tf2onnx/onnx_opset/rnn.py
@@ -92,7 +92,7 @@ class LSTMBlockCell:
         w_last_dim = int(w_shape[1] / 4)
         split_output_node = ctx.make_node(
             "Split", [merged_output_node.output[0]],
-            attr={"axis": 1},
+            attr={"axis": 1, 'num_outputs': 4},
             output_count=4
         )
         i, ci, f, o = split_output_node.output

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -2477,7 +2477,7 @@ def ragged_lengths_to_sparse_indices(ctx, ragged_lens):
 
 def ragged_row_ids_to_sparse_indices(ctx, row_ids):
     _, indices, _, counts = ctx.make_node("Unique", [row_ids], attr={'axis': 0}, output_count=4).output
-    num_cols = ctx.make_node("ReduceMax", [counts], attr={'axes': [0], 'keepdims': True}).output[0]
+    num_cols = GraphBuilder(ctx).make_reduce_max({"data": counts, "axes": [0], "keepdims": True})
     const_one = ctx.make_const(utils.make_name("const_one"), np.array(1, np.int64)).output[0]
     const_zero_unsq = ctx.make_const(utils.make_name("const_zero"), np.array([0], np.int64)).output[0]
     const_zero = ctx.make_const(utils.make_name("const_zero"), np.array(0, np.int64)).output[0]

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -2600,7 +2600,8 @@ class RaggedTensorToTensor:
             out_shape = ctx.make_node("Where", [unspec_dims, dense_shape, shape]).output[0]
             out_shape_unsq = GraphBuilder(ctx).make_unsqueeze({'data': out_shape, 'axes': [0]})
             amt_idx_in_bounds = ctx.make_node("Sub", [out_shape_unsq, sparse_indices]).output[0]
-            amt_in_bounds_flat = GraphBuilder(ctx).make_reduce_min({"data": amt_idx_in_bounds, "axes": [1], "keepdims": False})
+            amt_in_bounds_flat = GraphBuilder(ctx).make_reduce_min({"data": amt_idx_in_bounds, "axes": [1],
+                                                                    "keepdims": False})
             idx_in_bounds = ctx.make_node("Greater", [amt_in_bounds_flat, const_zero_int64]).output[0]
             sparse_indices = ctx.make_node("Compress", [sparse_indices, idx_in_bounds], attr={'axis': 0}).output[0]
             values = ctx.make_node("Compress", [values, idx_in_bounds], attr={'axis': 0}).output[0]
@@ -3043,7 +3044,8 @@ class DynamicPartition:
         equal_node = ctx.make_node("Equal", [partition_inp, range_const.output[0]])
         # Cast bool to int since ORT doesn't implement Split on bool.
         equal_int32 = ctx.make_node("Cast", [equal_node.output[0]], attr={"to": TensorProto.INT32})
-        split_node = ctx.make_node("Split", [equal_int32.output[0]], output_count=num_partitions, attr={'axis': 0, 'num_outputs': num_partitions})
+        split_node = ctx.make_node("Split", [equal_int32.output[0]], output_count=num_partitions,
+                                   attr={'axis': 0, 'num_outputs': num_partitions})
         for i in range(num_partitions):
             cond_bools = ctx.make_node("Cast", [split_node.output[i]], attr={"to": TensorProto.BOOL})
             squeeze_node = GraphBuilder(ctx).make_squeeze({'data': cond_bools.output[0], "axes": [0]}, return_node=True)
@@ -3593,7 +3595,7 @@ class MatrixDiag:
             diag_shape = mknode("Shape", [diag])
             diag_depth = mknode("Slice", [diag_shape, minus_two, minus_one])
             k = normalize(node.input[1]) if argc > 1 else zeo
-            k_min = GraphBuilder(ctx).make_reduce_min({"data": k}) 
+            k_min = GraphBuilder(ctx).make_reduce_min({"data": k})
             k_max = GraphBuilder(ctx).make_reduce_max({"data": k})
             k_max_nxt = mknode("Add", [k_max, one])
             k_depth = mknode("Sub", [k_max_nxt, k_min])

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -385,7 +385,7 @@ class Roll:
                 {'data': shifts_casted, "axes": [0]}, op_name_scope=node.name, return_node=True)
             shifts_split = [unsqueeze_node.output[0]]
         else:
-            shifts_split = ctx.make_node("Split", [shifts_casted], attr={'axis': 0},
+            shifts_split = ctx.make_node("Split", [shifts_casted], attr={'axis': 0, 'num_outputs': len(axes)},
                                          output_count=len(axes), op_name_scope=node.name).output
 
         zero_const = ctx.make_const(utils.make_name("zeros_const"), np.array([0], np.int64)).output[0]
@@ -681,6 +681,7 @@ class Split:
         # T outputs = Split(T input, @INT axis, @INTS split)
         split_dims = node.inputs[0].get_tensor_value()
         ctx.remove_input(node, node.input[0], 0)
+        node.set_attr("num_outputs", node.get_attr_int("num_split"))
         node.set_attr("axis", split_dims)
 
     @classmethod
@@ -1294,8 +1295,11 @@ class Unpack:
             shape = ctx.get_shape(node.input[0])
             utils.make_sure(shape is not None, "shape of unpack input is None: {}".format(node.input[0]))
             axis += len(shape)
+        num_outputs = node.get_attr_value("num")
         # split the tensor into n outputs
         node.type = "Split"
+        node.set_attr("num_outputs", num_outputs)
+        node.set_attr("axis", axis)
 
         # for each output we need to squeeze axis
         for n in node.output:
@@ -1529,7 +1533,7 @@ class BatchToSpace:
                 reshape = ctx.make_node("Cast",
                                         ctx.make_node("Reshape", inputs=[node.input[2], shape.output[0]]).output,
                                         attr={"to": utils.map_numpy_to_onnx_dtype(np.int64)})
-                crops = ctx.make_node("Split", inputs=reshape.output, attr={}, output_count=4).output
+                crops = ctx.make_node("Split", inputs=reshape.output, attr={'num_outputs': 4}, output_count=4).output
                 zero = ctx.make_const(name=utils.make_name("zero"), np_val=np.array([0], dtype=np.int64)).output[0]
                 int32_max = ctx.make_const(name=utils.make_name("int32_max"),
                                            np_val=np.array([np.iinfo(np.int32).max], dtype=np.int64)).output[0]
@@ -1717,7 +1721,7 @@ class SpaceToBatch:
                 shape = ctx.make_const(name=utils.make_name("shape"), np_val=np.array([-1], dtype=np.int64))
                 reshape = ctx.make_node("Reshape", inputs=[node.input[2], shape.output[0]])
                 cast = ctx.make_node("Cast", reshape.output, attr={'to': utils.map_numpy_to_onnx_dtype(np.int64)})
-                split = ctx.make_node("Split", inputs=cast.output, attr={}, output_count=4)
+                split = ctx.make_node("Split", inputs=cast.output, attr={'num_outputs': 4}, output_count=4)
                 pads = split.output
                 zero = ctx.make_const(name=utils.make_name("zero"), np_val=np.array([0], dtype=np.int64)).output[0]
                 new_pads = ctx.make_node("Concat", [zero, zero, pads[0], pads[2], zero, zero, pads[1], pads[3]],
@@ -2451,7 +2455,7 @@ class SparseToDense:
 
 def ragged_lengths_to_sparse_indices(ctx, ragged_lens):
     const_zero_int64 = ctx.make_const(utils.make_name("const_zero"), np.array(0, dtype=np.int64)).output[0]
-    num_cols = ctx.make_node("ReduceMax", [ragged_lens], attr={'axes': [0], 'keeepdims': True}).output[0]
+    num_cols = GraphBuilder(ctx).make_reduce_max({"data": ragged_lens, "axes": [0], "keepdims": True})
     num_rows = ctx.make_node("Shape", [ragged_lens]).output[0]
     range_len = ctx.make_node("Mul", [num_cols, num_rows]).output[0]
 
@@ -2596,8 +2600,8 @@ class RaggedTensorToTensor:
             out_shape = ctx.make_node("Where", [unspec_dims, dense_shape, shape]).output[0]
             out_shape_unsq = GraphBuilder(ctx).make_unsqueeze({'data': out_shape, 'axes': [0]})
             amt_idx_in_bounds = ctx.make_node("Sub", [out_shape_unsq, sparse_indices]).output[0]
-            amt_in_bounds_flat = ctx.make_node("ReduceMin", [amt_idx_in_bounds], attr={'axes': [1], 'keepdims': False})
-            idx_in_bounds = ctx.make_node("Greater", [amt_in_bounds_flat.output[0], const_zero_int64]).output[0]
+            amt_in_bounds_flat = GraphBuilder(ctx).make_reduce_min({"data": amt_idx_in_bounds, "axes": [1], "keepdims": False})
+            idx_in_bounds = ctx.make_node("Greater", [amt_in_bounds_flat, const_zero_int64]).output[0]
             sparse_indices = ctx.make_node("Compress", [sparse_indices, idx_in_bounds], attr={'axis': 0}).output[0]
             values = ctx.make_node("Compress", [values, idx_in_bounds], attr={'axis': 0}).output[0]
         else:
@@ -2814,8 +2818,8 @@ class SparseReshape:
     def any_version(cls, opset, ctx, node, **kwargs):
         indices_inp, shape_inp, new_shape_inp = node.input
 
-        product_curr_dims = ctx.make_node("ReduceProd", [shape_inp], attr={'axes': [0], 'keepdims': 1}).output[0]
-        product_new_dims = ctx.make_node("ReduceProd", [new_shape_inp], attr={'axes': [0], 'keepdims': 1}).output[0]
+        product_curr_dims = GraphBuilder(ctx).make_reduce_prod({"data": shape_inp, "axes": [0], "keepdims": 1})
+        product_new_dims = GraphBuilder(ctx).make_reduce_prod({"data": new_shape_inp, "axes": [0], "keepdims": 1})
         neg_missing_dims = ctx.make_node("Div", [product_curr_dims, product_new_dims]).output[0]
         pos_missing_dims = ctx.make_node("Neg", [neg_missing_dims]).output[0]
         zero_const = ctx.make_const(utils.make_name("cosnt_zero"), np.array(0, dtype=np.int64)).output[0]
@@ -2841,7 +2845,7 @@ class SparseReshape:
                 lower_triangular_bool = ctx.make_node("Cast", [lower_triangular],
                                                       attr={'to': TensorProto.BOOL}).output[0]
             terms = ctx.make_node("Where", [lower_triangular_bool, one_const, vector]).output[0]
-            return ctx.make_node("ReduceProd", [terms], attr={'axes': [1], 'keepdims': 0}).output[0]
+            return GraphBuilder(ctx).make_reduce_prod({"data": terms, "axes": [1], "keepdims": 0})
 
         cum_prod_curr_shape = cum_prod_of_vector(shape_inp)
         cum_prod_new_shape = cum_prod_of_vector(new_shape)
@@ -3005,7 +3009,7 @@ class DenseToDenseSetOperation:
         _, idx_loc, _, idx_cnts, = ctx.make_node("Unique", [merged_indices], attr={'axis': 0},
                                                  output_count=4, op_name_scope=node.name).output
 
-        max_cnt = ctx.make_node("ReduceMax", [idx_cnts], attr={'axes': [0], 'keepdims': True}).output[0]
+        max_cnt = GraphBuilder(ctx).make_reduce_max({"data": idx_cnts, "axes": [0], "keepdims": True})
         final_shape = ctx.make_node("Concat", [shape_prefix, max_cnt], attr={'axis': 0}).output[0]
         one_minus_cnts = ctx.make_node("Sub", [const_one, idx_cnts]).output[0]
         cnts_sliced = GraphBuilder(ctx).make_slice(
@@ -3039,7 +3043,7 @@ class DynamicPartition:
         equal_node = ctx.make_node("Equal", [partition_inp, range_const.output[0]])
         # Cast bool to int since ORT doesn't implement Split on bool.
         equal_int32 = ctx.make_node("Cast", [equal_node.output[0]], attr={"to": TensorProto.INT32})
-        split_node = ctx.make_node("Split", [equal_int32.output[0]], output_count=num_partitions, attr={'axis': 0})
+        split_node = ctx.make_node("Split", [equal_int32.output[0]], output_count=num_partitions, attr={'axis': 0, 'num_outputs': num_partitions})
         for i in range(num_partitions):
             cond_bools = ctx.make_node("Cast", [split_node.output[i]], attr={"to": TensorProto.BOOL})
             squeeze_node = GraphBuilder(ctx).make_squeeze({'data': cond_bools.output[0], "axes": [0]}, return_node=True)
@@ -3589,7 +3593,8 @@ class MatrixDiag:
             diag_shape = mknode("Shape", [diag])
             diag_depth = mknode("Slice", [diag_shape, minus_two, minus_one])
             k = normalize(node.input[1]) if argc > 1 else zeo
-            k_min, k_max = mknode("ReduceMin", [k]), mknode("ReduceMax", [k])
+            k_min = GraphBuilder(ctx).make_reduce_min({"data": k}) 
+            k_max = GraphBuilder(ctx).make_reduce_max({"data": k})
             k_max_nxt = mknode("Add", [k_max, one])
             k_depth = mknode("Sub", [k_max_nxt, k_min])
             equal = mknode("Equal", [k_depth, diag_depth])
@@ -3639,7 +3644,7 @@ class MatrixDiag:
         diag_depth = mknode("Slice", [diag_shape, minus_two, minus_one])
         k_range = mknode("Range", [squeeze(k_min), squeeze(k_max_nxt), squeeze(one)])
         abs_k_range = mknode("Abs", [k_range])
-        min_k2zeo = mknode("ReduceMin", [abs_k_range])
+        min_k2zeo = GraphBuilder(ctx).make_reduce_min({"data": abs_k_range})
         max_diag_len = mknode("Add", [min_k2zeo, diag_width])
 
         def outrowcol():

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -828,7 +828,8 @@ class TransposeOptimizer(GraphOptimizerBase):
         # when the second input is not a constant, let's shuffle it with Split followed by Concat
         # there are examples of models, where this non-constant input
         # gets constant folded anyway by a framework.
-        split = self._g.make_node("Split", inputs=[node.input[1]], attr={'num_outputs': trans_rank * 2}, output_count=trans_rank * 2)
+        split = self._g.make_node("Split", inputs=[node.input[1]], attr={'num_outputs': trans_rank * 2},
+                                  output_count=trans_rank * 2)
         pads = split.output
         new_pads = self._g.make_node("Concat", permute_pads(pads), {'axis': 0})
         self._g.replace_input(node, node.input[1], new_pads.output[0], 1)

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -828,7 +828,7 @@ class TransposeOptimizer(GraphOptimizerBase):
         # when the second input is not a constant, let's shuffle it with Split followed by Concat
         # there are examples of models, where this non-constant input
         # gets constant folded anyway by a framework.
-        split = self._g.make_node("Split", inputs=[node.input[1]], attr={}, output_count=trans_rank * 2)
+        split = self._g.make_node("Split", inputs=[node.input[1]], attr={'num_outputs': trans_rank * 2}, output_count=trans_rank * 2)
         pads = split.output
         new_pads = self._g.make_node("Concat", permute_pads(pads), {'axis': 0})
         self._g.replace_input(node, node.input[1], new_pads.output[0], 1)
@@ -862,13 +862,13 @@ class TransposeOptimizer(GraphOptimizerBase):
     def _arg_min_max_handler(self, trans, node):
         axis = node.get_attr_value("axis", 0)
         node.set_attr("axes", [axis])
-        result = self._reduce_handler(trans, node)
+        result = self._reduce_base_handler(trans, node)
         new_axis = node.get_attr_value("axes")[0]
         node.set_attr("axis", new_axis)
         del node.attr["axes"]
         return result
 
-    def _reduce_handler(self, trans, node):
+    def _reduce_base_handler(self, trans, node):
         keepdims = node.get_attr_value("keepdims", 1)
         trans_rank = get_transpose_rank(trans)
         axes = node.get_attr_value("axes", list(range(trans_rank)))
@@ -896,25 +896,8 @@ class TransposeOptimizer(GraphOptimizerBase):
             trans.set_attr("perm", new_perm)
         return True
 
-    def _tile_handler(self, trans, node):
-        if not node.inputs[1].is_const():
-            return False
-        if not self._switch_transpose_and_node(node, trans):
-            return False
-        repeats = node.inputs[1].get_tensor_value()
-        perm_inv = invert_perm(trans.get_attr_value("perm"))
-        repeats_val = [repeats[p] for p in perm_inv]
-        new_repeats = np.array(repeats_val, dtype=np.int64)
-        if not self._nodes_has_single_consumer_node([node.inputs[1]]):
-            new_inp = self._g.copy_const(node.inputs[1])
-            self._g.replace_input(node, node.input[1], new_inp.output[0], 1)
-        node.inputs[1].set_tensor_value(new_repeats)
-        return True
-
-    def _reducesum_handler(self, trans, node):
+    def _reduce_latest_handler(self, trans, node):
         keepdims = node.get_attr("keepdims")
-        if self._g.opset <= 12:
-            return self._reduce_handler(trans, node)
         if keepdims and keepdims.i == 0:
             return False
         if node.inputs[1].is_const():
@@ -931,6 +914,31 @@ class TransposeOptimizer(GraphOptimizerBase):
                 self._g.replace_input(node, node.input[1], new_axes_const.output[0], 1)
             return self._switch_transpose_and_node(node, trans)
         return False
+
+    def _reduce_handler(self, trans, node):
+        if self._g.opset < 18:
+            return self._reduce_base_handler(trans, node)
+        return self._reduce_latest_handler(trans, node)
+
+    def _tile_handler(self, trans, node):
+        if not node.inputs[1].is_const():
+            return False
+        if not self._switch_transpose_and_node(node, trans):
+            return False
+        repeats = node.inputs[1].get_tensor_value()
+        perm_inv = invert_perm(trans.get_attr_value("perm"))
+        repeats_val = [repeats[p] for p in perm_inv]
+        new_repeats = np.array(repeats_val, dtype=np.int64)
+        if not self._nodes_has_single_consumer_node([node.inputs[1]]):
+            new_inp = self._g.copy_const(node.inputs[1])
+            self._g.replace_input(node, node.input[1], new_inp.output[0], 1)
+        node.inputs[1].set_tensor_value(new_repeats)
+        return True
+
+    def _reducesum_handler(self, trans, node):
+        if self._g.opset < 13:
+            return self._reduce_base_handler(trans, node)
+        return self._reduce_latest_handler(trans, node)
 
     def _slice_handler(self, trans, node):
         axes = None

--- a/tf2onnx/symbolic_executor.py
+++ b/tf2onnx/symbolic_executor.py
@@ -146,7 +146,10 @@ class SymbolicExecutor:
 
     def compute_reduceprod(self, node, feed_dict):
         inp = feed_dict[node.input[0]]
-        axes = node.get_attr_value("axes")
+        if self.graph.opset < 18:
+            axes = node.get_attr_value("axes")
+        else:
+            axes = feed_dict[node.input[1]]
         keepdims = node.get_attr_value("keepdims", 1)
         return [np.prod(inp, axis=tuple(axes), keepdims=keepdims)]
 


### PR DESCRIPTION
1. Update Split op for the latest changes in opset 18: Either split or num_outputs need to be added to the node.
2. Update Reduce* ops for the latest changes in opset 18: 'axes' has been changed from an attribute to an input.
3. Update relative tests.
4. Enable opset 18 in CI tests.
5. Fix #2141 
6. Fix #2132 