### PR TITLE
Fix Edge Case: Shared Layer Output Between Model Output and Internal Layers

### DIFF
--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -486,6 +486,7 @@ class Graph(object):
         self.contained_graphs = {}  # {node_name: {node_attribute_name: Graph}}
 
         ops = [Node(node, self) for node in nodes]
+
         if input_names is not None:
             input_names_set = set(input_names)
             for n in ops:
@@ -740,7 +741,6 @@ class Graph(object):
 
             if op.name in self.contained_graphs:
                 remained_sub_graphs[op.name] = self.contained_graphs[op.name]
-
         self._nodes = ops
         self.contained_graphs = remained_sub_graphs
         self._nodes_by_name = {op.name: op for op in ops}
@@ -758,7 +758,7 @@ class Graph(object):
                 raise ValueError("graph input '" + n.name + "' not exist")
         for o in self.outputs:
             if o not in self._output_to_node_name:
-                raise ValueError("graph output '" + o.name + "' not exist")
+                raise ValueError("graph output '" + str(o) + "' not exist")
 
         self._dtypes = remained_dtypes
         self._output_shapes = remained_shapes

--- a/tf2onnx/optimizer/__init__.py
+++ b/tf2onnx/optimizer/__init__.py
@@ -21,7 +21,8 @@ from .. import logging
 
 # optimizer sequence need to be considered carefully
 _optimizers = OrderedDict([
-    ("optimize_transpose", TransposeOptimizer),
+    ("remove_identity", IdentityOptimizer),
+    ("optimize_transpose", TransposeOptimizer), # transpose to reshape or add reshape
     ("remove_redundant_upsample", UpsampleOptimizer),
     ("fold_constants", ConstFoldOptimizer),
     ("const_dequantize_optimizer", ConstDequantizeOptimizer),
@@ -32,7 +33,6 @@ _optimizers = OrderedDict([
     ("reshape_optimizer", ReshapeOptimizer),
     ("global_pool_optimizer", GlobalPoolOptimizer),
     ("q_dq_optimizer", QDQOptimizer),
-    ("remove_identity", IdentityOptimizer),
     ("remove_back_to_back", BackToBackOptimizer),
     ("einsum_optimizer", EinsumOptimizer),
 ])

--- a/tf2onnx/version.py
+++ b/tf2onnx/version.py
@@ -2,4 +2,4 @@
 
 
 version = '1.16.1'
-git_version = '13bab8a91e17ccd87541b2f361ab60e8e38359d3'
+git_version = 'None'


### PR DESCRIPTION
Fix Edge Case: Shared Layer Output Between Model Output and Internal Layers

🎯 Summary
This PR addresses a specific edge case that occurs when converting TensorFlow models to ONNX. It improves the handling of cases where a layer's output is used simultaneously as both the input to another layer and the model's final output.

🔧 Changes
* Edge case handling: Resolves the case where a layer's output is used as both the model output and the input to an internal layer.

* Improved Transpose output logic:
Uses identity nodes to handle output branching.
Differentiates between model output consumers and internal consumers.
Introduces a two-step process: edge case handling → regular case handling.

* Optimizer order optimization: Moves remove_identity to the front of the optimizer chain.

* Improved error messages: Provides clearer error messages during graph output validation.

Technical Details

Before:
When a layer's output is connected to both the model output and internal layers, the transpose operation fails, causing the graph structure to break.

After:
Output is branched through identity nodes.
Transpose is applied only to the model output consumer.
Internal consumers maintain the original output.

🔍 Files Changed

tf2onnx/tfonnx.py - Major improvements to the transpose_outputs function.
tf2onnx/graph.py - Improved error messages and code cleanup.
tf2onnx/optimizer/__init__.py - Changed optimizer order.