### PR TITLE
feat: add support for ExtractImagePatches

### DIFF
--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -2105,7 +2105,19 @@ class ExtractImagePatches:
         rates = node.get_attr_value("rates")
         padding = node.get_attr_str("padding")
 
-        # Our constraints.
+        # This implementation of ExtractImagePatches does not generalize
+        # to outputs that are empty. For example:
+        #
+        #   tf.image.extract_patches(
+        #     np.random.rand(1, 1, 1, 1), sizes=[1, 2, 2, 1], strides=[1, 1, 1, 1],
+        #     rates=[1, 1, 1, 1], padding="VALID"
+        #   )
+        #
+        # succeeds with the output of:
+        #
+        #   <tf.Tensor: shape=(1, 0, 0, 4), dtype=float64, numpy=array([], shape=(1, 0, 0, 4), dtype=float64)>
+        #
+        # whereas attempting the same here results in an "Invalid input shape" error for the "Conv" node.
         utils.make_sure(0 not in output_shape, "Empty ExtractImagePatches output is unsupported.")
         [_, size_rows, size_cols, _] = sizes
 

--- a/tf2onnx/onnx_opset/nn.py
+++ b/tf2onnx/onnx_opset/nn.py
@@ -2091,3 +2091,81 @@ class CTCGreedyDecoder:
         ctx.replace_all_inputs(node.output[3], sum_max_neg)
 
         ctx.remove_node(node.name)
+
+
+@tf_op("ExtractImagePatches")
+class ExtractImagePatches:
+    @classmethod
+    def version_9(cls, ctx, node, **kwargs):
+        input_shape = ctx.get_shape(node.input[0])
+        output_shape = node.output_shapes[0]
+
+        sizes = node.get_attr_value("ksizes")
+        strides = node.get_attr_value("strides")
+        rates = node.get_attr_value("rates")
+        padding = node.get_attr_str("padding")
+
+        # Our constraints.
+        utils.make_sure(0 not in output_shape, "Empty ExtractImagePatches output is unsupported.")
+        [_, size_rows, size_cols, _] = sizes
+
+        # Transform input into [N * C, H, W, 1].
+        transformed_input = ctx.make_node("Reshape", inputs=[
+            ctx.make_node("Transpose", inputs=node.input, attr=dict(perm=[0, 3, 1, 2])).output[0],
+            ctx.make_const(utils.make_name("new_shape"), np.int64([
+                input_shape[0] * input_shape[3],
+                input_shape[1],
+                input_shape[2],
+                1,
+            ])).output[0],
+        ])
+
+        # Create identity kernel.
+        k = size_rows * size_cols
+        identity_kernel = ctx.make_node("Reshape", inputs=[
+            ctx.make_node("EyeLike", inputs=[
+                ctx.make_node("ConstantOfShape", inputs=[
+                    ctx.make_const(utils.make_name("eye_size"), np.array([k, k], dtype=np.int64)).output[0],
+                ]).output[0],
+            ]).output[0],
+            ctx.make_const(utils.make_name("new_shape"), np.array([
+                size_rows,
+                size_cols,
+                1,
+                k,
+            ], dtype=np.int64)).output[0],
+        ])
+
+        # Construct placeholder convolution node and transform into [N * C, K, ?H, ?W].
+        convolution = ctx.make_node("Conv", inputs=[transformed_input.output[0], identity_kernel.output[0]],
+                                    shapes=[[input_shape[0] * input_shape[3], output_shape[1], output_shape[2], k]],
+                                    attr=dict(strides=strides, dilations=rates, padding=padding, data_format="NHWC"),
+                                    dtypes=node.output_dtypes)
+
+        # Transform into [N, ?H, ?W, C * K].
+        output_node = ctx.make_node("Reshape", inputs=[
+            ctx.make_node("Transpose", inputs=[
+                ctx.make_node("Reshape", inputs=[
+                    convolution.output[0],
+                    ctx.make_const(utils.make_name("new_shape"), np.array([
+                        input_shape[0],
+                        input_shape[3],
+                        output_shape[1],
+                        output_shape[2],
+                        k,
+                    ], dtype=np.int64)).output[0],
+                ]).output[0],
+            ], attr=dict(perm=[0, 2, 3, 4, 1])).output[0],
+            ctx.make_const(utils.make_name("new_shape"), np.array(output_shape, dtype=np.int64)).output[0],
+        ])
+
+        # Replace original node.
+        ctx.replace_all_inputs(node.output[0], output_node.output[0])
+        ctx.remove_node(node.name)
+
+        # Transform convolution node.
+        kernel_shape = conv_kernel_shape(ctx, convolution, 1)
+        strides = conv_dims_attr(convolution, "strides")
+        dilations = conv_dims_attr(convolution, "dilations")
+        add_padding(ctx, convolution, kernel_shape, strides, dilations)
+        conv_convert_inputs(ctx, convolution, with_kernel=True)


