### PR TITLE
Feat : support NHWC to NCHW in split node wo transpose

### DIFF
--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -194,6 +194,42 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
                                    model_proto, remaining_transpose_num=0)
 
     @parameterized.expand([
+        ((2, 3, 4, 6), [0, 3, 1, 2], [0, 2, 3, 1]),
+        ((2, 3, 4, 6, 8), [0, 4, 1, 2, 3], [0, 2, 3, 4, 1]),
+    ])
+    def test_transpose_with_split_multiple_outputs(self, input_shape, perm, inner_perm):
+        # Split with more than one output: the transpose must be pushed past each branch
+        # so that no Transpose remains and the result stays numerically identical.
+        input_shape_with_trans = [input_shape[i] for i in perm]
+        output_before_trans = list(input_shape)
+        output_shape = [output_before_trans[i] for i in perm]
+        for axis in range(len(input_shape)):
+            if input_shape[axis] % 2 != 0:
+                continue
+            node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=inner_perm, name="trans1")
+            if self.config.opset < 18:
+                node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=axis, name="split")
+            else:
+                node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=axis, name="split", num_outputs=2)
+            node3 = helper.make_node("Transpose", ["Z0"], ["res0"], perm=perm, name="trans2")
+            node4 = helper.make_node("Transpose", ["Z1"], ["res1"], perm=perm, name="trans3")
+
+            half = list(input_shape)
+            half[axis] //= 2
+            output_half = [half[i] for i in perm]
+            graph = helper.make_graph(
+                [node1, node2, node3, node4],
+                "test_transpose_with_split_multiple_outputs",
+                [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape_with_trans)],
+                [helper.make_tensor_value_info("res0", TensorProto.FLOAT, output_half),
+                 helper.make_tensor_value_info("res1", TensorProto.FLOAT, output_half)],
+            )
+
+            model_proto = self.make_model(graph, producer_name="onnx-tests")
+            feed_dict = {"X": np.random.randn(*input_shape_with_trans).astype(np.float32)}
+            self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=0)
+
+    @parameterized.expand([
         ((2, 3, 4), [2, 0, 1], [1, 2, 0]),
         ((2, 3, 4, 5), [0, 2, 3, 1], [0, 3, 1, 2]),
         ((2, 3, 4, 5, 6), [0, 2, 3, 4, 1], [0, 4, 1, 2, 3]),

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -295,44 +295,33 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             # One compensating Transpose per graph-output branch survives (nothing to fold into).
             self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=2)
 
-    def test_split_multi_output_graph_output_guard(self):
-        # White-box test for the defensive graph-output guard in the multi-output Split
-        # switch. Graph.__init__ buffers every graph output with an Identity, so end-to-end
-        # a Split output is never itself a graph output; this state only arises mid-
-        # optimization once that buffer has been folded away. We build it directly: attach a
-        # raw Split output to graph.outputs (no Identity), then assert _split_handler bails
-        # (returns False) and leaves the Split axis / input wiring untouched. Without the
-        # guard the switch relabels the axis and rewires the input, silently exposing the
-        # pre-transpose (NCHW) layout at that graph output.
-        from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
-        node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 3, 1, 2], name="trans1")
+    def test_transpose_with_split_at_graph_tail(self):
+        # End-to-end dummy model ending in a multi-output Split whose branches are the graph
+        # outputs, fed by a realistic Relu -> Transpose (NHWC->NCHW) head. Exercises the full
+        # optimizer pipeline (including the identity optimizer that can rename a producer's
+        # output to a graph-output name between transpose passes). The transpose is pushed
+        # past the Split; one compensating Transpose per branch survives (nothing downstream
+        # to fold into) and the result must stay numerically identical.
+        perm = [0, 3, 1, 2]                               # NHWC -> NCHW
+        input_shape = [2, 4, 6, 8]                        # NHWC
+        channels = input_shape[3]                         # split the channel axis
+        half = [input_shape[0], channels // 2, input_shape[1], input_shape[2]]  # NCHW half
+        node1 = helper.make_node("Relu", ["X"], ["R"], name="relu")
+        node2 = helper.make_node("Transpose", ["R"], ["Y"], perm=perm, name="trans")
         if self.config.opset < 18:
-            node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split")
+            node3 = helper.make_node("Split", ["Y"], ["res0", "res1"], axis=1, name="split")
         else:
-            node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split", num_outputs=2)
-        # "keep" is the only declared graph output, so Graph.__init__ buffers it (not Z0/Z1).
-        node3 = helper.make_node("Identity", ["Z0"], ["keep"], name="keep0")
+            node3 = helper.make_node("Split", ["Y"], ["res0", "res1"], axis=1, name="split", num_outputs=2)
         graph = helper.make_graph(
             [node1, node2, node3],
-            "test_split_multi_output_graph_output_guard",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 4, 6, 8])],
-            [helper.make_tensor_value_info("keep", TensorProto.FLOAT, [2, 4, 3, 8])],
+            "test_transpose_with_split_at_graph_tail",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)],
+            [helper.make_tensor_value_info("res0", TensorProto.FLOAT, half),
+             helper.make_tensor_value_info("res1", TensorProto.FLOAT, half)],
         )
