### PR TITLE
Fix nightly test issues.

### DIFF
--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -23,7 +23,8 @@ steps:
 
     if [[ $CI_TF_VERSION == 2.* ]] ;
     then
-      pip install onnxruntime-extensions==0.3.1
+      pip install onnxruntime-extensions
+
       if [[ $CI_TF_VERSION == 2.3* ]] ;
       then
         pip install tensorflow-text==${CI_TF_VERSION}

--- a/tests/test_einsum_optimizers.py
+++ b/tests/test_einsum_optimizers.py
@@ -94,8 +94,9 @@ class EinsumOptimizerTests(Tf2OnnxBackendTestBase):
         new_model_proto = self.run_einsum_compare(["Y"], feed_dict, model_proto,
                                                   catch_errors=catch_errors)
 
-        sess1 = InferenceSession(model_proto.SerializeToString())
-        sess2 = InferenceSession(new_model_proto.SerializeToString())
+        providers = ['CPUExecutionProvider']
+        sess1 = InferenceSession(model_proto.SerializeToString(), providers=providers)
+        sess2 = InferenceSession(new_model_proto.SerializeToString(), providers=providers)
         got1 = sess1.run(None, feed_dict)
         got2 = sess2.run(None, feed_dict)
         assert_almost_equal(got1, got2)


### PR DESCRIPTION
1. Fix installing the fixed version for onnxruntime-extensions in CI.
2. Update inferencesession() function to add providers.