### PR TITLE
Fuse Gemm for float64 (double) models (fixes #2353)

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4715,6 +4715,27 @@ class BackendTests(Tf2OnnxBackendTestBase):
         self._run_test_case(func, [_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2, _INPUT2: x_val3},
                             graph_validator=lambda g: check_op_count(g, "Gemm", 1))
 
+    def test_gemm_pattern0_double(self):
+        # float64 (double) MatMul+Add must fuse into Gemm too: ONNX Gemm allows
+        # double and onnxruntime implements the kernel. disabled=False so the
+        # validator actually asserts the fusion happened.
+        max_number = 10
+        m = np.random.randint(max_number)
+        n = np.random.randint(max_number)
+        k = np.random.randint(max_number)
+        x_val1 = np.random.rand(m, n).astype("float64")
+        x_val2 = np.random.rand(n, k).astype("float64")
+        x_val3 = np.random.rand(m, k).astype("float64")
+        def func(a, b, c):
+            alpha = tf.constant(1.0, dtype=tf.float64)
+            beta = tf.constant(2.0, dtype=tf.float64)
+            mul1 = tf.multiply(alpha, tf.matmul(a, b))
+            mul2 = tf.multiply(beta, c)
+            x_ = mul1 + mul2
+            return tf.identity(x_, name=_TFOUTPUT)
+        self._run_test_case(func, [_OUTPUT], {_INPUT: x_val1, _INPUT1: x_val2, _INPUT2: x_val3},
+                            graph_validator=lambda g: check_op_count(g, "Gemm", 1, disabled=False))
+
     # test for gemm pattern1: alpha*A*B + C
     def test_gemm_pattern1(self):
         max_number = 10

--- a/tf2onnx/rewriter/gemm_rewriter.py
+++ b/tf2onnx/rewriter/gemm_rewriter.py
@@ -4,11 +4,12 @@
 """
 tf2onnx.rewrite - rewrite tensorflow subgraph to onnx gemm op
 """
-import logging
 
 from onnx import onnx_pb
 
 from tf2onnx.graph_matcher import GraphMatcher, OpTypePattern
+
+_GEMM_SUPPORTED_DTYPES = {onnx_pb.TensorProto.FLOAT, onnx_pb.TensorProto.DOUBLE}
 
 # pylint: disable=missing-docstring
 
@@ -72,8 +73,10 @@ def rewrite_gemm(g, ops):
             for match in match_results:
                 matmul_node = match.get_op("matmul")
 
-                if g.get_dtype(matmul_node.input[0]) != onnx_pb.TensorProto.FLOAT:
-                    logging.warning(u"For now, onnxruntime only support float32 type for Gemm rewriter")
+                # ONNX Gemm's type constraint T allows float16/float/double and
+                # onnxruntime implements the float and double kernels, so fuse
+                # both float32 and float64 (double) MatMul+Add patterns.
+                if g.get_dtype(matmul_node.input[0]) not in _GEMM_SUPPORTED_DTYPES:
                     continue
 
                 attr, is_valid = get_gemm_attr(match)


### PR DESCRIPTION
Fixes #2353.

### Problem

The Gemm rewriter fuses `MatMul + Add` (with optional alpha/beta scaling) into a single ONNX `Gemm` node, but only when the input dtype is exactly `float32`:

```python
if g.get_dtype(matmul_node.input[0]) != onnx_pb.TensorProto.FLOAT:
    logging.warning(u"For now, onnxruntime only support float32 type for Gemm rewriter")
    continue
```

ONNX's `Gemm` type constraint `T` allows `float16`/`float`/`double`, and onnxruntime has implemented the `double` kernel for years. So float64 models never get the fusion float32 models get, and users are shown a misleading warning claiming double isn't supported when it is (#2353).

### Fix

Allow both `float32` and `float64` through the rewriter (scoped conservatively to those two — float16 is left out to avoid any half-precision tolerance discussion) and drop the stale warning:

```python
_GEMM_SUPPORTED_DTYPES = {onnx_pb.TensorProto.FLOAT, onnx_pb.TensorProto.DOUBLE}
...
if g.get_dtype(matmul_node.input[0]) not in _GEMM_SUPPORTED_DTYPES:
    continue
```

### Verification

- Confirmed onnxruntime executes a `double` `Gemm` node correctly (float64 output, numerically matching `A@B + C`).
- Before the change: a float64 `MatMul+Add` converts to separate `MatMul` + `Add` nodes (no fusion) plus the warning; after: it fuses to a single `Gemm`, matching the float32 behaviour. float32 behaviour is unchanged.
- Added `test_gemm_pattern0_double` mirroring `test_gemm_pattern0` with float64 and `check_op_count(..., disabled=False)` so it actually asserts the `Gemm` is formed. (The existing gemm tests use the default `disabled=True`, which makes that validator a no-op, so the fusion was never asserted.) `ruff` is clean.

---
*Disclosure: I used an LLM to help find and draft this change; I verified the onnxruntime double-Gemm behaviour and the fix myself.*
