### PR TITLE
test: add non-blocking TFLite builtin coverage guard

### DIFF
--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install tf2onnx
         run: |
           python -m pip install --upgrade pip
-          pip install "numpy<2" onnx flatbuffers packaging parameterized pytest tensorflow==2.15.0
+          pip install "numpy<2" onnx==1.16.1 flatbuffers packaging parameterized pytest
           pip install -e .
       - name: Run TFLite op coverage guard
         env:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -153,11 +153,12 @@ jobs:
       - name: Install tf2onnx
         run: |
           python -m pip install --upgrade pip
-          # tensorflow is required even though this test never runs a model:
-          # tf2onnx imports it unconditionally at package init (verbose_logging),
-          # and tests/conftest.py imports it too, so the guard cannot collect without
-          # it. onnx is pinned to keep the job deterministic.
-          pip install "numpy<2" onnx==1.16.1 flatbuffers packaging parameterized pytest tensorflow==2.15.0
+          # tensorflow and onnxruntime are required even though this test never
+          # runs a model: tf2onnx imports tensorflow unconditionally at package
+          # init (verbose_logging), and tests/conftest.py pulls in onnxruntime
+          # via TestConfig._get_backend_version(), so the guard cannot collect
+          # without either. Versions are pinned to keep the job deterministic.
+          pip install "numpy<2" onnx==1.16.1 onnxruntime==1.16.3 flatbuffers packaging parameterized pytest tensorflow==2.15.0
           pip install -e .
       - name: Run TFLite op coverage guard
         env:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -89,7 +89,11 @@ jobs:
       - name: Install tf2onnx
         run: |
           python -m pip install --upgrade pip
-          pip install "numpy<2" onnx==1.16.1 flatbuffers packaging parameterized pytest
+          # tensorflow is required even though this test never runs a model:
+          # tf2onnx imports it unconditionally at package init (verbose_logging),
+          # and tests/conftest.py imports it too, so the guard cannot collect without
+          # it. onnx is pinned to keep the job deterministic.
+          pip install "numpy<2" onnx==1.16.1 flatbuffers packaging parameterized pytest tensorflow==2.15.0
           pip install -e .
       - name: Run TFLite op coverage guard
         env:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -69,3 +69,29 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "artifacts/**/*.xml"
+
+  tflite-op-coverage:
+    # Advisory guard that flags TFLite builtins with no @tfl_op handler
+    # (tests/test_tflite_op_coverage.py). It is deterministic (pure source
+    # introspection, no model conversion) and isolated from the test matrix, so
+    # it can only fail for a PR that actually changes the handled-op set - never
+    # for unrelated changes. `continue-on-error` keeps it non-blocking while it
+    # beds in; promote to a required check once the baseline is trusted.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install tf2onnx
+        run: |
+          python -m pip install --upgrade pip
+          pip install "numpy<2" onnx flatbuffers packaging parameterized pytest tensorflow==2.15.0
+          pip install -e .
+      - name: Run TFLite op coverage guard
+        env:
+          TF2ONNX_TFLITE_COVERAGE: '1'
+        run: python -m pytest tests/test_tflite_op_coverage.py -o addopts="" -v

