### PR TITLE
Update `protobuf` Dependency to Support Versions 4 and 5

### DIFF
--- a/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_application_tests.yml
@@ -20,7 +20,7 @@ steps:
       pip install onnxconverter-common
       pip install $(ONNX_PATH)
       pip uninstall -y protobuf
-      pip install "protobuf~=3.20"
+      pip install "protobuf<6.0.0"
       pip install h5py==3.7.0
       pip install parameterized
       pip install timeout-decorator
@@ -85,7 +85,7 @@ steps:
       pip install onnxconverter-common
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install "protobuf~=3.20"
+      pip install "protobuf<6.0.0"
       pip install h5py==3.7.0
       pip install parameterized
       pip install timeout-decorator

--- a/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
+++ b/ci_build/azure_pipelines/templates/keras2onnx_unit_test.yml
@@ -20,7 +20,7 @@ steps:
       pip install onnxconverter-common
       pip install $(ONNX_PATH)
       pip uninstall -y protobuf
-      pip install "protobuf~=3.20"
+      pip install "protobuf<6.0.0"
       pip install h5py==3.7.0
       pip install parameterized
       pip install timeout-decorator
@@ -68,7 +68,7 @@ steps:
       pip install onnxconverter-common
       pip install %ONNX_PATH%
       pip uninstall -y protobuf
-      pip install "protobuf~=3.20"
+      pip install "protobuf<6.0.0"
       pip install h5py==3.7.0
       pip install parameterized
       pip install timeout-decorator

--- a/ci_build/azure_pipelines/templates/setup.yml
+++ b/ci_build/azure_pipelines/templates/setup.yml
@@ -30,7 +30,7 @@ steps:
     pip uninstall -y tensorflow
     pip install $(CI_PIP_TF_NAME)
     pip uninstall -y protobuf
-    pip install "protobuf~=3.20"
+    pip install "protobuf<6.0.0"
 
     python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author='ONNX',
     author_email='onnx-technical-discuss@lists.lfaidata.foundation',
     url='https://github.com/onnx/tensorflow-onnx',
-    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers>=1.12', 'protobuf~=3.20'],
+    install_requires=['numpy>=1.14.1', 'onnx>=1.4.1', 'requests', 'six', 'flatbuffers>=1.12', 'protobuf>=3.0.0,<6.0.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Packages like MediaPipe (0.10.14) rely on a `protobuf` version greater than 4, meaning `tensorflow-onnx` and `mediapipe` cannot be installed together in package managers like poetry due to the version restriction. This PR updates the `protobuf` dependency to `<6.0.0`, we aim to ensure compatibility with these libraries and improve overall dependency resolution. This is my first contribution to the TensorFlow-ONNX project. If this direction is not appropriate or there are other considerations, please let me know, and I will address them accordingly. Thank you for maintaining such an excellent project!