### PR TITLE
fix: avoid IndexError for TFLite ops without outputs

### DIFF
--- a/tests/test_tflite_utils.py
+++ b/tests/test_tflite_utils.py
@@ -72,3 +72,44 @@ class TFListUtilsTests(Tf2OnnxBackendTestBase):
             self.assertEqual(dtype, dtypes[name])
 
         self.assertTrue(len(onnx_nodes) >= 4)
+
+    @check_tf_min_version("2.0")
+    def test_parse_tflite_graph_op_without_outputs(self):
+        # Ops such as ASSIGN_VARIABLE have no outputs at all, so their node name
+        # cannot be derived from the first output tensor.
+
+        class VariableModule(tf.Module):
+            def __init__(self):
+                super().__init__()
+                self.v = tf.Variable([0.0, 0.0], dtype=tf.float32)
+
+            @tf.function(input_signature=[tf.TensorSpec([2], tf.float32, name="input")])
+            def __call__(self, x):
+                self.v.assign(x)
+                return tf.identity(self.v + 1.0, name="output")
+
+        module = VariableModule()
+        concrete_func = module.__call__.get_concrete_function()
+        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func], module)
+        converter.experimental_enable_resource_variables = True
+        tflite_model = converter.convert()
+
+        tflite_path = os.path.join(self.test_data_directory, self._testMethodName + ".tflite")
+        os.makedirs(os.path.dirname(tflite_path), exist_ok=True)
+        with open(tflite_path, 'wb') as f:
+            f.write(tflite_model)
+
+        tflite_graphs, opcodes_map, model, tensor_shapes = read_tflite_model(tflite_path)
+        nodes_without_outputs = []
+        for tflite_graph in tflite_graphs:
+            onnx_nodes = parse_tflite_graph(tflite_graph, opcodes_map, model,
+                                            tensor_shapes_override=tensor_shapes)[0]
+            names = [node.name for node in onnx_nodes]
+            self.assertEqual(len(names), len(set(names)))
+            for node in onnx_nodes:
+                self.assertTrue(node.name)
+                if len(node.output) == 0:
+                    nodes_without_outputs.append(node)
+
+        # The model must exercise the op-without-outputs path for this test to mean anything.
+        self.assertTrue(len(nodes_without_outputs) > 0)

--- a/tf2onnx/tflite_utils.py
+++ b/tf2onnx/tflite_utils.py
@@ -529,7 +529,6 @@ def parse_tflite_graph(tflite_g, opcodes_map, model, input_prefix='', tensor_sha
                         output_shapes[out] = None
         if has_prequantized_output:
             output_names = [get_prequant(out) for out in output_names]
-        onnx_node = utils.make_onnx_node_with_attr(optype, input_names, output_names, name=output_names[0], **attr)
         node_name = output_names[0] if output_names else utils.make_name(f"{optype}_Output")
         onnx_node = utils.make_onnx_node_with_attr(optype, input_names, output_names, name=node_name, **attr)
         onnx_nodes.append(onnx_node)


### PR DESCRIPTION
Fixes #2380

## Problem

Converting a TFLite model that contains an op with zero outputs (`ASSIGN_VARIABLE`, `CALL_ONCE`, ...) crashes:

```
File "tf2onnx/tflite_utils.py", line 532, in parse_tflite_graph
    onnx_node = utils.make_onnx_node_with_attr(optype, input_names, output_names, name=output_names[0], **attr)
IndexError: list index out of range
```

## Cause

`parse_tflite_graph` had three consecutive lines on `main`:

```python
onnx_node = utils.make_onnx_node_with_attr(optype, input_names, output_names, name=output_names[0], **attr)
node_name = output_names[0] if output_names else utils.make_name(f"{optype}_Output")
onnx_node = utils.make_onnx_node_with_attr(optype, input_names, output_names, name=node_name, **attr)
```

The guarded `node_name` fallback and the node creation that uses it are already there, but they are unreachable: the first, unguarded call runs before them and raises for any op with an empty `output_names`. Its result is also immediately overwritten, so the line is dead apart from the crash.

## Fix

Remove the stale unguarded call so the existing guarded path runs. `utils.make_name` appends a global counter, so the generated fallback names are unique; this is the only `output_names[0]` use left in the file.

## Verification

Reproduced with the model from the issue (macOS arm64, Python 3.12, TF 2.21, onnx 1.22):

```bash
curl -L -o okay_nabu.tflite https://github.com/esphome/micro-wake-word-models/raw/refs/heads/main/models/okay_nabu.tflite
python -m tf2onnx.convert --tflite okay_nabu.tflite --opset 18 --output okay_nabu.onnx
```

- Before: `IndexError: list index out of range` at `tflite_utils.py:532` (the model has 22 `ASSIGN_VARIABLE` ops and one `CALL_ONCE`, all with zero outputs).
- After: conversion finishes and writes a 220-node ONNX model; every node has a name. `tf2onnx` still logs `Unsupported ops: TFL_VAR_HANDLE, TFL_READ_VARIABLE` for that model — that is a separate missing-op gap and out of scope here; this change only removes the crash.

## Test

Added `tests/test_tflite_utils.py::TFListUtilsTests::test_parse_tflite_graph_op_without_outputs`: it builds a small `tf.Module` that assigns to a `tf.Variable`, converts it with `experimental_enable_resource_variables`, which produces `ASSIGN_VARIABLE`/`CALL_ONCE` ops with no outputs, and asserts `parse_tflite_graph` succeeds with non-empty, unique node names. It fails with the reported `IndexError` without the fix. CPU-only, no downloaded model.

`pytest tests/test_tflite_utils.py tests/test_tflite_postprocess.py` → 9 passed. `ruff check tf2onnx tests/*.py tools` → clean.

