### PR TITLE
fix: handle protobuf runtime_version import across versions

### DIFF
--- a/tests/test_protobuf_compat.py
+++ b/tests/test_protobuf_compat.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for protobuf runtime_version compatibility shim."""
+
+import sys
+import types
+
+import pytest
+
+
+def test_runtime_version_shim_provides_validator():
+    """When google.protobuf.runtime_version is missing, the shim injects one."""
+    # Simulate an older protobuf runtime by removing runtime_version from sys.modules.
+    real_module = sys.modules.pop("google.protobuf.runtime_version", None)
+    protobuf_pkg = sys.modules.get("google.protobuf")
+    original_has_runtime_version = hasattr(protobuf_pkg, "runtime_version") if protobuf_pkg else False
+    if protobuf_pkg and original_has_runtime_version:
+        delattr(protobuf_pkg, "runtime_version")
+
+    try:
+        # Clear any cached tf2onnx.protobuf_compat module so the shim path runs again.
+        sys.modules.pop("tf2onnx.protobuf_compat", None)
+        import tf2onnx.protobuf_compat  # noqa: F401  # side-effect under test
+
+        shim = sys.modules["google.protobuf.runtime_version"]
+        assert isinstance(shim, types.ModuleType)
+        assert hasattr(shim, "ValidateProtobufRuntimeVersion")
+        # The stubbed validator must be callable and not raise.
+        shim.ValidateProtobufRuntimeVersion(1, 2, 3, "", "dummy")
+    finally:
+        # Restore original state.
+        if real_module is not None:
+            sys.modules["google.protobuf.runtime_version"] = real_module
+        elif "google.protobuf.runtime_version" in sys.modules:
+            del sys.modules["google.protobuf.runtime_version"]
+        if protobuf_pkg and original_has_runtime_version:
+            protobuf_pkg.runtime_version = real_module
+
+
+def test_runtime_version_passthrough_when_present():
+    """If google.protobuf.runtime_version already exists, the shim leaves it alone."""
+    try:
+        from google.protobuf import runtime_version as real_runtime_version
+    except ImportError:
+        pytest.skip("protobuf runtime_version is not available in this environment")
+
+    sys.modules.pop("tf2onnx.protobuf_compat", None)
+    import tf2onnx.protobuf_compat  # noqa: F401  # side-effect under test
+
+    assert sys.modules["google.protobuf.runtime_version"] is real_runtime_version

--- a/tf2onnx/__init__.py
+++ b/tf2onnx/__init__.py
@@ -7,6 +7,8 @@ __all__ = ["utils", "graph_matcher", "graph", "graph_builder",
 
 import importlib
 
+from tf2onnx import protobuf_compat  # noqa: F401  # side-effect: shim google.protobuf.runtime_version
+
 import onnx
 
 from . import verbose_logging as logging

--- a/tf2onnx/protobuf_compat.py
+++ b/tf2onnx/protobuf_compat.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility shim for protobuf runtime_version.
+
+ONNX 1.16+ ships protobuf-generated files that import
+``google.protobuf.runtime_version`` and call ``ValidateProtobufRuntimeVersion``.
+That module was introduced in protobuf 5.27, so importing ONNX on older
+protobuf releases raises ``ImportError`` at load time.
+
+This module injects a no-op stub when the real ``runtime_version`` is missing,
+allowing tf2onnx to be imported with older protobuf runtimes.
+"""
+
+import sys
+import types
+
+try:
+    from google.protobuf import runtime_version  # type: ignore
+except ImportError:
+    # Protobuf runtime is older than 5.27 and does not expose runtime_version.
+    # Provide a minimal stub so ONNX's generated modules can still be imported.
+    _stub = types.ModuleType("google.protobuf.runtime_version")
+    _stub.MAJOR = 0
+    _stub.MINOR = 0
+    _stub.PATCH = 0
+    _stub.SUFFIX = ""
+    _stub.OSS_VERSION = 0
+
+    def ValidateProtobufRuntimeVersion(*args, **kwargs):  # pylint: disable=invalid-name
+        """No-op runtime version check for older protobuf installations."""
+
+    _stub.ValidateProtobufRuntimeVersion = ValidateProtobufRuntimeVersion
+    sys.modules["google.protobuf.runtime_version"] = _stub


### PR DESCRIPTION
Fixes #2418.

Installing from source and running `python -m tf2onnx.convert --tflite x.tflite --output x.onnx` can fail at import time with `ImportError: cannot import name 'runtime_version' from 'google.protobuf'`. The traceback points through `tf2onnx/__init__.py` → `onnx` → `onnx_ml_pb2.py`, which tries to import `google.protobuf.runtime_version`. That module was only introduced in protobuf 5.27, so ONNX 1.16+ generated files fail to load on older protobuf runtimes before `tf2onnx.convert` even starts.

A contributor checked this against current `main` (`6537fcb2`) in a clean Python 3.13 environment and could no longer reproduce the failure, because the current resolver now pulls in ONNX 1.22.0 and protobuf 7.35.1, both of which expose `runtime_version`. That change is partly driven by #2419, which bumped protobuf to patch CVEs. Still, the mismatch remains for anyone pinned to an older protobuf, and failing at import time is a bad experience regardless of what the latest resolver happens to choose.

Rather than force a protobuf upgrade, this adds a small compatibility shim. `tf2onnx/protobuf_compat.py` checks whether `google.protobuf.runtime_version` exists; if it does not, it injects a minimal stub module containing the constants ONNX's generated code expects (`MAJOR`, `MINOR`, `PATCH`, `SUFFIX`, `OSS_VERSION`) and a no-op `ValidateProtobufRuntimeVersion`. `tf2onnx/__init__.py` imports the shim before `import onnx`, so the stub is in place early enough. When the real module is already present, the shim is a no-op.

I added `tests/test_protobuf_compat.py` to cover both the stub path and the passthrough path. Running those tests together with the convert and const-fold suites passes; the unrelated `test_api.py` failures are the pre-existing Keras 3 / TF 2.16 issues.