### PR TITLE
feat : Expand ONNX version support: derive opset→IR map, CI for opset 19-22 & onnx 1.21/1.22

### DIFF
--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -75,6 +75,10 @@ jobs:
           # running the suite against them. Conversion opset is kept modest so the
           # produced models stay runnable under the paired ort; the point is to
           # exercise the onnx python API (build/checker/shape-inference/optimizer).
+          # NOTE: setup_test_env.sh pins numpy<2 while these onnx/ort wheels favour
+          # numpy 2.x, so a failure here may be a numpy-ABI mismatch rather than a
+          # real onnx-API regression - check the log before acting. These jobs are
+          # advisory (experimental) so such noise never blocks other PRs.
           - os: 'ubuntu-latest'
             tf_version: '2.15.0'
             python_version: '3.11'

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -26,13 +26,73 @@ jobs:
         tf_version: ['2.13.0', '2.15.0']
         python_version: ['3.10', '3.11']
         opset_version: ['18', '15']
+        # Single-element lists so existing combinations keep these pins without
+        # multiplying the matrix; the entries below override them per job.
+        onnx_version: ['1.16.1']
+        ort_version: ['1.16.3']
         exclude:
           # TF 2.13 supports Python 3.8-3.11 only
           - tf_version: '2.13.0'
             python_version: '3.12'
           - tf_version: '2.13.0'
             python_version: '3.13'
+        include:
+          # --- newer-opset coverage (onnx 1.17) -------------------------------
+          # The full backend suite converts real ops/models and runs them through
+          # onnxruntime, so these exercise opset 19-22 end-to-end. onnxruntime
+          # enforces an opset ceiling (verified: ort 1.16.3 -> 19, 1.19.2 -> 21,
+          # opset 22 needs ort >= 1.20), so each entry pins a compatible ort.
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '19'
+            onnx_version: '1.17.0'
+            ort_version: '1.19.2'
+            experimental: true
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '20'
+            onnx_version: '1.17.0'
+            ort_version: '1.19.2'
+            experimental: true
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '21'
+            onnx_version: '1.17.0'
+            ort_version: '1.19.2'
+            experimental: true
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '22'
+            onnx_version: '1.17.0'
+            ort_version: '1.20.1'
+            experimental: true
+          # --- newer onnx *package* integration (#2446, #2462) ----------------
+          # Detect API/behaviour incompatibilities with recent onnx releases by
+          # running the suite against them. Conversion opset is kept modest so the
+          # produced models stay runnable under the paired ort; the point is to
+          # exercise the onnx python API (build/checker/shape-inference/optimizer).
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '20'
+            onnx_version: '1.21.0'
+            ort_version: '1.20.1'
+            experimental: true
+          - os: 'ubuntu-latest'
+            tf_version: '2.15.0'
+            python_version: '3.11'
+            opset_version: '20'
+            onnx_version: '1.22.0'
+            ort_version: '1.20.1'
+            experimental: true
     runs-on: ${{ matrix.os }}
+    # Newly added coverage entries are advisory (experimental) so a failure there
+    # never blocks unrelated PRs; the pre-existing combinations stay required.
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -41,8 +101,8 @@ jobs:
         with:
           tf_version: ${{ matrix.tf_version }}
           python_version: ${{ matrix.python_version }}
-          ort_version: '1.16.3'
-          onnx_version: '1.16.1'
+          ort_version: ${{ matrix.ort_version }}
+          onnx_version: ${{ matrix.onnx_version }}
           opset_version: ${{ matrix.opset_version }}
           skip_tflite: 'False'
       - name: Upload Test Results

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -306,12 +306,18 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
             outputs=[helper.make_tensor_value_info("out:0", TensorProto.FLOAT, [2, 2])],
             initializer=[]
         )
+        tested = 0
         for opset in (19, 20, 21, 22):
             if opset > latest:
                 continue
             g = GraphUtil.create_graph_from_onnx_graph(graph_proto, opset_version=opset)
             model_proto = g.make_model("test")
             self.assertEqual(model_proto.ir_version, constants.OPSET_TO_IR_VERSION[opset])
