### PR TITLE
ci: test ONNX release candidates weekly

### DIFF
--- a/.github/workflows/onnx_release_candidate_ci.yml
+++ b/.github/workflows/onnx_release_candidate_ci.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/onnx_release_candidate_ci.yml
+++ b/.github/workflows/onnx_release_candidate_ci.yml
@@ -1,0 +1,77 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: ONNX Release Candidate
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/onnx_release_candidate_ci.yml"
+      - ".github/actions/unit_test/action.yml"
+      - "tools/latest_pypi_prerelease.py"
+      - "tools/test_latest_pypi_prerelease.py"
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-onnx-release-candidate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Test prerelease resolver
+        run: |
+          python -m pip install packaging
+          python -m unittest tools/test_latest_pypi_prerelease.py
+
+      - name: Resolve latest ONNX release candidate
+        id: onnx
+        shell: bash
+        run: |
+          metadata="${RUNNER_TEMP}/onnx-pypi.json"
+          curl --fail --retry 3 --retry-all-errors --retry-delay 2 \
+            --silent --show-error https://pypi.org/pypi/onnx/json \
+            --output "${metadata}"
+          version="$(python tools/latest_pypi_prerelease.py "${metadata}")"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          if [[ -n "${version}" ]]; then
+            echo "Testing ONNX ${version}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "No ONNX release candidate newer than the latest stable release." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Run unit tests against ONNX release candidate
+        if: steps.onnx.outputs.version != ''
+        uses: ./.github/actions/unit_test
+        with:
+          tf_version: "2.15.0"
+          python_version: "3.11"
+          ort_version: "1.20.1"
+          onnx_version: ${{ steps.onnx.outputs.version }}
+          opset_version: "18"
+          skip_tflite: "False"
+
+      - name: Upload test results
+        if: always() && steps.onnx.outputs.version != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ONNX RC Test Results (${{ steps.onnx.outputs.version }})
+          path: junit/test-results.xml

--- a/tools/latest_pypi_prerelease.py
+++ b/tools/latest_pypi_prerelease.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find the latest usable PyPI prerelease newer than the current stable release."""
+
+import argparse
+import json
+
+from packaging.version import InvalidVersion, Version
+
+
+def latest_prerelease(releases):
+    """Return the newest non-yanked prerelease newer than the latest stable."""
+    stable_versions = []
+    prerelease_versions = []
+
+    for value, files in releases.items():
+        try:
+            version = Version(value)
+        except InvalidVersion:
+            continue
+
+        if not files or all(file.get("yanked", False) for file in files):
+            continue
+
+        if version.is_prerelease and not version.is_devrelease:
+            prerelease_versions.append(version)
+        elif not version.is_devrelease:
+            stable_versions.append(version)
+
+    latest_stable = max(stable_versions, default=None)
+    candidates = [
+        version
+        for version in prerelease_versions
+        if latest_stable is None or version > latest_stable
+    ]
+    return str(max(candidates)) if candidates else ""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("metadata", type=argparse.FileType(encoding="utf-8"))
+    args = parser.parse_args()
+    print(latest_prerelease(json.load(args.metadata)["releases"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_latest_pypi_prerelease.py
+++ b/tools/test_latest_pypi_prerelease.py
@@ -29,6 +29,9 @@ class LatestPrereleaseTest(unittest.TestCase):
 
         self.assertEqual(latest_prerelease(releases), "")
 
+    def test_returns_empty_when_no_releases_exist(self):
+        self.assertEqual(latest_prerelease({}), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_latest_pypi_prerelease.py
+++ b/tools/test_latest_pypi_prerelease.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from tools.latest_pypi_prerelease import latest_prerelease
+
+
+class LatestPrereleaseTest(unittest.TestCase):
+    def test_returns_latest_usable_prerelease_newer_than_stable(self):
+        releases = {
+            "invalid": [{"yanked": False}],
+            "1.21.0rc1": [{"yanked": False}],
+            "1.22.0": [{"yanked": False}],
+            "1.23.0.dev1": [{"yanked": False}],
+            "1.23.0rc1": [{"yanked": True}],
+            "1.23.0rc2": [{"yanked": False}],
+            "1.23.0rc3": [],
+        }
+
+        self.assertEqual(latest_prerelease(releases), "1.23.0rc2")
+
+    def test_returns_empty_when_only_stale_prereleases_exist(self):
+        releases = {
+            "1.21.0rc1": [{"yanked": False}],
+            "1.21.0": [{"yanked": False}],
+            "1.22.0rc1": [{"yanked": False}],
+            "1.22.0": [{"yanked": False}],
+        }
+
+        self.assertEqual(latest_prerelease(releases), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a weekly and manually dispatchable ONNX release-candidate compatibility workflow
- select only non-yanked prereleases newer than the latest stable PyPI release
- skip cleanly when no active ONNX release candidate exists
- reuse the existing unit-test composite action and upload its JUnit results
- add focused tests for prerelease selection, including stale, yanked, dev, invalid, and empty releases

## Why

The release-integration roadmap in #2472 calls for a recurring ONNX RC lane so compatibility problems are found before each stable ONNX release instead of through one-off integration issues. The existing matrix covers fixed ONNX versions but cannot discover future release candidates automatically.

The workflow downloads official PyPI metadata with retries, resolves the current release candidate using PEP 440 ordering, and runs the established TensorFlow 2.15 / Python 3.11 compatibility suite at opset 18. When PyPI has no prerelease newer than stable, the run records that state in the job summary and exits successfully.

Addresses the recurring ONNX-RC integration follow-up in #2472.

## Validation

- `python -m unittest tools/test_latest_pypi_prerelease.py` on Python 3.11
- real PyPI metadata smoke test (currently resolves no active RC, as expected)
- `ruff check tools/latest_pypi_prerelease.py tools/test_latest_pypi_prerelease.py`
- `actionlint .github/workflows/onnx_release_candidate_ci.yml`
- YAML parse and `git diff --check`

Signed-off-by: Neal <neal.lin917@gmail.com>