### PR DESCRIPTION
Closes: https://github.com/onnx/tensorflow-onnx/issues/436

This rewrite is based on this comment: https://github.com/onnx/tensorflow-onnx/issues/436#issuecomment-993313423 with changes to make it more general and translatable into `tf2onnx`.

<details>
<summary>Equivalent TensorFlow function and automated test script (expand)</summary>

```python3
import tensorflow as tf
import numpy as np
from hypothesis import given, strategies as st, settings, assume


def our_extract_image_patches(sizes, strides, rates, padding):
    # TensorFlow's constraints.
    assert sizes[0] == 1 and sizes[3] == 1
    assert strides[0] == 1 and strides[3] == 1
    assert rates[0] == 1 and rates[3] == 1
    assert padding in ["SAME", "VALID"]

    # Extract size.
    [_, size_rows, size_cols, _] = sizes

    @tf.function
    def function(tensor):
        # Input shape of [N, H, W, C].
        tensor_shape = tensor.shape

        # Transpose and reshape to [N * C, H, W, 1].
        tensor = tf.transpose(tensor, perm=[0, 3, 1, 2])
        tensor = tf.reshape(tensor, [
            tensor_shape[0] * tensor_shape[3],
            tensor_shape[1],
            tensor_shape[2],
            1,
        ])

        # Convolve with identity kernel into [N * C, ?H, ?W, K].
        k = size_rows * size_cols
        kernel = tf.reshape(tf.eye(k), [size_rows, size_cols, 1, k])
        convolution = tf.nn.conv2d(tensor, kernel, strides=strides, padding=padding, dilations=rates)

        # Reshape into [N, C, ?H, ?W, K].
        reshaped = tf.reshape(convolution, [
            tensor_shape[0],
            tensor_shape[3],
            convolution.shape[1],
            convolution.shape[2],
            k,
        ])

        # Transpose and reshape into [N, ?H, ?W, C * K].
        patches = tf.transpose(reshaped, perm=[0, 2, 3, 4, 1])
        return tf.reshape(patches, [
            tensor_shape[0],
            convolution.shape[1],
            convolution.shape[2],
            tensor_shape[3] * k,
        ])

    return function


def tf_extract_image_patches(sizes, strides, rates, padding):
    @tf.function
    def function(tensor):
        return tf.image.extract_patches(
            tensor,
            sizes=sizes,
            strides=strides,
            rates=rates,
            padding=padding,
        )

    return function


@settings(max_examples=5000)
@given(
    st.lists(st.integers(min_value=1, max_value=20), min_size=4, max_size=4),
    st.integers(min_value=1, max_value=20),
    st.integers(min_value=1, max_value=20),
    st.integers(min_value=1, max_value=20),
    st.integers(min_value=1, max_value=20),
    st.integers(min_value=1, max_value=20),
    st.integers(min_value=1, max_value=20),
    st.sampled_from(["VALID", "SAME"]),
)
def test_equal(shape, size_rows, size_cols, stride_rows, stride_cols, dil_rows, dil_cols, padding):
    sizes = [1, size_rows, size_cols, 1]
    strides = [1, stride_rows, stride_cols, 1]
    rates = [1, dil_rows, dil_cols, 1]

    try:
        tensor = tf.cast(tf.reshape(tf.range(np.prod(shape)), shape), dtype=tf.float32)
        tfs = tf_extract_image_patches(sizes, strides, rates, padding)(tensor)

        if 0 in tfs.shape:
            # We cannot handle operations that produce empty outputs.
            assume(False)
    except ValueError:
        # Ignore input if TensorFlow would fail.
        assume(False)
        return

    ours = our_extract_image_patches(sizes, strides, rates, padding)(tensor)
    assert tf.reduce_all(tf.math.equal(tfs, ours)).numpy()
```
</details>

Output from `pytest convolve.py --hypothesis-show-statistics` (no failures):
```
convolve.py::test_equal:

  - during generate phase (70.74 seconds):
    - Typical runtimes: ~ 1-14 ms, of which < 1ms in data generation
    - 5000 passing examples, 0 failing examples, 3913 invalid examples

  - Stopped because settings.max_examples=5000
```