+            tested += 1
+        # guard against a silent pass when the installed onnx is too old to know
+        # any of these opsets - the test would otherwise assert nothing.
+        if latest >= 19:
+            self.assertGreater(tested, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -10,9 +10,9 @@ import numpy as np
 import tensorflow as tf
 from backend_test_base import Tf2OnnxBackendTestBase
 from common import unittest_main
-from onnx import TensorProto, helper, numpy_helper
+from onnx import TensorProto, defs, helper, numpy_helper
 
-from tf2onnx import tf_utils, utils
+from tf2onnx import constants, tf_utils, utils
 from tf2onnx.graph import GraphUtil
 from tf2onnx.graph_matcher import GraphMatcher, OpTypePattern
 from tf2onnx.tf_loader import tf_reset_default_graph, tf_session
@@ -281,6 +281,37 @@ class Tf2OnnxInternalTests(Tf2OnnxBackendTestBase):
             expected = tensors[name]
 
             self.assertTrue(np.array_equal(expected, actual))
+
+    def test_opset_to_ir_version_map(self):
+        # historical workaround must survive the release-table derivation:
+        # opset 7/8 shipped with IR3 but tf2onnx needs IR4 for PlaceholderWithDefault.
+        self.assertEqual(constants.OPSET_TO_IR_VERSION[7], 4)
+        self.assertEqual(constants.OPSET_TO_IR_VERSION[8], 4)
+        # every opset the installed onnx package knows about must be mapped.
+        self.assertIn(defs.onnx_opset_version(), constants.OPSET_TO_IR_VERSION)
+        # no regression for the previously hand-maintained entries.
+        legacy = {9: 4, 10: 5, 11: 6, 12: 7, 13: 7, 14: 7, 15: 8, 16: 8, 17: 8, 18: 8}
+        for opset, ir_version in legacy.items():
+            self.assertEqual(constants.OPSET_TO_IR_VERSION[opset], ir_version)
+
+    def test_ir_version_for_high_opsets(self):
+        # opset 19-22 used to fail with "Opset X is not supported yet"; make sure
+        # they now emit a model with the ir_version reported by the release table.
+        latest = defs.onnx_opset_version()
+        node = helper.make_node("Identity", ["input"], ["out:0"], name="n1")
+        graph_proto = helper.make_graph(
+            nodes=[node],
+            name="test",
+            inputs=[helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 2])],
+            outputs=[helper.make_tensor_value_info("out:0", TensorProto.FLOAT, [2, 2])],
+            initializer=[]
+        )
+        for opset in (19, 20, 21, 22):
+            if opset > latest:
+                continue
+            g = GraphUtil.create_graph_from_onnx_graph(graph_proto, opset_version=opset)
+            model_proto = g.make_model("test")
+            self.assertEqual(model_proto.ir_version, constants.OPSET_TO_IR_VERSION[opset])
 
 
 if __name__ == '__main__':

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -58,7 +58,9 @@ ENV_TF2ONNX_CATCH_ERRORS = "TF2ONNX_CATCH_ERRORS"
 # The map is naturally capped by the installed onnx package's known opsets.
 # Refer to https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
 OPSET_TO_IR_VERSION = {opset: ir_version for _, ir_version, opset, *_ in helper.VERSION_TABLE}
-# Historical override: opset 7 and opset 8 shipped with IR3, but tf2onnx emits
-# PlaceholderWithDefault which requires IR4. Keep the low-opset map explicit so
-# these workarounds survive regardless of what the release table reports.
+# Low-opset overrides for 1-8; this whole range must stay explicit because:
+#   * opsets 2, 3 and 4 have no row in VERSION_TABLE, so they are backfilled here
+#     (dropping them would make graph.py reject conversions at those opsets).
+#   * opsets 7 and 8 shipped with IR3, but tf2onnx emits PlaceholderWithDefault
+#     which requires IR4, so they are pinned to 4 rather than the table's value.
 OPSET_TO_IR_VERSION.update({1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4})

--- a/tf2onnx/constants.py
+++ b/tf2onnx/constants.py
@@ -52,8 +52,13 @@ ENV_TF2ONNX_DEBUG_MODE = "TF2ONNX_DEBUG_MODE"
 ENV_TF2ONNX_CATCH_ERRORS = "TF2ONNX_CATCH_ERRORS"
 
 # Mapping opset to IR version.
-# Note: opset 7 and opset 8 came out with IR3 but we need IR4 because of PlaceholderWithDefault
-# Refer from https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
-OPSET_TO_IR_VERSION = {
-    1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4, 9: 4, 10: 5, 11: 6, 12: 7, 13: 7, 14: 7, 15: 8, 16: 8, 17: 8, 18: 8
-}
+# Derived from the ONNX release table (helper.VERSION_TABLE rows are
+# (onnx_version, ir_version, opset, ai.onnx.ml, ai.onnx.training)) so that newer
+# ONNX releases are picked up automatically instead of hand-editing this map.
+# The map is naturally capped by the installed onnx package's known opsets.
+# Refer to https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
+OPSET_TO_IR_VERSION = {opset: ir_version for _, ir_version, opset, *_ in helper.VERSION_TABLE}
+# Historical override: opset 7 and opset 8 shipped with IR3, but tf2onnx emits
+# PlaceholderWithDefault which requires IR4. Keep the low-opset map explicit so
+# these workarounds survive regardless of what the release table reports.
+OPSET_TO_IR_VERSION.update({1: 3, 2: 3, 3: 3, 4: 3, 5: 3, 6: 3, 7: 4, 8: 4})