-        g = GraphUtil.create_graph_from_onnx_model(self.make_model(graph, producer_name="onnx-tests"))
-        split = g.get_node_by_name("split")
-        trans = g.get_node_by_name("trans1")
-        # Inject the vulnerable state: a raw Split output becomes a graph output (no Identity).
-        g.outputs = list(g.outputs) + [split.output[1]]
-
-        opt = TransposeOptimizer()
-        opt._g = g  # pylint: disable=protected-access
-        before_axis = split.get_attr_value("axis")
-        before_input = split.input[0]
-        handled = opt._split_handler(trans, split)  # pylint: disable=protected-access
-
-        self.assertFalse(handled, "the switch must bail when a Split output is a graph output")
-        self.assertEqual(split.get_attr_value("axis"), before_axis, "Split axis must be untouched")
-        self.assertEqual(split.input[0], before_input, "Split input wiring must be untouched")
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        feed_dict = {"X": np.random.randn(*input_shape).astype(np.float32)}
+        self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=2)
 
     @parameterized.expand([
         ((2, 3, 4), [2, 0, 1], [1, 2, 0]),

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -227,6 +227,113 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
             feed_dict = {"X": np.random.randn(*input_shape_with_trans).astype(np.float32)}
             self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=0)
 
+    @check_opset_min_version(13, "Split split-sizes became an input in opset 13")
+    def test_transpose_with_split_multiple_outputs_split_input(self):
+        # opset>=13 multi-output Split with an explicit, uneven split-sizes INPUT. The
+        # multi-output path relabels only the axis and must leave the split-sizes const
+        # intact -- a mangled (non-vector) split const would make onnxruntime reject the
+        # model. Uneven sizes make any accidental resize observable.
+        perm = [0, 3, 1, 2]
+        inner_perm = [0, 2, 3, 1]
+        input_shape = [2, 3, 4, 8]                       # logical (post-inner-transpose) shape
+        input_shape_with_trans = [input_shape[i] for i in perm]
+        axis = 3                                          # split the size-8 logical axis
+        sizes = [3, 5]
+        split_const = self._make_onnx_const(np.array(sizes, dtype=np.int64), "split_sizes")
+        node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=inner_perm, name="trans1")
+        node2 = helper.make_node("Split", ["Y", "split_sizes"], ["Z0", "Z1"], axis=axis, name="split")
+        node3 = helper.make_node("Transpose", ["Z0"], ["res0"], perm=perm, name="trans2")
+        node4 = helper.make_node("Transpose", ["Z1"], ["res1"], perm=perm, name="trans3")
+
+        z0 = list(input_shape); z0[axis] = sizes[0]
+        z1 = list(input_shape); z1[axis] = sizes[1]
+        graph = helper.make_graph(
+            [split_const, node1, node2, node3, node4],
+            "test_transpose_with_split_multiple_outputs_split_input",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape_with_trans)],
+            [helper.make_tensor_value_info("res0", TensorProto.FLOAT, [z0[i] for i in perm]),
+             helper.make_tensor_value_info("res1", TensorProto.FLOAT, [z1[i] for i in perm])],
+        )
+
+        model_proto = self.make_model(graph, producer_name="onnx-tests")
+        feed_dict = {"X": np.random.randn(*input_shape_with_trans).astype(np.float32)}
+        self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=0)
+
+    @parameterized.expand([
+        ((2, 3, 4, 6), [0, 3, 1, 2], [0, 2, 3, 1]),
+        ((2, 3, 4, 6, 8), [0, 4, 1, 2, 3], [0, 2, 3, 4, 1]),
+    ])
+    def test_transpose_with_split_outputs_are_graph_outputs(self, input_shape, perm, inner_perm):
+        # Multi-output Split whose outputs are the graph outputs (no downstream Transpose to
+        # cancel with). The upstream Transpose is pushed past the Split, producing one
+        # compensating Transpose per branch that feeds the graph output. There is nothing to
+        # fold them into, so both Transposes must remain and the result must stay numerically
+        # identical to the unoptimized graph. Regression guard for the multi-output switch
+        # interacting with graph-output edges.
+        input_shape_with_trans = [input_shape[i] for i in perm]
+        for axis in range(len(input_shape)):
+            if input_shape[axis] % 2 != 0:
+                continue
+            node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=inner_perm, name="trans1")
+            if self.config.opset < 18:
+                node2 = helper.make_node("Split", ["Y"], ["res0", "res1"], axis=axis, name="split")
+            else:
+                node2 = helper.make_node("Split", ["Y"], ["res0", "res1"], axis=axis, name="split", num_outputs=2)
+
+            half = list(input_shape)
+            half[axis] //= 2
+            graph = helper.make_graph(
+                [node1, node2],
+                "test_transpose_with_split_outputs_are_graph_outputs",
+                [helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape_with_trans)],
+                [helper.make_tensor_value_info("res0", TensorProto.FLOAT, half),
+                 helper.make_tensor_value_info("res1", TensorProto.FLOAT, half)],
+            )
+
+            model_proto = self.make_model(graph, producer_name="onnx-tests")
+            feed_dict = {"X": np.random.randn(*input_shape_with_trans).astype(np.float32)}
+            # One compensating Transpose per graph-output branch survives (nothing to fold into).
+            self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=2)
+
+    def test_split_multi_output_graph_output_guard(self):
+        # White-box test for the defensive graph-output guard in the multi-output Split
+        # switch. Graph.__init__ buffers every graph output with an Identity, so end-to-end
+        # a Split output is never itself a graph output; this state only arises mid-
+        # optimization once that buffer has been folded away. We build it directly: attach a
+        # raw Split output to graph.outputs (no Identity), then assert _split_handler bails
+        # (returns False) and leaves the Split axis / input wiring untouched. Without the
+        # guard the switch relabels the axis and rewires the input, silently exposing the
+        # pre-transpose (NCHW) layout at that graph output.
+        from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
+        node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 3, 1, 2], name="trans1")
+        if self.config.opset < 18:
+            node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split")
+        else:
+            node2 = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split", num_outputs=2)
+        # "keep" is the only declared graph output, so Graph.__init__ buffers it (not Z0/Z1).
+        node3 = helper.make_node("Identity", ["Z0"], ["keep"], name="keep0")
+        graph = helper.make_graph(
+            [node1, node2, node3],
+            "test_split_multi_output_graph_output_guard",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 4, 6, 8])],
+            [helper.make_tensor_value_info("keep", TensorProto.FLOAT, [2, 4, 3, 8])],
+        )
+        g = GraphUtil.create_graph_from_onnx_model(self.make_model(graph, producer_name="onnx-tests"))
+        split = g.get_node_by_name("split")
+        trans = g.get_node_by_name("trans1")
+        # Inject the vulnerable state: a raw Split output becomes a graph output (no Identity).
+        g.outputs = list(g.outputs) + [split.output[1]]
+
+        opt = TransposeOptimizer()
+        opt._g = g  # pylint: disable=protected-access
+        before_axis = split.get_attr_value("axis")
+        before_input = split.input[0]
+        handled = opt._split_handler(trans, split)  # pylint: disable=protected-access
+
+        self.assertFalse(handled, "the switch must bail when a Split output is a graph output")
+        self.assertEqual(split.get_attr_value("axis"), before_axis, "Split axis must be untouched")
+        self.assertEqual(split.input[0], before_input, "Split input wiring must be untouched")
+
     @parameterized.expand([
         ((2, 3, 4), [2, 0, 1], [1, 2, 0]),
         ((2, 3, 4, 5), [0, 2, 3, 1], [0, 3, 1, 2]),

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -201,8 +201,6 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         # Split with more than one output: the transpose must be pushed past each branch
         # so that no Transpose remains and the result stays numerically identical.
         input_shape_with_trans = [input_shape[i] for i in perm]
-        output_before_trans = list(input_shape)
-        output_shape = [output_before_trans[i] for i in perm]
         for axis in range(len(input_shape)):
             if input_shape[axis] % 2 != 0:
                 continue

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -261,6 +261,51 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         feed_dict = {"X": np.random.randn(*input_shape_with_trans).astype(np.float32)}
         self.run_transpose_compare(["res0", "res1"], feed_dict, model_proto, remaining_transpose_num=0)
 
+    def test_multi_output_switch_guards_shared_transpose(self):
+        # White-box guard test for _switch_transpose_and_node_with_multiple_outputs. The
+        # switch rewires `trans` onto a Split output, which is only safe when the Split is
+        # the transpose's sole consumer. Dispatch (_handle_nhwc_tranpose) only routes here
+        # when that already holds, so the guard cannot fire end-to-end; it protects any
+        # future caller that forgets the precondition (Copilot review on #2414) and mirrors
+        # the single-output _switch_transpose_and_node guard. Unlike a hand-mutated graph,
+        # this feeds a natural shape -- one Transpose feeding BOTH a multi-output Split and
+        # an independent Relu -- then calls the helper directly and asserts it bails
+        # (returns False) and leaves the graph untouched instead of repointing the sibling.
+        from tf2onnx.optimizer.transpose_optimizer import TransposeOptimizer
+        node1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 3, 1, 2], name="trans1")
+        if self.config.opset < 18:
+            split = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split")
+        else:
+            split = helper.make_node("Split", ["Y"], ["Z0", "Z1"], axis=1, name="split", num_outputs=2)
+        # Second, independent consumer of the SAME transpose output -> trans1 is shared.
+        relu = helper.make_node("Relu", ["Y"], ["R"], name="relu")
+        graph = helper.make_graph(
+            [node1, split, relu],
+            "test_multi_output_switch_guards_shared_transpose",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 4, 6, 8])],
+            [helper.make_tensor_value_info("Z0", TensorProto.FLOAT, [2, 4, 4, 6]),
+             helper.make_tensor_value_info("Z1", TensorProto.FLOAT, [2, 4, 4, 6]),
+             helper.make_tensor_value_info("R", TensorProto.FLOAT, [2, 8, 4, 6])],
+        )
+        g = GraphUtil.create_graph_from_onnx_model(self.make_model(graph, producer_name="onnx-tests"))
+        trans = g.get_node_by_name("trans1")
+        split_node = g.get_node_by_name("split")
+        opt = TransposeOptimizer()
+        opt._g = g  # pylint: disable=protected-access
+
+        before_axis = split_node.get_attr_value("axis")
+        before_split_input = list(split_node.input)
+        before_relu_input = list(g.get_node_by_name("relu").input)
+
+        # pylint: disable=protected-access
+        handled = opt._switch_transpose_and_node_with_multiple_outputs(split_node, trans)
+
+        self.assertFalse(handled, "the switch must bail when the transpose has more than one consumer")
+        self.assertEqual(split_node.get_attr_value("axis"), before_axis, "Split axis must be untouched")
+        self.assertEqual(list(split_node.input), before_split_input, "Split input wiring must be untouched")
+        self.assertEqual(list(g.get_node_by_name("relu").input), before_relu_input,
+                         "the sibling consumer of the shared transpose must be untouched")
+
     @parameterized.expand([
         ((2, 3, 4, 6), [0, 3, 1, 2], [0, 2, 3, 1]),
         ((2, 3, 4, 6, 8), [0, 4, 1, 2, 3], [0, 2, 3, 4, 1]),

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -245,8 +245,10 @@ class OptimizerTests(Tf2OnnxBackendTestBase):
         node3 = helper.make_node("Transpose", ["Z0"], ["res0"], perm=perm, name="trans2")
         node4 = helper.make_node("Transpose", ["Z1"], ["res1"], perm=perm, name="trans3")
 
-        z0 = list(input_shape); z0[axis] = sizes[0]
-        z1 = list(input_shape); z1[axis] = sizes[1]
+        z0 = list(input_shape)
+        z0[axis] = sizes[0]
+        z1 = list(input_shape)
+        z1[axis] = sizes[1]
         graph = helper.make_graph(
             [split_const, node1, node2, node3, node4],
             "test_transpose_with_split_multiple_outputs_split_input",

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -716,9 +716,11 @@ class Split:
         # T output = Split(int32 split_dim, T value, @int num_split)
         # T outputs = Split(T input, @INT axis, @INTS split)
         split_dims = node.inputs[0].get_tensor_value()
+        new_split_dims = split_dims + len(node.output_shapes[0]) if split_dims < 0 else split_dims
+        new_split_dims = 1 if new_split_dims == 3 else new_split_dims
         ctx.remove_input(node, node.input[0], 0)
         node.set_attr("num_outputs", node.get_attr_int("num_split"))
-        node.set_attr("axis", split_dims)
+        node.set_attr("axis", new_split_dims)
 
     @classmethod
     def version_2(cls, ctx, node, **kwargs):

--- a/tf2onnx/onnx_opset/tensor.py
+++ b/tf2onnx/onnx_opset/tensor.py
@@ -716,11 +716,9 @@ class Split:
         # T output = Split(int32 split_dim, T value, @int num_split)
         # T outputs = Split(T input, @INT axis, @INTS split)
         split_dims = node.inputs[0].get_tensor_value()
-        new_split_dims = split_dims + len(node.output_shapes[0]) if split_dims < 0 else split_dims
-        new_split_dims = 1 if new_split_dims == 3 else new_split_dims
         ctx.remove_input(node, node.input[0], 0)
         node.set_attr("num_outputs", node.get_attr_int("num_split"))
-        node.set_attr("axis", new_split_dims)
+        node.set_attr("axis", split_dims)
 
     @classmethod
     def version_2(cls, ctx, node, **kwargs):

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -312,10 +312,11 @@ class TransposeOptimizer(GraphOptimizerBase):
             self._g.set_shape(node.output[0], new_shape)
             self._g.set_shape(trans.output[0], shape)
         return True
+
     # this is for the case where node has multiple outputs. e.g. split node.
     def _switch_transpose_and_node_with_multiple_outputs(self, node, trans, update_shape=True):
         input_index = self._get_input_index_for_trans(node, trans)
-        for idx,_output in enumerate(node.output):
+        for idx, _output in enumerate(node.output):
             shape = self._g.get_shape(_output)
             nxt_nodes = self._g.find_output_consumers(_output)
             if idx == 0:
@@ -326,7 +327,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                 transpose = self._g.make_node("Transpose", [_output], attr={"perm": trans.get_attr_value("perm")})
             for nxt_node in nxt_nodes:
                 self._g.replace_input(nxt_node, _output, transpose.output[0])
-                
+
             if update_shape and shape:
                 perm_inv = invert_perm(transpose.get_attr_value("perm"))
                 new_shape = [shape[i] for i in perm_inv]
@@ -715,20 +716,20 @@ class TransposeOptimizer(GraphOptimizerBase):
                 new_axes_const = self._g.make_const(utils.make_name(node.inputs[1].name), new_axes_np)
                 self._g.replace_inputs(node, [node.input[0], new_axes_const.output[0]])
             return True
-        # handling having branches
+        # Split with more than 1 output (the single-output case is handled above by
+        # _handle_node_having_branches, which bails out when len(node.output) != 1).
         if len(node.output) > 1:
+            perm = trans.get_attr_value("perm")
             trans_rank = get_transpose_rank(trans)
-            axes = node.get_attr_value("axis", 0)
-            perm = trans.get_attr("perm").ints
-            axes = [axes + trans_rank if axes < 0 else axes]
-            if split:
-                new_axes_np = np.array(split, dtype=np.int64)
-                new_axes_const = self._g.make_const(utils.make_name(node.inputs[1].name), new_axes_np)
+            axis = node.get_attr_value("axis", 0)
+            if axis < 0:
+                axis += trans_rank
             # [Transpose -> Split -> next_nodes] -> [Split -> Transpose -> next_nodes]
-            if not self._switch_transpose_and_node_with_multiple_outputs(node, trans, 1):
+            # The split sizes stay the same; only the axis is relabelled to the
+            # pre-transpose layout. ONNX Split's "axis" is a scalar int attribute.
+            if not self._switch_transpose_and_node_with_multiple_outputs(node, trans):
                 return False
-            new_axes = [perm[a] for a in axes]
-            node.set_attr("axes", new_axes)
+            node.set_attr("axis", perm[axis])
             return True
         return False
 

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -315,6 +315,16 @@ class TransposeOptimizer(GraphOptimizerBase):
 
     # this is for the case where node has multiple outputs. e.g. split node.
     def _switch_transpose_and_node_with_multiple_outputs(self, node, trans, update_shape=True):
+        # Defensive guard, mirroring _handle_nhwc_tranpose's `trans.output[0] in outputs`
+        # check. Each output needs a compensating Transpose inserted between `node` and its
+        # consumers; a graph-output edge has no node-consumer to redirect, so the switch
+        # would silently expose the pre-transpose (NCHW) layout at that output and, for
+        # idx > 0, leave an orphaned Transpose behind. In the normal pipeline the Graph
+        # buffers every graph output with an Identity (see Graph.__init__), so `node.output`
+        # is not itself a graph output here; this guards the mid-optimization case where
+        # that buffer has been folded away.
+        if any(out in self._g.outputs for out in node.output):
+            return False
         input_index = self._get_input_index_for_trans(node, trans)
         for idx, _output in enumerate(node.output):
             shape = self._g.get_shape(_output)
@@ -334,6 +344,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                 self._g.set_shape(_output, new_shape)
                 self._g.set_shape(transpose.output[0], shape)
         return True
+
     # if return value is True, then it means Transpose is handled as designed
     # otherwise, it means that we skip handling since it is not in our support set
     def _handle_nhwc_tranpose(self, trans):
@@ -701,42 +712,46 @@ class TransposeOptimizer(GraphOptimizerBase):
         return False
 
     def _split_handler(self, trans, node):
-        split = None
-        if self._g.opset >= 13 and len(node.input) > 1 and node.inputs[1].is_const():
-            # split is an input not attr since opset 13
-            split = node.inputs[1].get_tensor_value(as_list=True)
-        if self._handle_node_having_branches(trans, node):
-            perm = trans.get_attr_value("perm")
-            axis = node.get_attr_value("axis", 0)
-            new_axis = perm[axis]
-            node.set_attr("axis", new_axis)
-            if split:
-                new_axes_np = np.array(split, dtype=np.int64)
-                new_axes_const = self._g.make_const(utils.make_name(node.inputs[1].name), new_axes_np)
-                self._g.replace_inputs(node, [node.input[0], new_axes_const.output[0]])
-            return True
-        # Split with more than 1 output (the single-output case is handled above by
-        # _handle_node_having_branches, which bails out when len(node.output) != 1).
+        # Dispatch on output cardinality: the two paths use different mechanisms. Split's
+        # "axis" is always an attribute; only the split sizes moved from an attribute
+        # (opset < 13) to input[1] (opset >= 13), and that difference only matters for the
+        # single-output path below.
         if len(node.output) > 1:
-            # _switch_transpose_and_node_with_multiple_outputs rewires `trans` to consume
-            # the Split output. If `trans` feeds more than just this Split, that rewrite
-            # would change the value seen by the other consumers and corrupt the graph, so
-            # only proceed when `trans` is exclusively consumed here.
+            # Multi-output: rewire the Transpose past each branch. This never touches the
+            # split sizes, so it is opset-agnostic. _switch_transpose_and_node_with_multiple_
+            # outputs rewires `trans` to consume a Split output, so if `trans` feeds anything
+            # other than this Split that rewrite would corrupt those consumers -- only proceed
+            # when `trans` is exclusively consumed here.
             if not self._nodes_has_single_consumer_node([trans]):
                 return False
             perm = trans.get_attr_value("perm")
-            trans_rank = get_transpose_rank(trans)
             axis = node.get_attr_value("axis", 0)
             if axis < 0:
-                axis += trans_rank
-            # [Transpose -> Split -> next_nodes] -> [Split -> Transpose -> next_nodes]
-            # The split sizes stay the same; only the axis is relabelled to the
-            # pre-transpose layout. ONNX Split's "axis" is a scalar int attribute.
+                axis += get_transpose_rank(trans)
+            # [Transpose -> Split -> next] -> [Split -> Transpose -> next]; the split sizes
+            # stay the same, only the axis is relabelled to the pre-transpose layout.
             if not self._switch_transpose_and_node_with_multiple_outputs(node, trans):
                 return False
             node.set_attr("axis", perm[axis])
             return True
-        return False
+
+        # Single-output: _handle_node_having_branches pushes the Transpose through by wrapping
+        # every input in transpose pairs, which mangles the opset-13 1-D split-sizes const
+        # (input[1]) into a Reshape/Transpose chain. Snapshot the sizes BEFORE the push and
+        # rebuild a clean const AFTER. On opset < 13 the sizes are an attribute and untouched,
+        # so `split` stays None and this repair is skipped.
+        split = None
+        if self._g.opset >= 13 and len(node.input) > 1 and node.inputs[1].is_const():
+            split = node.inputs[1].get_tensor_value(as_list=True)
+        if not self._handle_node_having_branches(trans, node):
+            return False
+        perm = trans.get_attr_value("perm")
+        node.set_attr("axis", perm[node.get_attr_value("axis", 0)])
+        if split is not None:
+            split_sizes_np = np.array(split, dtype=np.int64)
+            split_sizes_const = self._g.make_const(utils.make_name(node.name + "_split"), split_sizes_np)
+            self._g.replace_inputs(node, [node.input[0], split_sizes_const.output[0]])
+        return True
 
     def _unsqueeze_handler(self, trans, node):
         trans_rank = get_transpose_rank(trans)

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -315,16 +315,6 @@ class TransposeOptimizer(GraphOptimizerBase):
 
     # this is for the case where node has multiple outputs. e.g. split node.
     def _switch_transpose_and_node_with_multiple_outputs(self, node, trans, update_shape=True):
-        # Purely defensive guard, mirroring _handle_nhwc_tranpose's `trans.output[0] in
-        # outputs` check. Each output needs a compensating Transpose between `node` and its
-        # consumers; a graph-output edge has no node-consumer to redirect, so the switch
-        # would expose the pre-transpose (NCHW) layout at that output and, for idx > 0, leave
-        # an orphaned Transpose behind. Note: the normal pipeline buffers every graph output
-        # with an Identity (Graph.__init__), so this condition has not been observed to fire
-        # end-to-end -- the Split is always processed while its outputs are still buffered.
-        # Kept only for symmetry/safety; if you can prove it is unreachable, it can go.
-        if any(out in self._g.outputs for out in node.output):
-            return False
         input_index = self._get_input_index_for_trans(node, trans)
         for idx, _output in enumerate(node.output):
             shape = self._g.get_shape(_output)
@@ -730,8 +720,7 @@ class TransposeOptimizer(GraphOptimizerBase):
                 axis += get_transpose_rank(trans)
             # [Transpose -> Split -> next] -> [Split -> Transpose -> next]; the split sizes
             # stay the same, only the axis is relabelled to the pre-transpose layout.
-            if not self._switch_transpose_and_node_with_multiple_outputs(node, trans):
-                return False
+            self._switch_transpose_and_node_with_multiple_outputs(node, trans)
             node.set_attr("axis", perm[axis])
             return True
 

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -701,7 +701,6 @@ class TransposeOptimizer(GraphOptimizerBase):
         return False
 
     def _split_handler(self, trans, node):
-        # Todo: need handle cases where Split node has more than 1 outputs.
         split = None
         if self._g.opset >= 13 and len(node.input) > 1 and node.inputs[1].is_const():
             # split is an input not attr since opset 13
@@ -719,6 +718,12 @@ class TransposeOptimizer(GraphOptimizerBase):
         # Split with more than 1 output (the single-output case is handled above by
         # _handle_node_having_branches, which bails out when len(node.output) != 1).
         if len(node.output) > 1:
+            # _switch_transpose_and_node_with_multiple_outputs rewires `trans` to consume
+            # the Split output. If `trans` feeds more than just this Split, that rewrite
+            # would change the value seen by the other consumers and corrupt the graph, so
+            # only proceed when `trans` is exclusively consumed here.
+            if not self._nodes_has_single_consumer_node([trans]):
+                return False
             perm = trans.get_attr_value("perm")
             trans_rank = get_transpose_rank(trans)
             axis = node.get_attr_value("axis", 0)

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -315,14 +315,14 @@ class TransposeOptimizer(GraphOptimizerBase):
 
     # this is for the case where node has multiple outputs. e.g. split node.
     def _switch_transpose_and_node_with_multiple_outputs(self, node, trans, update_shape=True):
-        # Defensive guard, mirroring _handle_nhwc_tranpose's `trans.output[0] in outputs`
-        # check. Each output needs a compensating Transpose inserted between `node` and its
+        # Purely defensive guard, mirroring _handle_nhwc_tranpose's `trans.output[0] in
+        # outputs` check. Each output needs a compensating Transpose between `node` and its
         # consumers; a graph-output edge has no node-consumer to redirect, so the switch
-        # would silently expose the pre-transpose (NCHW) layout at that output and, for
-        # idx > 0, leave an orphaned Transpose behind. In the normal pipeline the Graph
-        # buffers every graph output with an Identity (see Graph.__init__), so `node.output`
-        # is not itself a graph output here; this guards the mid-optimization case where
-        # that buffer has been folded away.
+        # would expose the pre-transpose (NCHW) layout at that output and, for idx > 0, leave
+        # an orphaned Transpose behind. Note: the normal pipeline buffers every graph output
+        # with an Identity (Graph.__init__), so this condition has not been observed to fire
+        # end-to-end -- the Split is always processed while its outputs are still buffered.
+        # Kept only for symmetry/safety; if you can prove it is unreachable, it can go.
         if any(out in self._g.outputs for out in node.output):
             return False
         input_index = self._get_input_index_for_trans(node, trans)

--- a/tf2onnx/optimizer/transpose_optimizer.py
+++ b/tf2onnx/optimizer/transpose_optimizer.py
@@ -314,7 +314,15 @@ class TransposeOptimizer(GraphOptimizerBase):
         return True
 
     # this is for the case where node has multiple outputs. e.g. split node.
+    # `trans` is rewired to consume node.output[0], so it must be the sole consumer of
+    # `trans`; otherwise any sibling consumer of `trans` would be silently repointed to
+    # the Split output. The only current caller (_split_handler) is reached via dispatch
+    # only when that already holds, so this guard is defensive -- it keeps the invariant
+    # for any future caller and mirrors the single-output _switch_transpose_and_node above.
     def _switch_transpose_and_node_with_multiple_outputs(self, node, trans, update_shape=True):
+        if not self._nodes_has_single_consumer_node([trans]):
+            return False
+
         input_index = self._get_input_index_for_trans(node, trans)
         for idx, _output in enumerate(node.output):
             shape = self._g.get_shape(_output)
@@ -708,19 +716,17 @@ class TransposeOptimizer(GraphOptimizerBase):
         # single-output path below.
         if len(node.output) > 1:
             # Multi-output: rewire the Transpose past each branch. This never touches the
-            # split sizes, so it is opset-agnostic. _switch_transpose_and_node_with_multiple_
-            # outputs rewires `trans` to consume a Split output, so if `trans` feeds anything
-            # other than this Split that rewrite would corrupt those consumers -- only proceed
-            # when `trans` is exclusively consumed here.
-            if not self._nodes_has_single_consumer_node([trans]):
-                return False
+            # split sizes, so it is opset-agnostic. The switch requires `trans` to be
+            # consumed only by this Split (it rewires `trans` onto a Split output); the
+            # helper guards that precondition and bails, so honour its return value.
             perm = trans.get_attr_value("perm")
             axis = node.get_attr_value("axis", 0)
             if axis < 0:
                 axis += get_transpose_rank(trans)
             # [Transpose -> Split -> next] -> [Split -> Transpose -> next]; the split sizes
             # stay the same, only the axis is relabelled to the pre-transpose layout.
-            self._switch_transpose_and_node_with_multiple_outputs(node, trans)
+            if not self._switch_transpose_and_node_with_multiple_outputs(node, trans):
+                return False
             node.set_attr("axis", perm[axis])
             return True
 


### PR DESCRIPTION
# Summary
- current tf2onnx doesn't support to convert without transpose NHWC to NCHW in split node. 
- and the most of functions are not consider when operator has multiple outputs.

# Changes
- add features that change axis of Split in transpose optimizer for NHWC to NCHW.
- add `_switch_transpose_and_node_with_multiple_outputs` functions for switching transpose node and split node has multiple-output.

# Test
- Unfortunately due to security issues, I attach before & after figure instead of my test model. 
<img width="514" height="655" alt="image" src="https://github.com/user-attachments/assets/6bb653cb-01a5-471a-bd8b-35cea506d90a" />

- in unit_test,`python setup.py test`,  i got results as below. i think those failed issues are not related in my code.

<img width="1357" height="160" alt="image" src="https://github.com/user-attachments/assets/c75d32df-38cc-45c8-b36b-2aa1fe1dab6e" />
