### PR TITLE
Support bitwise ops

### DIFF
--- a/support_status.md
+++ b/support_status.md
@@ -32,6 +32,9 @@
 | BiasAdd | 1 ~ 17 |
 | BiasAddV1 | 1 ~ 17 |
 | Bincount | 11 ~ 17 |
+| BitwiseAnd | 18 |
+| BitwiseOr | 18 |
+| BitwiseXor | 18 |
 | BroadcastTo | 8 ~ 17 |
 | CTCGreedyDecoder | 11 ~ 17 |
 | Cast | 1 ~ 17 |
@@ -93,6 +96,7 @@
 | Identity | 1 ~ 17 |
 | IdentityN | 1 ~ 17 |
 | If | 1 ~ 17 |
+| Invert | 18 |
 | InvertPermutation | 11 ~ 17 |
 | IsFinite | 10 ~ 17 |
 | IsInf | 10 ~ 17 |

--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -58,7 +58,7 @@ def get_img(shape, path, dtype, should_scale=True):
     resize_to = shape[1:3]
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
     img = PIL.Image.open(path)
-    img = img.resize(resize_to, PIL.Image.ANTIALIAS)
+    img = img.resize(resize_to, PIL.Image.LANCZOS)
     img_np = np.array(img).astype(dtype)
     img_np = np.stack([img_np] * shape[0], axis=0).reshape(shape)
     if should_scale:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4895,7 +4895,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = tf.bitwise.right_shift(x, 1)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
-    
+
     @check_opset_min_version(18, "BitwiseAnd")
     def test_bitwise_and(self):
         x_val = np.array([21, 4, 1], dtype=np.int32)
@@ -4904,7 +4904,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = tf.bitwise.bitwise_and(x, y)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
-    
+
     @check_opset_min_version(18, "BitwiseOr")
     def test_bitwise_or(self):
         x_val = np.array([21, 4, 87], dtype=np.int32)
@@ -4913,7 +4913,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = tf.bitwise.bitwise_or(x, y)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
-    
+
     @check_opset_min_version(18, "BitwiseXor")
     def test_bitwise_xor(self):
         x_val = np.array([21, 4, 87], dtype=np.int32)
@@ -4922,7 +4922,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = tf.bitwise.bitwise_xor(x, y)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
-    
+
     @check_opset_min_version(18, "BitwiseNot")
     def test_bitwise_not(self):
         x_val = np.array([21, 4, 1], dtype=np.int32)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4906,7 +4906,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
     
     @check_opset_min_version(18, "BitwiseOr")
-    def test_bitwise_and(self):
+    def test_bitwise_or(self):
         x_val = np.array([21, 4, 87], dtype=np.int32)
         y_val = np.array([45, 69, 173], dtype=np.int32)
         def func(x, y):
@@ -4915,7 +4915,7 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
     
     @check_opset_min_version(18, "BitwiseXor")
-    def test_bitwise_and(self):
+    def test_bitwise_xor(self):
         x_val = np.array([21, 4, 87], dtype=np.int32)
         y_val = np.array([45, 69, 173], dtype=np.int32)
         def func(x, y):
@@ -4924,10 +4924,10 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
     
     @check_opset_min_version(18, "BitwiseNot")
-    def test_bitwise_and(self):
+    def test_bitwise_not(self):
         x_val = np.array([21, 4, 1], dtype=np.int32)
         def func(x):
-            x_ = tf.bitwise.bitwise_not(x)
+            x_ = tf.bitwise.invert(x)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4895,6 +4895,41 @@ class BackendTests(Tf2OnnxBackendTestBase):
             x_ = tf.bitwise.right_shift(x, 1)
             return tf.identity(x_, name=_TFOUTPUT)
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
+    
+    @check_opset_min_version(18, "BitwiseAnd")
+    def test_bitwise_and(self):
+        x_val = np.array([21, 4, 1], dtype=np.int32)
+        y_val = np.array([45, 69, 3], dtype=np.int32)
+        def func(x, y):
+            x_ = tf.bitwise.bitwise_and(x, y)
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
+    
+    @check_opset_min_version(18, "BitwiseOr")
+    def test_bitwise_and(self):
+        x_val = np.array([21, 4, 87], dtype=np.int32)
+        y_val = np.array([45, 69, 173], dtype=np.int32)
+        def func(x, y):
+            x_ = tf.bitwise.bitwise_or(x, y)
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
+    
+    @check_opset_min_version(18, "BitwiseXor")
+    def test_bitwise_and(self):
+        x_val = np.array([21, 4, 87], dtype=np.int32)
+        y_val = np.array([45, 69, 173], dtype=np.int32)
+        def func(x, y):
+            x_ = tf.bitwise.bitwise_xor(x, y)
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val, _INPUT1: y_val})
+    
+    @check_opset_min_version(18, "BitwiseNot")
+    def test_bitwise_and(self):
+        x_val = np.array([21, 4, 1], dtype=np.int32)
+        def func(x):
+            x_ = tf.bitwise.bitwise_not(x)
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val})
 
     @check_tf_min_version("1.14", "tensor_scatter_nd_update needs tf 1.14")
     @check_opset_min_version(11, "ScatterND")

--- a/tf2onnx/onnx_opset/math.py
+++ b/tf2onnx/onnx_opset/math.py
@@ -792,7 +792,6 @@ class Det:
 
 @tf_op(["LeftShift", "RightShift"])
 class BitShift:
-
     @classmethod
     def version_11(cls, ctx, node, **kwargs):
         dir_map = {"LeftShift": "LEFT", "RightShift": "RIGHT"}
@@ -816,6 +815,16 @@ class BitShift:
             ctx.set_dtype(cast_back_node.output[0], dtypes[0])
             ctx.copy_shape(node.name, cast_back_node.output[0])
             ctx.copy_dtype(node.input[0], node.output[0])
+
+
+@tf_op("BitwiseAnd")
+@tf_op("BitwiseOr")
+@tf_op("BitwiseXor")
+@tf_op("Invert", onnx_op="BitwiseNot")
+class BitwiseOps:
+    @classmethod
+    def version_18(cls, ctx, node, **kwargs):
+        pass
 
 
 @tf_op("SquaredDistance", onnx_op="MeanSquaredDistance")


### PR DESCRIPTION
Support the following bitwise ops with ONNX opset 18:

- tf.bitwise.bitwise_and
- tf.bitwise.bitwise_or
- tf.bitwise.bitwise_xor
- tf.bitwise.invert
