### PR TITLE
Change the way to set node name.

### DIFF
--- a/tf2onnx/tflite_utils.py
+++ b/tf2onnx/tflite_utils.py
@@ -483,6 +483,8 @@ def parse_tflite_graph(tflite_g, opcodes_map, model, input_prefix='', tensor_sha
         if has_prequantized_output:
             output_names = [get_prequant(out) for out in output_names]
         onnx_node = helper.make_node(optype, input_names, output_names, name=output_names[0], **attr)
+        node_name = output_names[0] if output_names else utils.make_name(f"{optype}_Output")
+        onnx_node = helper.make_node(optype, input_names, output_names, name=node_name, **attr)
         onnx_nodes.append(onnx_node)
 
     inputs = [tensor_names[tflite_g.Inputs(i)] for i in range(tflite_g.InputsLength())]


### PR DESCRIPTION
Sometimes, in a tf model to be converted, there are some training ops inside it. And those ops might not have output as others. This fix is going to construct a new name if it's this case. 

This fix won't help to convert those training ops to ONNX ops, but it will help the converting process could end smoothly.

Fix #2275, partially.
