### PR TITLE
fix: make_onnx_node_with_attr() supports empty strings

### DIFF
--- a/tf2onnx/utils.py
+++ b/tf2onnx/utils.py
@@ -198,8 +198,8 @@ def make_onnx_node_with_attr(op_type: str, inputs: Sequence[str], outputs: Seque
         valid_attrs = {}
         if kwargs:
             for key, value in sorted(kwargs.items()):
-                if not isinstance(value, bytes) and \
-                    isinstance(value, collections.abc.Sequence) and len(list(value)) == 0:
+                if not isinstance(value, (bytes, str)) and \
+                    isinstance(value, collections.abc.Iterable) and len(list(value)) == 0:
                     attr_empty_lists[key] = value
                 else:
                     valid_attrs[key] = value


### PR DESCRIPTION
In the current code, the workaround of ONNX 1.15.0's `helper.make_node()` not supporting empty iterators seems incomplete:

In https://github.com/onnx/onnx/blob/8a6b70f0adcff5409b8cd65883bbbea7d6c4f4e1/onnx/helper.py#L901 there is `elif isinstance(value, (str, bytes)):` and in https://github.com/onnx/onnx/blob/8a6b70f0adcff5409b8cd65883bbbea7d6c4f4e1/onnx/helper.py#L918 there is `elif isinstance(value, collections.abc.Iterable):`. 

The result is that empty strings are attempted to be handled as integer attributes, which results in an exception.

This fix allows also empty strings to be passed to `make_node()` (the emptiness check is not applied there) and uses exactly the same type `collections.abc.Iterable` as `make_node()`.