--- a/tests/test_tflite_op_coverage.py
+++ b/tests/test_tflite_op_coverage.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""Coverage guard for the TFLite frontend.
+
+Compares every TFLite builtin operator (tf2onnx's vendored ``BuiltinOperator``
+enum) against the handlers registered with ``@tfl_op``. It does NOT convert or
+run any model - it only introspects tf2onnx's own source, so it is
+version-independent and never flaky. It fails only when a change alters the set
+of handled TFLite ops: deleting a handler, adding one without updating the list
+below, or a schema bump that introduces a new builtin. Such failures always
+point at the change that caused them, never at unrelated PRs.
+
+Runs only in its dedicated (non-blocking) CI job via ``TF2ONNX_TFLITE_COVERAGE``;
+skipped in the normal test matrix so it can never block unrelated PRs.
+"""
+
+import os
+import unittest
+
+import pytest
+
+# TFLite builtins that currently have NO ``@tfl_op`` handler. Emitting one of
+# these yields an invalid ``TFL_<NAME>`` passthrough node that no ONNX runtime
+# can load (e.g. TFL_GELU). Keep this list honest:
+#   * implement a handler for one of these -> REMOVE it here
+#   * a TF/tflite upgrade adds a new builtin -> ADD it here (or add a handler)
+KNOWN_UNSUPPORTED = {
+    "ASSIGN_VARIABLE", "BIDIRECTIONAL_SEQUENCE_LSTM", "BIDIRECTIONAL_SEQUENCE_RNN", "BITCAST",
+    "BROADCAST_ARGS", "BUCKETIZE", "CALL", "CALL_ONCE", "CONCAT_EMBEDDINGS", "DENSIFY",
+    "DYNAMIC_UPDATE_SLICE", "EMBEDDING_LOOKUP", "EMBEDDING_LOOKUP_SPARSE", "FAKE_QUANT", "GELU",
+    "HASHTABLE", "HASHTABLE_FIND", "HASHTABLE_IMPORT", "HASHTABLE_LOOKUP", "HASHTABLE_SIZE",
+    "IMAG", "L2_POOL_2D", "LSH_PROJECTION", "LSTM", "READ_VARIABLE", "REAL", "RELU_0_TO_1",
+    "RELU_N1_TO_1", "RNN", "SKIP_GRAM", "STABLEHLO_ADD", "STABLEHLO_DIVIDE",
+    "STABLEHLO_LOGISTIC", "STABLEHLO_MAXIMUM", "STABLEHLO_MULTIPLY", "SVDF",
+    "UNIDIRECTIONAL_SEQUENCE_LSTM", "UNIDIRECTIONAL_SEQUENCE_RNN", "VAR_HANDLE",
+}
+
+# Enum entries that are not real operators and never need a handler.
+_SENTINELS = {"CUSTOM", "DELEGATE", "PLACEHOLDER_FOR_GREATER_OP_CODES"}
+
+
+def _builtins_and_handled():
+    """Return (all builtin op names, names that have a TFL_ handler)."""
+    import tf2onnx.convert  # noqa: F401  pylint: disable=unused-import  (registers handlers)
+    from tf2onnx.handler import tf_op
+    from tf2onnx.tflite import BuiltinOperator as bo
+
+    builtins = {
+        k for k, v in vars(bo.BuiltinOperator).items()
+        if not k.startswith("_") and isinstance(v, int) and k not in _SENTINELS
+    }
+    registered = set()
+    for opset_list in tf_op.get_opsets().values():
+        for ops in opset_list:
+            registered.update(ops)
+    handled = {n[len("TFL_"):] for n in registered if n.startswith("TFL_")}
+    return builtins, handled
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TF2ONNX_TFLITE_COVERAGE"),
+    reason="TFLite coverage guard runs only in its dedicated non-blocking CI job",
+)
+class TFLiteOpCoverageTests(unittest.TestCase):
+
+    def test_no_new_unsupported_builtins(self):
+        # A builtin with no handler that we did not already know about: either a
+        # regressed handler or a newly added builtin.
+        builtins, handled = _builtins_and_handled()
+        new_gaps = (builtins - handled) - KNOWN_UNSUPPORTED
+        self.assertEqual(
+            set(), new_gaps,
+            "Unhandled TFLite builtin(s) not in KNOWN_UNSUPPORTED: %s. "
+            "Implement an @tfl_op handler, or add them to KNOWN_UNSUPPORTED if "
+            "leaving them unsupported is intentional." % sorted(new_gaps))
+
+    def test_allowlist_still_accurate(self):
+        builtins, handled = _builtins_and_handled()
+        # Someone added a handler but forgot to shrink the list.
+        now_supported = KNOWN_UNSUPPORTED & handled
+        self.assertEqual(
+            set(), now_supported,
+            "TFLite builtin(s) now have a handler; remove them from "
+            "KNOWN_UNSUPPORTED: %s" % sorted(now_supported))
+        # Guard against typos / renamed enum entries in the list.
+        stale = KNOWN_UNSUPPORTED - builtins
+        self.assertEqual(
+            set(), stale,
+            "KNOWN_UNSUPPORTED has name(s) not in BuiltinOperator "
+            "(typo or renamed op): %s" % sorted(stale))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tflite_op_coverage.py
+++ b/tests/test_tflite_op_coverage.py
@@ -18,8 +18,6 @@ skipped in the normal test matrix so it can never block unrelated PRs.
 import os
 import unittest
 
-import pytest
-
 # TFLite builtins that currently have NO ``@tfl_op`` handler. Emitting one of
 # these yields an invalid ``TFL_<NAME>`` passthrough node that no ONNX runtime
 # can load (e.g. TFL_GELU). Keep this list honest:
@@ -58,9 +56,12 @@ def _builtins_and_handled():
     return builtins, handled
 
 
-@pytest.mark.skipif(
-    not os.environ.get("TF2ONNX_TFLITE_COVERAGE"),
-    reason="TFLite coverage guard runs only in its dedicated non-blocking CI job",
+# unittest.skipUnless (not pytest.mark.skipif) so the guard is honored under both
+# runners -- `pytest` and a direct `python -m unittest` / `unittest.main()` via the
+# __main__ block below.
+@unittest.skipUnless(
+    os.environ.get("TF2ONNX_TFLITE_COVERAGE"),
+    "TFLite coverage guard runs only in its dedicated non-blocking CI job",
 )
 class TFLiteOpCoverageTests(unittest.TestCase):
 


### PR DESCRIPTION
Nothing in CI systematically checks which TFLite builtin operators tf2onnx can convert: the backend suite only exercises builtins that the TFLiteConverter happens to emit from its TF-op-based tests. As a result, fused builtins that no test triggers (e.g. GELU) pass through as an invalid TFL_<NAME> node that no ONNX runtime can load, undetected.

Add tests/test_tflite_op_coverage.py: it introspects tf2onnx's vendored BuiltinOperator enum against the @tfl_op registry and flags builtins with no handler (39 today, listed in KNOWN_UNSUPPORTED). It converts/runs nothing, so it is deterministic and never flaky, and fails only for a change that alters the handled-op set - deleting a handler, adding one without shrinking the list, or a schema bump adding a builtin.

It runs in a dedicated, continue-on-error CI job (TF2ONNX_TFLITE_COVERAGE=1) and is skipped in the normal matrix, so it can never block unrelated PRs.