### PR TITLE
Limit ubuntu version to 22.04 for python 3.7.

### DIFF
--- a/.github/actions/keras_application_test/action.yml
+++ b/.github/actions/keras_application_test/action.yml
@@ -32,7 +32,7 @@ runs:
           pip install coloredlogs flatbuffers
           pip install tensorflow==${{ inputs.tf_version }}
           pip install onnxruntime==${{ inputs.ort_version }}
-          pip install Pillow==8.2.0
+          pip install pillow
           pip install opencv-python
           pip install tqdm
           pip install keras-segmentation==0.2.0

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -99,7 +99,7 @@ jobs:
         onnx_version: ['1.16.1']
         include:
           - name: 'py38-tf2.13'
-            tf_version: '2.13.1'
+            tf_version: '2.13.0'
             python_version: '3.8'
           - name: 'py39-tf2.15'
             tf_version: '2.15.0'

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -92,15 +92,15 @@ jobs:
       fail-fast: false
       matrix:
         name:
-          - 'py39-tf2.10'
+          - 'py38-tf2.13'
           - 'py39-tf2.15'
         os: ['ubuntu-latest', 'windows-2022']
         ort_version: ['1.16.3']
         onnx_version: ['1.16.1']
         include:
-          - name: 'py39-tf2.10'
-            tf_version: '2.10.0'
-            python_version: '3.9'
+          - name: 'py38-tf2.13'
+            tf_version: '2.13.1'
+            python_version: '3.8'
           - name: 'py39-tf2.15'
             tf_version: '2.15.0'
             python_version: '3.9'

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -66,7 +66,7 @@ jobs:
   Test_py37_with_tf1_15: # Do not change this name because it is used in Ruleset of this repo.
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -65,7 +65,7 @@ jobs:
   Test_py37_with_tf1_15: # Do not change this name because it is used in Ruleset of this repo.
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
 
-  Test_min_py_with_min_tf: # Do not change this name because it is used in Ruleset of this repo.
+  Test_min_py_with_min_tf: # Do not change this name because it is used in 'publish-test-results' section below.
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
           name: Test Results (Py38-TF2.9-18-ubuntu)
           path: ./**/test-results-*.xml
 
-  Test_max_py_with_latest_tf: # Do not change this name because it is used in Ruleset of this repo.
+  Test_max_py_with_latest_tf: # Do not change this name because it is used in 'publish-test-results' section below.
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -69,7 +69,33 @@ jobs:
           name: Test Results (Py310-TF2.15-18-ubuntu)
           path: ./**/test-results-*.xml
 
-  Extra_tests:
+  Test_py37_with_tf1_15: # Do not change this name because it is used in 'publish-test-results' section below.
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Tests (Py310-TF2.15-18)
+        uses: ./.github/actions/pretrained_model_test
+        with:
+          tf_version: '1.15.5'
+          python_version: '3.7'
+          os: 'ubuntu-22.04'  # Max ubuntu version supports python 3.7.
+          opset_version: '15'
+          ort_version: '1.14.1'
+          onnx_version: '1.14.1'
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (Py37-TF1.15-15-ubuntu)
+          path: ./**/test-results-*.xml
+
+  Extra_tests:  # Do not change this name because it is used in 'publish-test-results' section below.
     strategy:
       fail-fast: false
       matrix:
@@ -88,15 +114,7 @@ jobs:
           - name: 'py39-tf2.15'
             tf_version: '2.15.0'
             python_version: '3.9'
-          - name: 'py37-tf1.15'
-            tf_version: '1.15.5'
-            python_version: '3.7'
-            os: 'ubuntu-22.04'  # Max ubuntu version supports python 3.7.
-            opset_version: '15'
-            ort_version: '1.14.1'
-            onnx_version: '1.14.1'
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -121,7 +139,7 @@ jobs:
 
   publish-test-results:
     name: "Publish Tests Results to Github"
-    needs: [Test_min_py_with_min_tf, Test_max_py_with_latest_tf, Extra_tests]
+    needs: [Test_min_py_with_min_tf, Test_max_py_with_latest_tf, Test_py37_with_tf1_15, Extra_tests]
     runs-on: ubuntu-latest
     permissions:
       checks: write

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -91,7 +91,7 @@ jobs:
           - name: 'py37-tf1.15'
             tf_version: '1.15.5'
             python_version: '3.7'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-22.04'  # Max ubuntu version supports python 3.7.
             opset_version: '15'
             ort_version: '1.14.1'
             onnx_version: '1.14.1'

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -91,7 +91,7 @@ jobs:
           - name: 'py37-tf1.15'
             tf_version: '1.15.5'
             python_version: '3.7'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-22.04'  # Max ubuntu version supports python 3.7.
             opset_version: '15'
             ort_version: '1.14.1'
             onnx_version: '1.14.1'


### PR DESCRIPTION
Limit the ubuntu version to 22.04 which is the max version supports python 3.7.

Fix #2375 