### PR TITLE
Troves for python 3.11 and 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,5 +98,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.12']
         'Programming Language :: Python :: 3.10']
 )


### PR DESCRIPTION
Thanks for the great project!

When attempting to pull this in, under python 3.12, I noticed that the satsolver failed to resolve (I'm using [uv](https://docs.astral.sh/uv/)!) as there's no trove for python 3.12.

I'm positive there are changes other than this that are necessary, but I wanted to at least help this along, as python 3.12 is the default install on several Linux distributions.

How else can I help?