### PR TITLE
Use TFLite Interpreter's public instead of private API to get tensor details

### DIFF
--- a/tests/backend_test_base.py
+++ b/tests/backend_test_base.py
@@ -28,7 +28,6 @@ from tf2onnx.tf_loader import tf_reset_default_graph, tf_session, tf_placeholder
 from tf2onnx.tf_loader import tf_optimize, is_tf2, get_hash_table_info
 from tf2onnx.tf_utils import compress_graph_def
 from tf2onnx.graph import ExternalTensorStorage
-from tf2onnx.tflite.Model import Model
 
 
 if is_tf2():
@@ -249,14 +248,10 @@ class Tf2OnnxBackendTestBase(unittest.TestCase):
 
     def tflite_has_supported_types(self, tflite_path):
         try:
-            with open(tflite_path, 'rb') as f:
-                buf = f.read()
-            buf = bytearray(buf)
-            model = Model.GetRootAsModel(buf, 0)
-            tensor_cnt = model.Subgraphs(0).TensorsLength()
             interpreter = tf.lite.Interpreter(tflite_path)
-            for i in range(tensor_cnt):
-                dtype = interpreter._get_tensor_details(i)['dtype']   # pylint: disable=protected-access
+            tensor_details = interpreter.get_tensor_details()
+            for tensor_detail in tensor_details:
+                dtype = tensor_detail.get('dtype')
                 if np.dtype(dtype).kind == 'O':
                     return False
             return True

--- a/tf2onnx/tflite_utils.py
+++ b/tf2onnx/tflite_utils.py
@@ -196,14 +196,14 @@ def read_tflite_model(tflite_path):
     try:
         interpreter = tf.lite.Interpreter(tflite_path)
         interpreter.allocate_tensors()
-        tensor_cnt = model.Subgraphs(0).TensorsLength()
-        for i in range(tensor_cnt):
-            name = model.Subgraphs(0).Tensors(i).Name().decode()
-            details = interpreter._get_tensor_details(i)   # pylint: disable=protected-access
-            if "shape_signature" in details:
-                tensor_shapes[name] = details["shape_signature"].tolist()
-            elif "shape" in details:
-                tensor_shapes[name] = details["shape"].tolist()
+        tensor_details = interpreter.get_tensor_details()
+
+        for tensor_detail in tensor_details:
+            name = tensor_detail.get('name')
+            if "shape_signature" in tensor_detail:
+                tensor_shapes[name] = tensor_detail["shape_signature"].tolist()
+            elif "shape" in tensor_detail:
+                tensor_shapes[name] = tensor_detail["shape"].tolist()
     except Exception as e:    # pylint: disable=broad-except
         logger.warning("Error loading model into tflite interpreter: %s", e)
     tflite_graphs = get_model_subgraphs(model)


### PR DESCRIPTION
TF-2.12.0 introduced API change that breaks tf2onnx UT tests on the tflite paths, due to the addition of compulsory subgraph arg to several function's input signature:
https://github.com/tensorflow/tensorflow/commit/55d84d7bba942fb4adb552881897c6bbd6e91eef

This commit changes tf2onnx functions that call to TFLite Interpreter class's private `_get_tensor_details`, to instead call its public API `get_tensor_details`. I think the code change is functionality-wise equivalent, from tf2onnx's usage perspective, and circumvent backward comp issue from using a private function.

#2154 