--- a/tf2onnx/keras2onnx_api.py
+++ b/tf2onnx/keras2onnx_api.py
@@ -8,7 +8,7 @@ Use tf2onnx.keras2onnx_api.convert_keras instead of deprecated keras2onnx.conver
 # pylint: disable=unused-argument,missing-docstring
 
 import tensorflow as tf
-from onnx import defs, mapping
+from onnx import defs, helper
 
 import tf2onnx
 from tf2onnx.constants import OPSET_TO_IR_VERSION
@@ -16,7 +16,9 @@ from tf2onnx.constants import OPSET_TO_IR_VERSION
 
 def to_tf_tensor_spec(onnx_type, name=None, unknown_dim=1):
     shp = [unknown_dim if isinstance(n_, str) else n_ for n_ in onnx_type.shape]
-    return tf.TensorSpec(shp, mapping.TENSOR_TYPE_TO_NP_TYPE[onnx_type.to_onnx_type().tensor_type.elem_type],
+    # onnx.mapping (incl. TENSOR_TYPE_TO_NP_TYPE) was removed in onnx 1.19; use
+    # the helper function instead so tf2onnx works on modern onnx releases.
+    return tf.TensorSpec(shp, helper.tensor_dtype_to_np_dtype(onnx_type.to_onnx_type().tensor_type.elem_type),
                          name=name)
 
 def _process_initial_types(initial_types, unknown_dim=1):


### PR DESCRIPTION
## Summary                                                                                              
  Expand tf2onnx's ONNX version support along three axes: newer **opsets**, newer                       
  **onnx packages**, and a **removed-API** fix that blocks modern onnx. Targets the                       
  recurring release-integration requests #2446 (onnx 1.21) and #2462 (onnx 1.22).                      
 This is part of #2472    
                                                                                                          
  ## Changes                                                                                              
  - **Enable opsets 19-22** — derive `OPSET_TO_IR_VERSION` from                                           
    `onnx.helper.VERSION_TABLE` instead of a hand-maintained dict that stopped at                         
    opset 18 (which made `--opset 19..22` fail at graph.py's `make_sure`). The map                        
    now tracks whatever the installed onnx knows, with no manual step; the opset                          
    7/8 → IR4 workaround is preserved and opsets 2-4 (absent from the table) are                          
    backfilled. Unit-tested (map contents + opset 19-22 `ir_version` on emit).                            
  - **CI coverage** — advisory (`experimental`) matrix jobs that run the full                             
    backend suite (convert real ops/models → onnxruntime):                                                
    - opset 19-22 on onnx 1.17.0 (ort pinned per its opset ceiling);                                      
    - onnx **1.21.0** and **1.22.0** package integration to surface API/behaviour                         
      incompatibilities (refs #2446, #2462).                                                              
  - **Fix removed API** — `onnx.mapping.TENSOR_TYPE_TO_NP_TYPE` was removed in onnx                       
    1.19; replace it with `helper.tensor_dtype_to_np_dtype` (equivalent across all                        
    tensor types, available since onnx 1.14) so tf2onnx imports on modern onnx.                           
                                                                                                          
  ## Relation to #2468                               
  #2468 (@bertsky) targets the same `OPSET_TO_IR_VERSION` gap by extending the dict                       
  by hand. This PR uses the release-table derivation instead, which avoids manual
  maintenance and hardcoding IR versions for unreleased opsets, and adds the CI                           
  coverage + import fix on top. Happy to reconcile however the author/maintainers
  prefer — credit to @bertsky for surfacing the gap.                                                      
                                                     
  ## Safety
  All added CI entries set `experimental: true`, and the job uses 
  `continue-on-error: ${{ matrix.experimental || false }}`. These advisory jobs
  **never block unrelated PRs**; the 16 pre-existing combinations keep their pins
  (onnx 1.16.1 / ort 1.16.3) and required status.                                                         
                                                                                                          
  ## Notes / limitations                                                                                  
  - onnxruntime enforces an opset ceiling (verified: ort 1.16.3 → opset 19,                               
    1.19.2 → 21; opset 22 needs ort ≥ 1.20), so each new job pins a compatible ort.                       
    Exact onnx/ort pairings may need one CI run to settle.                                                
  - The onnx 1.21/1.22 jobs pair newer onnx/ort with `numpy<2`, so a failure there
    may be a numpy-ABI mismatch rather than an onnx-API regression — check the log.                       
    Being advisory, this is non-disruptive (which is the point of "integrate the                          
    release branch to detect incompatibilities").                                                         
                                                                                                          
  ## Out of scope (follow-ups)                                                                            
  This PR is the enablement + diagnostic layer. Follow-ups its CI will help                               
  prioritise: remaining numpy-2.0 alias purge (#2373), protobuf pin vs TF 2.20                            
  (#2409), per-op handler coverage where opset signatures changed, `--opset`                              
  clamping to the target onnxruntime, and a recurring onnx-RC integration CI lane.