### PR TITLE
chore: untangle protobuf/numpy test pinning

### DIFF
--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: 'OPSET version'
   skip_tflite:
     description: 'Skip TFLite tests'
+  numpy_spec:
+    description: 'pip requirement spec for numpy (e.g. "numpy<2" or "numpy>=2")'
+    default: 'numpy<2'
 
 runs:
   using: "composite"
@@ -29,9 +32,10 @@ runs:
         TF_VERSION: ${{ inputs.tf_version }}
         ORT_VERSION: ${{ inputs.ort_version }}
         ONNX_VERSION: ${{ inputs.onnx_version }}
+        NUMPY_SPEC: ${{ inputs.numpy_spec }}
       run: |
         chmod +x ./tests/utils/setup_test_env.sh
-        ./tests/utils/setup_test_env.sh "$TF_VERSION" "$ORT_VERSION" "$ONNX_VERSION"
+        ./tests/utils/setup_test_env.sh "$TF_VERSION" "$ORT_VERSION" "$ONNX_VERSION" "$NUMPY_SPEC"
 
     - name: Fix Paths (Windows only)
       shell: pwsh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
     "onnx>=1.14.0",
     "requests",
     "flatbuffers>=1.12",
-    "protobuf>=3.20",
+    # protobuf is intentionally not pinned here: it is a transitive dependency of
+    # onnx, tensorflow and onnxruntime, which already agree on a compatible range.
+    # Declaring our own floor only risks resolver conflicts (e.g. blocking newer
+    # TensorFlow that requires a different protobuf) without adding safety.
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/utils/setup_test_env.sh
+++ b/tests/utils/setup_test_env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # # Check if the argument is provided
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <tensorflow_version> <onnxruntime_version> <onnx_version>"
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "Usage: $0 <tensorflow_version> <onnxruntime_version> <onnx_version> [numpy_spec]"
     exit 1
 fi
 
@@ -10,12 +10,16 @@ fi
 TF_VERSION=$1
 ORT_VERSION=$2
 ONNX_VERSION=$3
+# numpy constraint is configurable so a lane can exercise the suite under numpy
+# 2.x; default keeps the historical numpy<2 pin for the existing combinations.
+NUMPY_SPEC=${4:-"numpy<2"}
 
 echo "==== TensorFlow version: $TF_VERSION"
 echo "==== ONNXRuntime version: $ORT_VERSION"
 echo "==== ONNX version: $ONNX_VERSION"
+echo "==== numpy spec: $NUMPY_SPEC"
 
-pip install "numpy<2" onnx==$ONNX_VERSION onnxruntime==$ORT_VERSION onnxruntime-extensions
+pip install "$NUMPY_SPEC" onnx==$ONNX_VERSION onnxruntime==$ORT_VERSION onnxruntime-extensions
 pip install pytest pytest-cov pytest-runner coverage graphviz requests pyyaml pillow pandas parameterized sympy coloredlogs flatbuffers timeout-decorator
 pip install tensorflow==$TF_VERSION
 

--- a/tests/utils/setup_test_env.sh
+++ b/tests/utils/setup_test_env.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fail fast: stop on the first error (e.g. a failed pip install) and on unset
+# variables, so a version-matrix job never silently proceeds with a broken env.
+set -euo pipefail
+
 # # Check if the argument is provided
 if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
     echo "Usage: $0 <tensorflow_version> <onnxruntime_version> <onnx_version> [numpy_spec]"
@@ -12,7 +16,7 @@ ORT_VERSION=$2
 ONNX_VERSION=$3
 # numpy constraint is configurable so a lane can exercise the suite under numpy
 # 2.x; default keeps the historical numpy<2 pin for the existing combinations.
-NUMPY_SPEC=${4:-"numpy<2"}
+NUMPY_SPEC="${4:-numpy<2}"
 
 echo "==== TensorFlow version: $TF_VERSION"
 echo "==== ONNXRuntime version: $ORT_VERSION"


### PR DESCRIPTION
## What                                            
                                                     
  Two independent bits of dependency untangling toward supporting modern stacks
  (newer TensorFlow / numpy 2.x). Part of #2472.     
                                                                                                          
  **1. Drop the direct `protobuf>=3.20` runtime dependency.**
  `protobuf` is already a transitive dependency of `onnx`, `tensorflow` and
  `onnxruntime`, which agree on a compatible range. Declaring our own floor only                          
  risks resolver conflicts (e.g. blocking a newer TensorFlow that pulls a
  different protobuf — see #2409) without adding any safety.
                                                                                                          
  **2. Make the unit-test numpy constraint configurable instead of hardcoding `numpy<2`.**
  - `tests/utils/setup_test_env.sh` takes an optional 4th arg `numpy_spec`
    (default `"numpy<2"`).                                                                                
  - The `unit_test` composite action exposes a matching `numpy_spec` input
    (default `"numpy<2"`).                           
                                                                                                          
  Default behaviour is unchanged for every existing job — this only *enables* a                           
  future lane to run the suite under numpy 2.x.      
                                                                                                          
## Relationship to #2474                           
                                                                                                          
  This is the **packaging / CI** half of numpy-2 support and is complementary to
  the source-code half in #2474 (replacing numpy-2.0-removed aliases like
  `np.product` / `np.string_`). #2474 makes the code *run* under numpy 2.x; this                          
  PR makes it possible to *test* under numpy 2.x. There is no file overlap between
  the two. Both are Part of #2472.              
                                                                                                          
  ## Why not add the numpy>=2 lane here?                                                                  
                                                     
  numpy 2.x requires **TensorFlow >= 2.19** (the 2.13/2.15 wheels hard-require
  `numpy<2`), which also pulls in **Keras 3** — a combination the test matrix does                        
  not yet cover. Establishing that baseline is its own change; this PR is the                             
  enabler so it can land cleanly on top.             
                                                     
  ## Testing                                         
                                                     
  - `pyproject.toml` parses; `protobuf` removed from direct deps, `onnx` retained;                        
    protobuf still resolves transitively via onnx/tensorflow/onnxruntime.
  - `setup_test_env.sh` argument guard accepts 3–4 args and rejects 2/5; the
    `numpy_spec` default resolves to `numpy<2` when omitted and to the passed                             
    value otherwise.                                 
  - `.github/actions/unit_test/action.yml` is valid YAML and forwards the 4th arg.