### PR TITLE
Fix QAT model converting

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3150,6 +3150,19 @@ class BackendTests(Tf2OnnxBackendTestBase):
 
     @check_tf_min_version("1.15")
     @check_opset_min_version(10, "quantize_and_dequantize")
+    def test_qdq_signed_input_narrow_range(self):
+        x_shape = [3, 3, 2]
+        x_val = np.arange(-np.prod(x_shape)/2, np.prod(x_shape)/2).astype("float32").reshape(x_shape)
+        min_x = np.min(x_val)
+        max_x = np.max(x_val)
+        def func(x):
+            x_ = quantize_and_dequantize(x, min_x, max_x, signed_input=True, narrow_range=True, range_given=True)
+            return tf.identity(x_, name=_TFOUTPUT)
+        _ = self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
+
+
+    @check_tf_min_version("1.15")
+    @check_opset_min_version(10, "quantize_and_dequantize")
     def test_qdq_optimizer(self):
         x_shape = [3, 3, 2]
         x_val = np.arange(1, 1+np.prod(x_shape)).astype("float32").reshape(x_shape)

--- a/tf2onnx/tf_utils.py
+++ b/tf2onnx/tf_utils.py
@@ -221,7 +221,7 @@ def compute_const_folding_using_tf(g, const_node_values, graph_outputs):
                     progress = True
             can_fold = node.type not in ['Enter', 'Placeholder', 'PlaceholderWithDefault', 'Switch', 'Merge',
                                          'NextIteration', 'Exit', 'QuantizeAndDequantizeV2', 'QuantizeAndDequantizeV3',
-                                         'QuantizeAndDequantizeV4']
+                                         'QuantizeAndDequantizeV4', 'FakeQuantWithMinMaxVars']
             can_fold = can_fold and not node.type.startswith('Random')
             can_fold = can_fold and len(input_names) > 0 and all(inp in outputs_to_values for inp in input_names)
             # We can only fold nodes with a single output


### PR DESCRIPTION
Convert quantization aware trained model from TF to ONNX has several issues -- 
1. `QuantizeLinear` and `DequantizeLinear` are fused into conv layer, but the downstream compiler(e.g., TensorRT) needs the Q/DQ layers to determine whether to use int8 or not. See issue #1972 .  We need to keep Q/DQ layer unfused. QuantizeLinear and DequantizeLinear are corresponding to `FakeQuantWithMinMaxVars` in TensorFlow, so excluding it from `can_fold` in `tf_utils.py` can solve it. 
2. Need to allow `narrow_range` in quantized nodes. TensorRT maps [min, max] to [-127, 127](see [Page 12](https://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf)) , which needs 0 in fp32 to be mapped to 0 in int8. Also see [narrow_range=True ](https://github.com/NVIDIA/TensorRT/blob/main/tools/tensorflow-quantization/tensorflow_quantization/__init__.py#L19-L21)in TensorRT/tools/tensorflow-quantization here. 