### PR TITLE
ci: drop excess actions:write permission, align SPDX headers

### DIFF
--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -8,9 +8,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -50,17 +50,8 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results to Github"
     needs: [test]
-    runs-on: ubuntu-latest
+    if: always()
     permissions:
       checks: write
       pull-requests: write
-    if: always()
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
-        with:
-          files: "artifacts/**/*.xml"
+    uses: ./.github/workflows/publish-test-results.yml

--- a/.github/workflows/keras_application_test_ci.yml
+++ b/.github/workflows/keras_application_test_ci.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Keras Application Test
 
 on:
@@ -17,8 +21,6 @@ jobs:
 
   test:
     timeout-minutes: 90
-    permissions:
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Keras Unit Test
 
 on:
@@ -17,8 +21,6 @@ jobs:
 
   test:
     timeout-minutes: 60
-    permissions:
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -8,9 +8,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/keras_unit_test_ci.yml
+++ b/.github/workflows/keras_unit_test_ci.yml
@@ -50,17 +50,8 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results to Github"
     needs: [test]
-    runs-on: ubuntu-latest
+    if: always()
     permissions:
       checks: write
       pull-requests: write
-    if: always()
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
-        with:
-          files: "artifacts/**/*.xml"
+    uses: ./.github/workflows/publish-test-results.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Lint
 
 on:

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -53,17 +53,8 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results to Github"
     needs: [test]
-    runs-on: ubuntu-latest
+    if: always()
     permissions:
       checks: write
       pull-requests: write
-    if: always()
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
-        with:
-          files: "artifacts/**/*.xml"
+    uses: ./.github/workflows/publish-test-results.yml

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Pretrained Model Test
 
 on:
@@ -17,8 +21,6 @@ jobs:
 
   test:
     timeout-minutes: 90
-    permissions:
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -8,9 +8,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pretrained_model_test_ci.yml
+++ b/.github/workflows/pretrained_model_test_ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,23 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish Test Results
+
+on:
+  workflow_call:
+
+jobs:
+  publish-test-results:
+    name: "Publish Tests Results to Github"
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: artifacts
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        with:
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 on:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -124,20 +124,11 @@ jobs:
   publish-test-results:
     name: "Publish Tests Results to Github"
     needs: [test]
-    runs-on: ubuntu-latest
+    if: always()
     permissions:
       checks: write
       pull-requests: write
-    if: always()
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
-        with:
-          files: "artifacts/**/*.xml"
+    uses: ./.github/workflows/publish-test-results.yml
 
   tflite-op-coverage:
     # Advisory guard that flags TFLite builtins with no @tfl_op handler

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -8,9 +8,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/unit_test_ci.yml
+++ b/.github/workflows/unit_test_ci.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Unit Test
 
 on:
@@ -17,8 +21,6 @@ jobs:
 
   test:
     timeout-minutes: 60
-    permissions:
-      actions: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Removes the `permissions: actions: write` grant from the `test` job in `unit_test_ci.yml`, `keras_application_test_ci.yml`, `keras_unit_test_ci.yml`, and `pretrained_model_test_ci.yml`. That job only runs pytest and uploads a junit artifact — it never calls the Actions API, so the grant was unnecessary excess privilege on a job that runs on `pull_request`.
- Declares `permissions: contents: read` explicitly at the workflow level in those same four files, instead of leaving the `test` job (and `unit_test_ci.yml`'s `tflite-op-coverage` job) with no permissions block at all — matching the explicit-permissions convention already used in `lint.yml`, `release.yml`, and `zizmor.yml`.
- Adds the `Copyright (c) ONNX Project Contributors` / `SPDX-License-Identifier: Apache-2.0` header (already used in `dependabot.yml` and `zizmor.yml`) to the remaining workflow files that were missing it: `unit_test_ci.yml`, `keras_application_test_ci.yml`, `keras_unit_test_ci.yml`, `lint.yml`, `pretrained_model_test_ci.yml`, `release.yml`.
- Extracts the `publish-test-results` job (download-artifact + EnricoMi publish), which was byte-for-byte identical across all four test workflows, into a new reusable workflow `.github/workflows/publish-test-results.yml` (`workflow_call`). Each caller now just does `uses: ./.github/workflows/publish-test-results.yml`, so a future action version bump only needs to land in one place. Permissions stay declared on the caller job (the recommended pattern for reusable workflows — the caller sets the ceiling), and `if: always()` moves to the caller job so results still publish when the test matrix fails.
- Adds `paths-ignore: ['**.md']` to the `pull_request`/`push` triggers of `unit_test_ci.yml`, `keras_application_test_ci.yml`, `keras_unit_test_ci.yml`, and `pretrained_model_test_ci.yml`. `unit_test_ci.yml` alone runs ~22 matrix jobs per run, and two of these workflows carry a 90-minute matrix — none of that needs to run for a markdown-only change. `main`'s branch protection has no required status checks configured, so a skipped run here can't strand a PR waiting on a check that never reports.

No behavioral change to what the workflows produce for code changes — permissions, headers, de-duplication, and trigger scoping only.

## Test plan
- [ ] CI runs green on this PR, including the reusable-workflow call resolving correctly and `publish-test-results` still running when a matrix job fails
- [ ] A follow-up doc-only PR confirms these four workflows no longer trigger