### PR TITLE
fix: replace numpy 2.0-removed aliases (np.product/np.cast/np.string_)

### DIFF
--- a/tests/run_pretrained_models.py
+++ b/tests/run_pretrained_models.py
@@ -151,7 +151,7 @@ def get_sentences(shape):
     def get_sentence():
         length = random.randint(2, 7)
         return ' '.join(random.choice(words) for _ in range(length))
-    return np.array([get_sentence() for _ in range(np.product(shape))]).reshape(shape)
+    return np.array([get_sentence() for _ in range(np.prod(shape))]).reshape(shape)
 
 
 _INPUT_FUNC_MAPPING = {

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1428,8 +1428,8 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2})
 
     def test_equal_string(self):
-        x_val1 = np.array(['1'], dtype=np.string_)
-        x_val2 = np.array(['2'], dtype=np.string_)
+        x_val1 = np.array(['1'], dtype=np.bytes_)
+        x_val2 = np.array(['2'], dtype=np.bytes_)
         def func(x1, x2):
             mi = tf.equal(x1, x2)
             return tf.identity(mi, name=_TFOUTPUT)

--- a/tf2onnx/graph.py
+++ b/tf2onnx/graph.py
@@ -102,7 +102,7 @@ class Node(object):
             return external_tensor_storage.node_to_modified_value_attr[self]
         if external_tensor_storage is None or a.type != AttributeProto.TENSOR:
             return a
-        if np.product(a.t.dims) > external_tensor_storage.external_tensor_size_threshold:
+        if np.prod(a.t.dims) > external_tensor_storage.external_tensor_size_threshold:
             a = copy.deepcopy(a)
             tensor_name = self.name.strip() + "_" + str(external_tensor_storage.name_counter)
             for c in '~"#%&*:<>?/\\{|}':

--- a/tf2onnx/tfjs_utils.py
+++ b/tf2onnx/tfjs_utils.py
@@ -318,7 +318,7 @@ def graphs_from_tfjs(model_path, input_names=None, output_names=None, shape_over
 def read_tfjs_weight(weight, weights_data, offset):
     """Returns the name, numpy array, and number of bytes for a tfjs weight"""
     name = weight['name']
-    count = np.product(weight['shape'], dtype=np.int64)
+    count = np.prod(weight['shape'], dtype=np.int64)
     if weight['dtype'] == 'string':
         num_strings = np.prod(weight['shape'], dtype=np.int64)
         string_list, num_bytes = read_string_weight(weights_data, offset, num_strings)

--- a/tools/onnx-experiments.py
+++ b/tools/onnx-experiments.py
@@ -52,7 +52,7 @@ def rewrite_constant_fold(g, ops):
         "Unsqueeze": not None,
         "Slice": not None,
         "Add": np.add,
-        "Cast": np.cast,
+        "Cast": not None,
         "Mul": np.multiply,
         "Sqrt": np.sqrt,
         "Sub": np.subtract,
@@ -78,7 +78,7 @@ def rewrite_constant_fold(g, ops):
                     if op.type == "Cast":
                         dst = op.get_attr_int("to")
                         np_type = tf2onnx.utils.map_onnx_to_numpy_type(dst)
-                        val = np.cast[np_type](*inputs)
+                        val = np.asarray(*inputs).astype(np_type)
                     elif op.type == "Transpose":
                         perm = op.get_attr("perm").ints
                         val = np.transpose(inputs[0], perm)


### PR DESCRIPTION
 ## What                                            
                                                     
  numpy 2.0 removed several long-deprecated aliases. This replaces the remaining                          
  usages left in the tree with their supported equivalents. Every change is
  behaviour-preserving — the replacements are exact aliases or an equivalent                              
  expression, so no conversion output changes.                                                            
                                                                                                          
  | Location | Before | After |                                                                           
  |---|---|---|                                      
  | `tf2onnx/graph.py` | `np.product(...)` | `np.prod(...)` |                                             
  | `tf2onnx/tfjs_utils.py` | `np.product(...)` | `np.prod(...)` |
  | `tests/run_pretrained_models.py` | `np.product(...)` | `np.prod(...)` |
  | `tools/onnx-experiments.py` | `np.cast[t](*inputs)` | `np.asarray(*inputs).astype(t)` |
  | `tools/onnx-experiments.py` | `"Cast": np.cast` | `"Cast": not None` |
  | `tests/test_backend.py` | `dtype=np.string_` | `dtype=np.bytes_` |
                                                     
  Details:                                           
                                                                                                          
  - **`np.product` → `np.prod`** — `np.product` was removed in numpy 2.0; `np.prod`                       
    is the canonical name and has the identical signature (the `dtype=` kwarg in                          
    `tfjs_utils.py` is preserved).                                                                        
  - **`np.string_` → `np.bytes_`** — `np.string_` was removed in numpy 2.0;
    `np.bytes_` is the `S`-kind dtype it aliased.                                                         
  - **`np.cast`** — removed in numpy 2.0. In `onnx-experiments.py`, `Cast` is
    special-cased inside the constant-folding loop, so `func_map["Cast"]` is only                         
    read as a non-`None` sentinel (never called). It now matches the neighbouring
    `"Transpose"/"Unsqueeze"/"Slice": not None` entries, and the real cast is done
    with `np.asarray(x).astype(t)`.                                                                       
                                                     
  This keeps the existing numpy-alias cleanup going (`onnx.mapping` and earlier                           
  `np.*` fixes already landed); a repo-wide scan for numpy-2.0-removed symbols is                         
  clean after this change.      
                                                                          
## Scope
 
  This PR is **source-code only** — it swaps numpy-2.0-removed aliases for their
  supported equivalents so the library doesn't crash under numpy 2.x. It does
  **not** touch dependency pinning or CI.                                                                 
                                                     
  The packaging/CI side of numpy-2 support — dropping the redundant direct                                
  `protobuf` dependency and making the unit-test `numpy<2` pin configurable — is                          
  handled separately in #2475 so the two concerns can be reviewed independently.
  There is no file overlap between the two. Both are Part of #2472.
                                                                                                    
  ## Testing                                         
                                                                                                          
  - Repo-wide grep for numpy 2.0-removed aliases returns no hits.
  - Edited `tf2onnx` modules import cleanly; the edited tool/test files compile.
  - The affected `tests/test_backend.py::test_equal_string` passes.

Part of #2472