### PR TITLE
fix: map Keras 3 model outputs to traced tensors

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,7 @@ class ApiTests(Tf2OnnxBackendTestBase):
         n = np.array([2.], dtype=np.float32)
         ky = model.predict([x, n])
         spec = (tf.TensorSpec((None, 224, 224, 3), tf.float32, name="input"),
-                tf.TensorSpec((), tf.float32, name="n"))
+                tf.TensorSpec((None,), tf.float32, name="n"))
         if large_model:
             output_path = os.path.join(self.test_data_directory, "model.zip")
         else:
@@ -71,6 +71,24 @@ class ApiTests(Tf2OnnxBackendTestBase):
     @check_tf_min_version("1.15")
     def test_keras_api(self):
         self._test_keras_api(large_model=False)
+
+    @check_tf_min_version("2.16")
+    def test_keras3_output_name_mapping(self):
+        model = tf.keras.Sequential([
+            tf.keras.layers.Input(shape=(4,), name="features"),
+            tf.keras.layers.Dense(3, activation="relu"),
+            tf.keras.layers.Dense(2, name="scores"),
+        ])
+        model(np.zeros((1, 4), dtype=np.float32))
+        model_path = os.path.join(self.test_data_directory, "model.keras")
+        model.save(model_path)
+        model = tf.keras.models.load_model(model_path)
+        spec = (tf.TensorSpec((None, 4), tf.float32, name="features"),)
+
+        model_proto, _ = tf2onnx.convert.from_keras(
+            model, input_signature=spec, opset=self.config.opset)
+
+        self.assertEqual([output.name for output in model_proto.graph.output], ["scores"])
 
     @check_tf_min_version("1.15")
     @skip_tf_versions(["2.0", "2.1"], "TF 2 requires 2.2 for large model freezing")

--- a/tf2onnx/convert.py
+++ b/tf2onnx/convert.py
@@ -37,9 +37,16 @@ def _get_output_names(model):
     """Get output names from a Keras model, compatible with old and new Keras."""
     if hasattr(model, 'output_names'):
         return model.output_names
-    # Keras in TF 2.12+ removed output_names; derive from output layers
+    # Keras 3 removed output_names. Prefer the operation that produced each
+    # symbolic output: the tensor name itself is only an internal keras_tensor_N
+    # identifier and does not match the traced concrete function.
     try:
-        return [output.name.split('/')[0] for output in model.outputs]
+        names = []
+        for output in model.outputs:
+            history = getattr(output, '_keras_history', None)
+            operation = getattr(history, 'operation', None)
+            names.append(getattr(operation, 'name', None) or output.name.split('/')[0])
+        return names
     except (AttributeError, IndexError):
         return None
 
@@ -527,7 +534,14 @@ def from_keras(model, input_signature=None, opset=None, custom_ops=None, custom_
     model_out_names = _get_output_names(model)
     if model_out_names:
         # model output_names is an optional field of Keras models indicating output order.
-        output_names = [reverse_lookup[out] for out in model_out_names]
+        if all(out in reverse_lookup for out in model_out_names):
+            output_names = [reverse_lookup[out] for out in model_out_names]
+        elif len(model_out_names) == len(output_names):
+            # Keras 3 returns symbolic keras_tensor_N model outputs while the
+            # traced function exposes Identity tensors. Their order is stable,
+            # so retain the traced output tensors and give them the model's
+            # public output names instead of looking them up by symbolic name.
+            tensors_to_rename.update(zip(output_names, model_out_names))
     elif isinstance(concrete_func.structured_outputs, dict):
         # Other models specify output order using the key order of structured_outputs
         output_names = [reverse_lookup[out] for out in concrete_func.structured_outputs.keys()]


### PR DESCRIPTION
Fixes #2448.

Keras 3 no longer exposes `model.output_names`; its symbolic model outputs are named `keras_tensor_N`, while the traced concrete function exposes tensors such as `Identity:0`. Looking up the symbolic name in the trace rename map caused `from_keras` to raise `KeyError`.

This change:
- derives public output names from each Keras output's producing operation;
- preserves the existing structured-output reordering path;
- maps traced outputs by stable model-output order when Keras 3 names are absent from the reverse lookup;
- updates the existing Keras API test signature for Keras 3's batched scalar shape;
- adds a `.keras` save/load regression for the reported failure.

Validation:
- Python 3.11.15
- TensorFlow 2.16.1 / Keras 3.15.1
- ONNX 1.17.0 / ONNX Runtime 1.29.0
- `ruff check tf2onnx/convert.py tests/test_api.py`
- `pytest tests/test_api.py -q` (9 passed, 1 skipped)