### PR TITLE
ci: pin all GitHub Actions to commit hashes (zizmor)

### DIFF
--- a/.github/actions/keras_application_test/action.yml
+++ b/.github/actions/keras_application_test/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python (${{ inputs.python_version }})
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/actions/keras_unit_test/action.yml
+++ b/.github/actions/keras_unit_test/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python (${{ inputs.python_version }})
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/actions/pretrained_model_test/action.yml
+++ b/.github/actions/pretrained_model_test/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python (${{ inputs.python_version }})
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python (${{ inputs.python_version }})
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -56,6 +56,6 @@ jobs:
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -26,7 +26,7 @@ jobs:
         tf_version: ['2.13.0', '2.15.0']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/keras_application_test
@@ -37,7 +37,7 @@ jobs:
           onnx_version: '1.16.1'
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Test Results (${{ matrix.os }}-tf${{ matrix.tf_version }})
           path: junit/test-results.xml
@@ -52,10 +52,10 @@ jobs:
     if: always()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -56,6 +56,6 @@ jobs:
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -26,7 +26,7 @@ jobs:
         tf_version: ['2.13.0', '2.15.0']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/keras_unit_test
@@ -37,7 +37,7 @@ jobs:
           onnx_version: '1.16.1'
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Test Results (${{ matrix.os }}-tf${{ matrix.tf_version }})
           path: junit/test-results.xml
@@ -52,10 +52,10 @@ jobs:
     if: always()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,15 +8,20 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   enforce-style:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -27,7 +27,7 @@ jobs:
         opset_version: ['18', '15']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/pretrained_model_test
@@ -40,7 +40,7 @@ jobs:
           skip_tflite: 'False'
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Test Results (${{ matrix.os }}-tf${{ matrix.tf_version }}-opset${{ matrix.opset_version }})
           path: junit/test-results.xml
@@ -55,10 +55,10 @@ jobs:
     if: always()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -59,6 +59,6 @@ jobs:
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,23 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -31,7 +38,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -43,14 +50,15 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment: pypi
     permissions:
+      contents: read
       id-token: write  # required for trusted publishing (OIDC)
 
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -34,7 +34,7 @@ jobs:
             python_version: '3.13'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/unit_test
@@ -47,7 +47,7 @@ jobs:
           skip_tflite: 'False'
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Test Results (${{ matrix.os }}-tf${{ matrix.tf_version }}-py${{ matrix.python_version }}-opset${{ matrix.opset_version }})
           path: junit/test-results.xml
@@ -62,10 +62,10 @@ jobs:
     if: always()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         with:
           files: "artifacts/**/*.xml"

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -66,6 +66,6 @@ jobs:
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
## Summary

Fixes all [zizmor](https://github.com/woodruffw/zizmor) security findings in the GitHub Actions workflows.

- **27 × `unpinned-uses` (high):** All action references pinned to immutable commit hashes to prevent supply-chain attacks via mutable version tags
- **1 × `artipacked` (low):** Added `persist-credentials: false` to checkout in `release.yml` and `lint.yml`
- **2 × `excessive-permissions` (medium):** Added explicit `permissions: contents: read` blocks to `release.yml` at workflow and job level

### Actions pinned

| Action | Tag | Commit hash |
|--------|-----|-------------|
| `actions/checkout` | v6.0.2 | `de0fac2e` |
| `actions/setup-python` | v5.6.0 | `a26af69b` |
| `actions/setup-python` | v6.2.0 | `a309ff8b` |
| `actions/upload-artifact` | v7 | `043fb46d` |
| `actions/download-artifact` | v8 | `3e5f45b2` |
| `EnricoMi/publish-unit-test-result-action` | v2 | `2ceeed2b` |
| `pypa/gh-action-pypi-publish` | release/v1 | `cef22109` |

After this change `uvx zizmor .` reports **no findings** (22 suppressed by the existing `.github/workflows/zizmor.yml` config).

---
*Initial draft assisted by [Claude](https://claude.ai).*