### PR TITLE
Fix RaggedTensor structured output renaming

### DIFF
--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -344,7 +344,7 @@ def tensor_names_from_structed(concrete_func, input_names, output_names):
     if isinstance(concrete_func.structured_outputs, dict):
         for k, v in concrete_func.structured_outputs.items():
             if isinstance(v, tf.RaggedTensor):
-                tensors_to_rename[v.values.name] = k
+                tensors_to_rename[v.flat_values.name] = k
             else:
                 tensors_to_rename[v.name] = k
     return tensors_to_rename

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -343,7 +343,10 @@ def tensor_names_from_structed(concrete_func, input_names, output_names):
     tensors_to_rename.update(zip(input_names, structured_inputs))
     if isinstance(concrete_func.structured_outputs, dict):
         for k, v in concrete_func.structured_outputs.items():
-            tensors_to_rename[v.name] = k
+            if isinstance(v, tf.RaggedTensor):
+                tensors_to_rename[v.values.name] = k
+            else:
+                tensors_to_rename[v.name] = k
     return tensors_to_rename
 
 


### PR DESCRIPTION
## Summary

Fix conversion when dict structured outputs contain a `tf.RaggedTensor`.

`tensor_names_from_structed` assumes each structured output value has a `.name` attribute. `tf.RaggedTensor` does not, so conversion can fail before ONNX graph conversion starts.

This change detects ragged tensor outputs and maps the ragged tensor's values tensor name to the structured output key.

## Testing

I tested this locally with a TensorFlow object detection model that previously failed during ONNX conversion. With this fix, the model converts successfully and the converted ONNX model runs successfully.
